### PR TITLE
VDB-966 terminate container

### DIFF
--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -17,7 +17,7 @@ Build with (e.g. from the project directory) `docker build ./ -t vulcanize_mcd_t
     - `FILESYSTEM_STORAGEDIFFSPATH` or `STORAGEDIFFS_SOURCE` - this depends on where you're getting storage diffs from, see below.
         - Use `FILESYSTEM_STORAGEDIFFSPATH` only when getting storage diffs from a CSV file - this will be the path to the CSV file.
         - Set `STORAGEDIFFS_SOURCE` to `geth` when getting storage diffs from a subscription to a geth client. The default `STORAGEDIFFS_SOURCE` is `csv`.
-1. Run with required environment variables: `docker run -e CLIENT_IPCPATH="https://kovan.infura.io/v3/token" -e DATABASE_NAME="vulcanize_public" -e DATABASE_HOSTNAME="host.docker.internal" -e DATABASE_PORT="5432" -e DATABASE_USER="vulcanize" -e DATABASE_PASSWORD="vulcanize" -e FILESYSTEM_STORAGEDIFFSPATH="/path/to/diffs" vulcanize_mcd_transformers:0.0.1`.
+1. Run with required environment variables: `docker run -e CLIENT_IPCPATH="https://kovan.infura.io/v3/token" -e DATABASE_NAME="vulcanize_public" -e DATABASE_HOSTNAME="host.docker.internal" -e DATABASE_PORT="5432" -e DATABASE_USER="vulcanize" -e DATABASE_PASSWORD="vulcanize" -e STARTING_BLOCK_NUMBER=0 -e FILESYSTEM_STORAGEDIFFSPATH="/path/to/diffs" vulcanize_mcd_transformers:0.0.1`.
     - This triggers `headerSync` + `composeAndExecute`.
     - NOTE: contract addresses are currently configured in `environments/docker.toml` to point at the given release's Kovan deployment.
        You can optionally replace any address with an environment variable, e.g. `-e CONTRACT_CONTRACT_MCD_FLIP_ETH_A_ADDRESS=0x1234"`.

--- a/dockerfiles/startup_script.sh
+++ b/dockerfiles/startup_script.sh
@@ -37,11 +37,29 @@ then
 fi
 
 
+echo "Starting headerSync and executing the transformers..."
 # Fire up the services
 if [ $? -eq 0 ]; then
   # Fire up the services
   ./vulcanizedb headerSync --config config.toml -s $STARTING_BLOCK_NUMBER &
   ./vulcanizedb execute --config config.toml &
 fi
+
+
+# Check every 60 seconds to see if either process has excited.
+# If grepping for process names finds something, they exit with 0 status. If they are not both 0, then one of the processes has already excited.
+
+while sleep 60; do
+  ps aux | grep headerSync | grep -q -v grep
+  HEADER_SYNC_STATUS=$?
+
+  ps aux | grep execute | grep -q -v grep
+  EXECUTE_STATUS=$?
+
+  if [ $HEADER_SYNC_STATUS -ne 0 -o $EXECUTE_STATUS -ne 0 ]; then
+    echo "One of the processes has already exited."
+    exit 1
+  fi
+done
 
 wait

--- a/dockerfiles/startup_script.sh
+++ b/dockerfiles/startup_script.sh
@@ -1,20 +1,29 @@
 #!/bin/sh
 # Runs the migrations and starts the headerSync and continuousLogSync services
 
+MISSING_VAR_MESSAGE=" is required and no value was given"
+
 # DEBUG
 set -x
 
-if test -z "$VDB_PG_CONNECT"; then
-  # Exit if the variable tests fail
-  set -e
+function testDatabaseVariables() {
+  for a in DATABASE_NAME DATABASE_HOSTNAME DATABASE_PORT DATABASE_USER DATABASE_PASSWORD
+  do
+    eval arg="$"$a
+    test $arg
+    if [ $? -ne 0 ]; then
+      echo $a $MISSING_VAR_MESSAGE
+      exit 1
+    fi
+  done
+}
 
-  # Check the database variables are set
-  test $DATABASE_NAME
-  test $DATABASE_HOSTNAME
-  test $DATABASE_PORT
-  test $DATABASE_USER
-  test $DATABASE_PASSWORD
-  set +e
+if test -z "$VDB_PG_CONNECT"; then
+  # Exits if the variable tests fail
+  testDatabaseVariables
+  if [ $? -ne 0 ]; then
+    exit 1
+  fi
 
   # Construct the connection string for postgres
   VDB_PG_CONNECT=postgresql://$DATABASE_USER:$DATABASE_PASSWORD@$DATABASE_HOSTNAME:$DATABASE_PORT/$DATABASE_NAME?sslmode=disable
@@ -32,7 +41,7 @@ fi
 
 if test -z "$STARTING_BLOCK_NUMBER"
 then
-    echo "STARTING_BLOCK_NUMBER is required and no value was given"
+    echo STARTING_BLOCK_NUMBER $MISSING_VAR_MESSAGE
     exit 1
 fi
 

--- a/dockerfiles/startup_script.sh
+++ b/dockerfiles/startup_script.sh
@@ -61,5 +61,3 @@ while sleep 60; do
     exit 1
   fi
 done
-
-wait

--- a/dockerfiles/startup_script.sh
+++ b/dockerfiles/startup_script.sh
@@ -58,7 +58,7 @@ fi
 # Check every 60 seconds to see if either process has excited.
 # If grepping for process names finds something, they exit with 0 status. If they are not both 0, then one of the processes has already excited.
 
-while sleep 60; do
+while sleep 10; do
   ps aux | grep headerSync | grep -q -v grep
   HEADER_SYNC_STATUS=$?
 


### PR DESCRIPTION
- terminates the container if one of the processes exits for some reason
- we probably want to switch to having a different container for each process at some point, but i think this may be helpful in the short term
- also added some error messaging/refactored testing if required arguments have been passed to docker run