### PR TITLE
(VDB-969) Add triggers for re-org safety in ilk history table

### DIFF
--- a/db/migrations/20190919141224_create_ilk_state_history_table_and_triggers.sql
+++ b/db/migrations/20190919141224_create_ilk_state_history_table_and_triggers.sql
@@ -26,12 +26,14 @@ COMMENT ON COLUMN api.historical_ilk_state.ilk_identifier IS '@name id';
 CREATE FUNCTION ilk_rate_before_block(ilk_id INTEGER, header_id INTEGER) RETURNS NUMERIC AS
 $$
 WITH passed_block_number AS (
-    SELECT block_number FROM public.headers WHERE id = header_id
+    SELECT block_number
+    FROM public.headers
+    WHERE id = header_id
 )
 
 SELECT rate
 FROM maker.vat_ilk_rate
-    LEFT JOIN public.headers ON vat_ilk_rate.header_id = headers.id
+         LEFT JOIN public.headers ON vat_ilk_rate.header_id = headers.id
 WHERE vat_ilk_rate.ilk_id = ilk_rate_before_block.ilk_id
   AND headers.block_number < (SELECT block_number FROM passed_block_number)
 ORDER BY block_number DESC
@@ -43,12 +45,14 @@ $$
 CREATE FUNCTION ilk_art_before_block(ilk_id INTEGER, header_id INTEGER) RETURNS NUMERIC AS
 $$
 WITH passed_block_number AS (
-    SELECT block_number FROM public.headers WHERE id = header_id
+    SELECT block_number
+    FROM public.headers
+    WHERE id = header_id
 )
 
 SELECT art
 FROM maker.vat_ilk_art
-    LEFT JOIN public.headers ON vat_ilk_art.header_id = headers.id
+         LEFT JOIN public.headers ON vat_ilk_art.header_id = headers.id
 WHERE vat_ilk_art.ilk_id = ilk_art_before_block.ilk_id
   AND headers.block_number < (SELECT block_number FROM passed_block_number)
 ORDER BY block_number DESC
@@ -60,12 +64,14 @@ $$
 CREATE FUNCTION ilk_spot_before_block(ilk_id INTEGER, header_id INTEGER) RETURNS NUMERIC AS
 $$
 WITH passed_block_number AS (
-    SELECT block_number FROM public.headers WHERE id = header_id
+    SELECT block_number
+    FROM public.headers
+    WHERE id = header_id
 )
 
 SELECT spot
 FROM maker.vat_ilk_spot
-    LEFT JOIN public.headers ON vat_ilk_spot.header_id = headers.id
+         LEFT JOIN public.headers ON vat_ilk_spot.header_id = headers.id
 WHERE vat_ilk_spot.ilk_id = ilk_spot_before_block.ilk_id
   AND headers.block_number < (SELECT block_number FROM passed_block_number)
 ORDER BY block_number DESC
@@ -77,12 +83,14 @@ $$
 CREATE FUNCTION ilk_line_before_block(ilk_id INTEGER, header_id INTEGER) RETURNS NUMERIC AS
 $$
 WITH passed_block_number AS (
-    SELECT block_number FROM public.headers WHERE id = header_id
+    SELECT block_number
+    FROM public.headers
+    WHERE id = header_id
 )
 
 SELECT line
 FROM maker.vat_ilk_line
-    LEFT JOIN public.headers ON vat_ilk_line.header_id = headers.id
+         LEFT JOIN public.headers ON vat_ilk_line.header_id = headers.id
 WHERE vat_ilk_line.ilk_id = ilk_line_before_block.ilk_id
   AND headers.block_number < (SELECT block_number FROM passed_block_number)
 ORDER BY block_number DESC
@@ -94,12 +102,14 @@ $$
 CREATE FUNCTION ilk_dust_before_block(ilk_id INTEGER, header_id INTEGER) RETURNS NUMERIC AS
 $$
 WITH passed_block_number AS (
-    SELECT block_number FROM public.headers WHERE id = header_id
+    SELECT block_number
+    FROM public.headers
+    WHERE id = header_id
 )
 
 SELECT dust
 FROM maker.vat_ilk_dust
-    LEFT JOIN public.headers ON vat_ilk_dust.header_id = headers.id
+         LEFT JOIN public.headers ON vat_ilk_dust.header_id = headers.id
 WHERE vat_ilk_dust.ilk_id = ilk_dust_before_block.ilk_id
   AND headers.block_number < (SELECT block_number FROM passed_block_number)
 ORDER BY block_number DESC
@@ -111,12 +121,14 @@ $$
 CREATE FUNCTION ilk_chop_before_block(ilk_id INTEGER, header_id INTEGER) RETURNS NUMERIC AS
 $$
 WITH passed_block_number AS (
-    SELECT block_number FROM public.headers WHERE id = header_id
+    SELECT block_number
+    FROM public.headers
+    WHERE id = header_id
 )
 
 SELECT chop
 FROM maker.cat_ilk_chop
-    LEFT JOIN public.headers ON cat_ilk_chop.header_id = headers.id
+         LEFT JOIN public.headers ON cat_ilk_chop.header_id = headers.id
 WHERE cat_ilk_chop.ilk_id = ilk_chop_before_block.ilk_id
   AND headers.block_number < (SELECT block_number FROM passed_block_number)
 ORDER BY block_number DESC
@@ -128,12 +140,14 @@ $$
 CREATE FUNCTION ilk_lump_before_block(ilk_id INTEGER, header_id INTEGER) RETURNS NUMERIC AS
 $$
 WITH passed_block_number AS (
-    SELECT block_number FROM public.headers WHERE id = header_id
+    SELECT block_number
+    FROM public.headers
+    WHERE id = header_id
 )
 
 SELECT lump
 FROM maker.cat_ilk_lump
-    LEFT JOIN public.headers ON cat_ilk_lump.header_id = headers.id
+         LEFT JOIN public.headers ON cat_ilk_lump.header_id = headers.id
 WHERE cat_ilk_lump.ilk_id = ilk_lump_before_block.ilk_id
   AND headers.block_number < (SELECT block_number FROM passed_block_number)
 ORDER BY block_number DESC
@@ -145,12 +159,14 @@ $$
 CREATE FUNCTION ilk_flip_before_block(ilk_id INTEGER, header_id INTEGER) RETURNS TEXT AS
 $$
 WITH passed_block_number AS (
-    SELECT block_number FROM public.headers WHERE id = header_id
+    SELECT block_number
+    FROM public.headers
+    WHERE id = header_id
 )
 
 SELECT flip
 FROM maker.cat_ilk_flip
-    LEFT JOIN public.headers ON cat_ilk_flip.header_id = headers.id
+         LEFT JOIN public.headers ON cat_ilk_flip.header_id = headers.id
 WHERE cat_ilk_flip.ilk_id = ilk_flip_before_block.ilk_id
   AND headers.block_number < (SELECT block_number FROM passed_block_number)
 ORDER BY block_number DESC
@@ -163,12 +179,14 @@ CREATE FUNCTION ilk_rho_before_block(ilk_id INTEGER, header_id INTEGER) RETURNS 
 $$
 
 WITH passed_block_number AS (
-    SELECT block_number FROM public.headers WHERE id = header_id
+    SELECT block_number
+    FROM public.headers
+    WHERE id = header_id
 )
 
 SELECT rho
 FROM maker.jug_ilk_rho
-    LEFT JOIN public.headers ON jug_ilk_rho.header_id = headers.id
+         LEFT JOIN public.headers ON jug_ilk_rho.header_id = headers.id
 WHERE jug_ilk_rho.ilk_id = ilk_rho_before_block.ilk_id
   AND headers.block_number < (SELECT block_number FROM passed_block_number)
 ORDER BY block_number DESC
@@ -180,12 +198,14 @@ $$
 CREATE FUNCTION ilk_duty_before_block(ilk_id INTEGER, header_id INTEGER) RETURNS NUMERIC AS
 $$
 WITH passed_block_number AS (
-    SELECT block_number FROM public.headers WHERE id = header_id
+    SELECT block_number
+    FROM public.headers
+    WHERE id = header_id
 )
 
 SELECT duty
 FROM maker.jug_ilk_duty
-    LEFT JOIN public.headers ON jug_ilk_duty.header_id = headers.id
+         LEFT JOIN public.headers ON jug_ilk_duty.header_id = headers.id
 WHERE jug_ilk_duty.ilk_id = ilk_duty_before_block.ilk_id
   AND headers.block_number < (SELECT block_number FROM passed_block_number)
 ORDER BY block_number DESC
@@ -197,12 +217,14 @@ $$
 CREATE FUNCTION ilk_pip_before_block(ilk_id INTEGER, header_id INTEGER) RETURNS TEXT AS
 $$
 WITH passed_block_number AS (
-    SELECT block_number FROM public.headers WHERE id = header_id
+    SELECT block_number
+    FROM public.headers
+    WHERE id = header_id
 )
 
 SELECT pip
 FROM maker.spot_ilk_pip
-    LEFT JOIN public.headers ON spot_ilk_pip.header_id = headers.id
+         LEFT JOIN public.headers ON spot_ilk_pip.header_id = headers.id
 WHERE spot_ilk_pip.ilk_id = ilk_pip_before_block.ilk_id
   AND headers.block_number < (SELECT block_number FROM passed_block_number)
 ORDER BY block_number DESC
@@ -213,13 +235,15 @@ $$
 
 CREATE FUNCTION ilk_mat_before_block(ilk_id INTEGER, header_id INTEGER) RETURNS NUMERIC AS
 $$
-    WITH passed_block_number AS (
-        SELECT block_number FROM public.headers WHERE id = header_id
-    )
+WITH passed_block_number AS (
+    SELECT block_number
+    FROM public.headers
+    WHERE id = header_id
+)
 
 SELECT mat
 FROM maker.spot_ilk_mat
-    LEFT JOIN public.headers ON spot_ilk_mat.header_id = headers.id
+         LEFT JOIN public.headers ON spot_ilk_mat.header_id = headers.id
 WHERE spot_ilk_mat.ilk_id = ilk_mat_before_block.ilk_id
   AND headers.block_number < (SELECT block_number FROM passed_block_number)
 ORDER BY block_number DESC
@@ -237,6 +261,55 @@ WHERE vat_init.ilk_id = ilk_time_created.ilk_id
 $$
     LANGUAGE sql;
 
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION maker.delete_redundant_ilk_state(ilk_id INTEGER, header_id INTEGER) RETURNS api.historical_ilk_state
+AS
+$$
+DECLARE
+    associated_ilk TEXT                     := (
+        SELECT identifier
+        FROM maker.ilks
+        WHERE id = delete_redundant_ilk_state.ilk_id);
+    ilk_state_block_number BIGINT                   := (
+        SELECT block_number
+        FROM public.headers
+        WHERE id = header_id);ilk_state      api.historical_ilk_state := (
+        SELECT (ilk_identifier, historical_ilk_state.block_number, rate, art, spot, line, dust, chop, lump, flip, rho,
+                duty, pip, mat, created, updated)
+        FROM api.historical_ilk_state
+        WHERE ilk_identifier = associated_ilk
+          AND historical_ilk_state.block_number = ilk_state_block_number);
+    prev_ilk_state         api.historical_ilk_state := (
+        SELECT (ilk_identifier, historical_ilk_state.block_number, rate, art, spot, line, dust, chop, lump, flip, rho,
+                duty, pip, mat, created, updated)
+        FROM api.historical_ilk_state
+        WHERE ilk_identifier = associated_ilk
+          AND historical_ilk_state.block_number < ilk_state_block_number
+        ORDER BY historical_ilk_state.block_number DESC
+        LIMIT 1);
+BEGIN
+    DELETE
+    FROM api.historical_ilk_state
+    WHERE historical_ilk_state.ilk_identifier = associated_ilk
+      AND historical_ilk_state.block_number = ilk_state_block_number
+      AND (ilk_state.rate IS NULL OR ilk_state.rate = prev_ilk_state.rate)
+      AND (ilk_state.art IS NULL OR ilk_state.art = prev_ilk_state.art)
+      AND (ilk_state.spot IS NULL OR ilk_state.spot = prev_ilk_state.spot)
+      AND (ilk_state.line IS NULL OR ilk_state.line = prev_ilk_state.line)
+      AND (ilk_state.dust IS NULL OR ilk_state.dust = prev_ilk_state.dust)
+      AND (ilk_state.chop IS NULL OR ilk_state.chop = prev_ilk_state.chop)
+      AND (ilk_state.lump IS NULL OR ilk_state.lump = prev_ilk_state.lump)
+      AND (ilk_state.flip IS NULL OR ilk_state.flip = prev_ilk_state.flip)
+      AND (ilk_state.rho IS NULL OR ilk_state.rho = prev_ilk_state.rho)
+      AND (ilk_state.duty IS NULL OR ilk_state.duty = prev_ilk_state.duty)
+      AND (ilk_state.pip IS NULL OR ilk_state.pip = prev_ilk_state.pip)
+      AND (ilk_state.mat IS NULL OR ilk_state.mat = prev_ilk_state.mat);
+    RETURN NULL;
+END
+$$
+    LANGUAGE plpgsql;
+-- +goose StatementEnd
+
 
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.insert_new_rate(new_diff maker.vat_ilk_rate) RETURNS maker.vat_ilk_rate
@@ -251,14 +324,14 @@ DECLARE
         SELECT api.epoch_to_datetime(block_timestamp)
         FROM public.headers
         WHERE id = new_diff.header_id);
-    diff_block_number NUMERIC := (
+    diff_block_number    NUMERIC   := (
         SELECT block_number
         FROM public.headers
         WHERE id = new_diff.header_id);
 BEGIN
     INSERT
-    INTO api.historical_ilk_state (ilk_identifier, block_number, rate, art, spot, line, dust, chop, lump, flip, rho, duty,
-                                pip, mat, created, updated)
+    INTO api.historical_ilk_state (ilk_identifier, block_number, rate, art, spot, line, dust, chop, lump, flip, rho,
+                                   duty, pip, mat, created, updated)
     VALUES (diff_ilk_identifier,
             diff_block_number,
             new_diff.rate,
@@ -284,29 +357,29 @@ $$
 -- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.update_later_rates(new_diff maker.vat_ilk_rate) RETURNS maker.vat_ilk_rate
+CREATE OR REPLACE FUNCTION maker.update_rates_until_next_diff(start_at_diff maker.vat_ilk_rate, new_rate NUMERIC) RETURNS maker.vat_ilk_rate
 AS
 $$
 DECLARE
     diff_ilk_identifier  TEXT   := (
         SELECT identifier
         FROM maker.ilks
-        WHERE ilks.id = new_diff.ilk_id);
-    diff_block_number BIGINT := (
+        WHERE ilks.id = start_at_diff.ilk_id);
+    diff_block_number    BIGINT := (
         SELECT block_number
         FROM public.headers
-        WHERE id = new_diff.header_id);
+        WHERE id = start_at_diff.header_id);
     next_rate_diff_block BIGINT := (
         SELECT MIN(block_number)
         FROM maker.vat_ilk_rate
-            LEFT JOIN public.headers ON vat_ilk_rate.header_id = headers.id
-        WHERE vat_ilk_rate.ilk_id = new_diff.ilk_id
-          AND headers.block_number > diff_block_number);
+                 LEFT JOIN public.headers ON vat_ilk_rate.header_id = headers.id
+        WHERE vat_ilk_rate.ilk_id = start_at_diff.ilk_id
+          AND block_number > diff_block_number);
 BEGIN
     UPDATE api.historical_ilk_state
-    SET rate = new_diff.rate
+    SET rate = new_rate
     WHERE historical_ilk_state.ilk_identifier = diff_ilk_identifier
-      AND historical_ilk_state.block_number > diff_block_number
+      AND historical_ilk_state.block_number >= diff_block_number
       AND (next_rate_diff_block IS NULL
         OR historical_ilk_state.block_number < next_rate_diff_block);
     RETURN NULL;
@@ -316,12 +389,17 @@ $$
 -- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.insert_ilk_rates() RETURNS TRIGGER
+CREATE OR REPLACE FUNCTION maker.update_ilk_rates() RETURNS TRIGGER
 AS
 $$
 BEGIN
-    PERFORM maker.insert_new_rate(NEW);
-    PERFORM maker.update_later_rates(NEW);
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_new_rate(NEW);
+        PERFORM maker.update_rates_until_next_diff(NEW, NEW.rate);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.update_rates_until_next_diff(OLD, ilk_rate_before_block(OLD.ilk_id, OLD.header_id));
+        PERFORM maker.delete_redundant_ilk_state(OLD.ilk_id, OLD.header_id);
+    END IF;
     RETURN NULL;
 END
 $$
@@ -329,10 +407,10 @@ $$
 -- +goose StatementEnd
 
 CREATE TRIGGER ilk_rate
-    AFTER INSERT OR UPDATE
+    AFTER INSERT OR UPDATE OR DELETE
     ON maker.vat_ilk_rate
     FOR EACH ROW
-EXECUTE PROCEDURE maker.insert_ilk_rates();
+EXECUTE PROCEDURE maker.update_ilk_rates();
 
 
 -- +goose StatementBegin
@@ -348,14 +426,14 @@ DECLARE
         SELECT api.epoch_to_datetime(block_timestamp)
         FROM public.headers
         WHERE id = new_diff.header_id);
-    diff_block_number NUMERIC := (
+    diff_block_number    NUMERIC   := (
         SELECT block_number
         FROM public.headers
         WHERE id = new_diff.header_id);
 BEGIN
     INSERT
-    INTO api.historical_ilk_state (ilk_identifier, block_number, rate, art, spot, line, dust, chop, lump, flip, rho, duty,
-                                pip, mat, created, updated)
+    INTO api.historical_ilk_state (ilk_identifier, block_number, rate, art, spot, line, dust, chop, lump, flip, rho,
+                                   duty, pip, mat, created, updated)
     VALUES (diff_ilk_identifier,
             diff_block_number,
             ilk_rate_before_block(new_diff.ilk_id, new_diff.header_id),
@@ -381,29 +459,29 @@ $$
 -- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.update_later_arts(new_diff maker.vat_ilk_art) RETURNS maker.vat_ilk_art
+CREATE OR REPLACE FUNCTION maker.update_arts_until_next_diff(start_at_diff maker.vat_ilk_art, new_art NUMERIC) RETURNS maker.vat_ilk_art
 AS
 $$
 DECLARE
     diff_ilk_identifier TEXT   := (
         SELECT identifier
         FROM maker.ilks
-        WHERE ilks.id = new_diff.ilk_id);
-    diff_block_number BIGINT := (
+        WHERE ilks.id = start_at_diff.ilk_id);
+    diff_block_number   BIGINT := (
         SELECT block_number
         FROM public.headers
-        WHERE id = new_diff.header_id);
+        WHERE id = start_at_diff.header_id);
     next_art_diff_block BIGINT := (
         SELECT MIN(block_number)
         FROM maker.vat_ilk_art
-            LEFT JOIN public.headers ON vat_ilk_art.header_id = headers.id
-        WHERE vat_ilk_art.ilk_id = new_diff.ilk_id
+                 LEFT JOIN public.headers ON vat_ilk_art.header_id = headers.id
+        WHERE vat_ilk_art.ilk_id = start_at_diff.ilk_id
           AND block_number > diff_block_number);
 BEGIN
     UPDATE api.historical_ilk_state
-    SET art = new_diff.art
+    SET art = new_art
     WHERE historical_ilk_state.ilk_identifier = diff_ilk_identifier
-      AND historical_ilk_state.block_number > diff_block_number
+      AND historical_ilk_state.block_number >= diff_block_number
       AND (next_art_diff_block IS NULL
         OR historical_ilk_state.block_number < next_art_diff_block);
     RETURN NULL;
@@ -413,12 +491,17 @@ $$
 -- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.insert_ilk_arts() RETURNS TRIGGER
+CREATE OR REPLACE FUNCTION maker.update_ilk_arts() RETURNS TRIGGER
 AS
 $$
 BEGIN
-    PERFORM maker.insert_new_art(NEW);
-    PERFORM maker.update_later_arts(NEW);
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_new_art(NEW);
+        PERFORM maker.update_arts_until_next_diff(NEW, NEW.art);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.update_arts_until_next_diff(OLD, ilk_art_before_block(OLD.ilk_id, OLD.header_id));
+        PERFORM maker.delete_redundant_ilk_state(OLD.ilk_id, OLD.header_id);
+    END IF;
     RETURN NULL;
 END
 $$
@@ -426,10 +509,10 @@ $$
 -- +goose StatementEnd
 
 CREATE TRIGGER ilk_art
-    AFTER INSERT OR UPDATE
+    AFTER INSERT OR UPDATE OR DELETE
     ON maker.vat_ilk_art
     FOR EACH ROW
-EXECUTE PROCEDURE maker.insert_ilk_arts();
+EXECUTE PROCEDURE maker.update_ilk_arts();
 
 
 -- +goose StatementBegin
@@ -445,14 +528,14 @@ DECLARE
         SELECT api.epoch_to_datetime(block_timestamp)
         FROM public.headers
         WHERE headers.id = new_diff.header_id);
-    diff_block_number NUMERIC := (
+    diff_block_number    NUMERIC   := (
         SELECT block_number
         FROM public.headers
         WHERE headers.id = new_diff.header_id);
 BEGIN
     INSERT
-    INTO api.historical_ilk_state (ilk_identifier, block_number, rate, art, spot, line, dust, chop, lump, flip, rho, duty,
-                                pip, mat, created, updated)
+    INTO api.historical_ilk_state (ilk_identifier, block_number, rate, art, spot, line, dust, chop, lump, flip, rho,
+                                   duty, pip, mat, created, updated)
     VALUES (diff_ilk_identifier,
             diff_block_number,
             ilk_rate_before_block(new_diff.ilk_id, new_diff.header_id),
@@ -478,29 +561,29 @@ $$
 -- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.update_later_spots(new_diff maker.vat_ilk_spot) RETURNS maker.vat_ilk_spot
+CREATE OR REPLACE FUNCTION maker.update_spots_until_next_diff(start_at_diff maker.vat_ilk_spot, new_spot NUMERIC) RETURNS maker.vat_ilk_spot
 AS
 $$
 DECLARE
     diff_ilk_identifier  TEXT   := (
         SELECT identifier
         FROM maker.ilks
-        WHERE ilks.id = new_diff.ilk_id);
-    diff_block_number BIGINT := (
+        WHERE ilks.id = start_at_diff.ilk_id);
+    diff_block_number    BIGINT := (
         SELECT block_number
         FROM public.headers
-        WHERE id = new_diff.header_id);
+        WHERE id = start_at_diff.header_id);
     next_spot_diff_block BIGINT := (
         SELECT MIN(block_number)
         FROM maker.vat_ilk_spot
-            LEFT JOIN public.headers ON vat_ilk_spot.header_id = headers.id
-        WHERE vat_ilk_spot.ilk_id = new_diff.ilk_id
+                 LEFT JOIN public.headers ON vat_ilk_spot.header_id = headers.id
+        WHERE vat_ilk_spot.ilk_id = start_at_diff.ilk_id
           AND block_number > diff_block_number);
 BEGIN
     UPDATE api.historical_ilk_state
-    SET spot = new_diff.spot
+    SET spot = new_spot
     WHERE historical_ilk_state.ilk_identifier = diff_ilk_identifier
-      AND historical_ilk_state.block_number > diff_block_number
+      AND historical_ilk_state.block_number >= diff_block_number
       AND (next_spot_diff_block IS NULL
         OR historical_ilk_state.block_number < next_spot_diff_block);
     RETURN NULL;
@@ -510,12 +593,17 @@ $$
 -- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.insert_ilk_spots() RETURNS TRIGGER
+CREATE OR REPLACE FUNCTION maker.update_ilk_spots() RETURNS TRIGGER
 AS
 $$
 BEGIN
-    PERFORM maker.insert_new_spot(NEW);
-    PERFORM maker.update_later_spots(NEW);
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_new_spot(NEW);
+        PERFORM maker.update_spots_until_next_diff(NEW, NEW.spot);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.update_spots_until_next_diff(OLD, ilk_spot_before_block(OLD.ilk_id, OLD.header_id));
+        PERFORM maker.delete_redundant_ilk_state(OLD.ilk_id, OLD.header_id);
+    END IF;
     RETURN NULL;
 END
 $$
@@ -523,10 +611,10 @@ $$
 -- +goose StatementEnd
 
 CREATE TRIGGER ilk_spot
-    AFTER INSERT OR UPDATE
+    AFTER INSERT OR UPDATE OR DELETE
     ON maker.vat_ilk_spot
     FOR EACH ROW
-EXECUTE PROCEDURE maker.insert_ilk_spots();
+EXECUTE PROCEDURE maker.update_ilk_spots();
 
 
 -- +goose StatementBegin
@@ -542,14 +630,14 @@ DECLARE
         SELECT api.epoch_to_datetime(block_timestamp)
         FROM public.headers
         WHERE id = new_diff.header_id);
-    diff_block_number NUMERIC := (
+    diff_block_number    NUMERIC   := (
         SELECT block_number
         FROM public.headers
         WHERE id = new_diff.header_id);
 BEGIN
     INSERT
-    INTO api.historical_ilk_state (ilk_identifier, block_number, rate, art, spot, line, dust, chop, lump, flip, rho, duty,
-                                pip, mat, created, updated)
+    INTO api.historical_ilk_state (ilk_identifier, block_number, rate, art, spot, line, dust, chop, lump, flip, rho,
+                                   duty, pip, mat, created, updated)
     VALUES (diff_ilk_identifier,
             diff_block_number,
             ilk_rate_before_block(new_diff.ilk_id, new_diff.header_id),
@@ -575,29 +663,29 @@ $$
 -- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.update_later_lines(new_diff maker.vat_ilk_line) RETURNS maker.vat_ilk_line
+CREATE OR REPLACE FUNCTION maker.update_lines_until_next_diff(start_at_diff maker.vat_ilk_line, new_line NUMERIC) RETURNS maker.vat_ilk_line
 AS
 $$
 DECLARE
     diff_ilk_identifier  TEXT   := (
         SELECT identifier
         FROM maker.ilks
-        WHERE ilks.id = new_diff.ilk_id);
-    diff_block_number BIGINT := (
+        WHERE ilks.id = start_at_diff.ilk_id);
+    diff_block_number    BIGINT := (
         SELECT block_number
         FROM public.headers
-        WHERE id = new_diff.header_id);
+        WHERE id = start_at_diff.header_id);
     next_line_diff_block BIGINT := (
         SELECT MIN(block_number)
         FROM maker.vat_ilk_line
-            LEFT JOIN public.headers ON vat_ilk_line.header_id = headers.id
-        WHERE vat_ilk_line.ilk_id = new_diff.ilk_id
+                 LEFT JOIN public.headers ON vat_ilk_line.header_id = headers.id
+        WHERE vat_ilk_line.ilk_id = start_at_diff.ilk_id
           AND block_number > diff_block_number);
 BEGIN
     UPDATE api.historical_ilk_state
-    SET line = new_diff.line
+    SET line = new_line
     WHERE historical_ilk_state.ilk_identifier = diff_ilk_identifier
-      AND historical_ilk_state.block_number > diff_block_number
+      AND historical_ilk_state.block_number >= diff_block_number
       AND (next_line_diff_block IS NULL
         OR historical_ilk_state.block_number < next_line_diff_block);
     RETURN NULL;
@@ -607,12 +695,17 @@ $$
 -- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.insert_ilk_lines() RETURNS TRIGGER
+CREATE OR REPLACE FUNCTION maker.update_ilk_lines() RETURNS TRIGGER
 AS
 $$
 BEGIN
-    PERFORM maker.insert_new_line(NEW);
-    PERFORM maker.update_later_lines(NEW);
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_new_line(NEW);
+        PERFORM maker.update_lines_until_next_diff(NEW, NEW.line);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.update_lines_until_next_diff(OLD, ilk_line_before_block(OLD.ilk_id, OLD.header_id));
+        PERFORM maker.delete_redundant_ilk_state(OLD.ilk_id, OLD.header_id);
+    END IF;
     RETURN NULL;
 END
 $$
@@ -620,10 +713,10 @@ $$
 -- +goose StatementEnd
 
 CREATE TRIGGER ilk_line
-    AFTER INSERT OR UPDATE
+    AFTER INSERT OR UPDATE OR DELETE
     ON maker.vat_ilk_line
     FOR EACH ROW
-EXECUTE PROCEDURE maker.insert_ilk_lines();
+EXECUTE PROCEDURE maker.update_ilk_lines();
 
 
 -- +goose StatementBegin
@@ -639,14 +732,14 @@ DECLARE
         SELECT api.epoch_to_datetime(block_timestamp)
         FROM public.headers
         WHERE id = new_diff.header_id);
-    diff_block_number NUMERIC := (
+    diff_block_number    NUMERIC   := (
         SELECT block_number
         FROM public.headers
         WHERE id = new_diff.header_id);
 BEGIN
     INSERT
-    INTO api.historical_ilk_state (ilk_identifier, block_number, rate, art, spot, line, dust, chop, lump, flip, rho, duty,
-                                pip, mat, created, updated)
+    INTO api.historical_ilk_state (ilk_identifier, block_number, rate, art, spot, line, dust, chop, lump, flip, rho,
+                                   duty, pip, mat, created, updated)
     VALUES (diff_ilk_identifier,
             diff_block_number,
             ilk_rate_before_block(new_diff.ilk_id, new_diff.header_id),
@@ -672,29 +765,29 @@ $$
 -- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.update_later_dusts(new_diff maker.vat_ilk_dust) RETURNS maker.vat_ilk_dust
+CREATE OR REPLACE FUNCTION maker.update_dusts_until_next_diff(start_at_diff maker.vat_ilk_dust, new_dust NUMERIC) RETURNS maker.vat_ilk_dust
 AS
 $$
 DECLARE
     diff_ilk_identifier  TEXT   := (
         SELECT identifier
         FROM maker.ilks
-        WHERE ilks.id = new_diff.ilk_id);
-    diff_block_number BIGINT := (
+        WHERE ilks.id = start_at_diff.ilk_id);
+    diff_block_number    BIGINT := (
         SELECT block_number
         FROM public.headers
-        WHERE id = new_diff.header_id);
+        WHERE id = start_at_diff.header_id);
     next_dust_diff_block BIGINT := (
         SELECT MIN(block_number)
         FROM maker.vat_ilk_dust
-            LEFT JOIN public.headers ON vat_ilk_dust.header_id = headers.id
-        WHERE vat_ilk_dust.ilk_id = new_diff.ilk_id
+                 LEFT JOIN public.headers ON vat_ilk_dust.header_id = headers.id
+        WHERE vat_ilk_dust.ilk_id = start_at_diff.ilk_id
           AND block_number > diff_block_number);
 BEGIN
     UPDATE api.historical_ilk_state
-    SET dust = new_diff.dust
+    SET dust = new_dust
     WHERE historical_ilk_state.ilk_identifier = diff_ilk_identifier
-      AND historical_ilk_state.block_number > diff_block_number
+      AND historical_ilk_state.block_number >= diff_block_number
       AND (next_dust_diff_block IS NULL
         OR historical_ilk_state.block_number < next_dust_diff_block);
     RETURN NULL;
@@ -704,12 +797,17 @@ $$
 -- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.insert_ilk_dusts() RETURNS TRIGGER
+CREATE OR REPLACE FUNCTION maker.update_ilk_dusts() RETURNS TRIGGER
 AS
 $$
 BEGIN
-    PERFORM maker.insert_new_dust(NEW);
-    PERFORM maker.update_later_dusts(NEW);
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_new_dust(NEW);
+        PERFORM maker.update_dusts_until_next_diff(NEW, NEW.dust);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.update_dusts_until_next_diff(OLD, ilk_dust_before_block(OLD.ilk_id, OLD.header_id));
+        PERFORM maker.delete_redundant_ilk_state(OLD.ilk_id, OLD.header_id);
+    END IF;
     RETURN NULL;
 END
 $$
@@ -717,10 +815,10 @@ $$
 -- +goose StatementEnd
 
 CREATE TRIGGER ilk_dust
-    AFTER INSERT OR UPDATE
+    AFTER INSERT OR UPDATE OR DELETE
     ON maker.vat_ilk_dust
     FOR EACH ROW
-EXECUTE PROCEDURE maker.insert_ilk_dusts();
+EXECUTE PROCEDURE maker.update_ilk_dusts();
 
 
 -- +goose StatementBegin
@@ -736,14 +834,14 @@ DECLARE
         SELECT api.epoch_to_datetime(block_timestamp)
         FROM public.headers
         WHERE id = new_diff.header_id);
-    diff_block_number NUMERIC := (
+    diff_block_number    NUMERIC   := (
         SELECT block_number
         FROM public.headers
         WHERE id = new_diff.header_id);
 BEGIN
     INSERT
-    INTO api.historical_ilk_state (ilk_identifier, block_number, rate, art, spot, line, dust, chop, lump, flip, rho, duty,
-                                pip, mat, created, updated)
+    INTO api.historical_ilk_state (ilk_identifier, block_number, rate, art, spot, line, dust, chop, lump, flip, rho,
+                                   duty, pip, mat, created, updated)
     VALUES (diff_ilk_identifier,
             diff_block_number,
             ilk_rate_before_block(new_diff.ilk_id, new_diff.header_id),
@@ -769,29 +867,29 @@ $$
 -- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.update_later_chops(new_diff maker.cat_ilk_chop) RETURNS maker.cat_ilk_chop
+CREATE OR REPLACE FUNCTION maker.update_chops_until_next_diff(start_at_diff maker.cat_ilk_chop, new_chop NUMERIC) RETURNS maker.cat_ilk_chop
 AS
 $$
 DECLARE
     diff_ilk_identifier  TEXT   := (
         SELECT identifier
         FROM maker.ilks
-        WHERE ilks.id = new_diff.ilk_id);
-    diff_block_number BIGINT := (
+        WHERE ilks.id = start_at_diff.ilk_id);
+    diff_block_number    BIGINT := (
         SELECT block_number
         FROM public.headers
-        WHERE id = new_diff.header_id);
+        WHERE id = start_at_diff.header_id);
     next_chop_diff_block BIGINT := (
         SELECT MIN(block_number)
         FROM maker.cat_ilk_chop
-            LEFT JOIN public.headers ON cat_ilk_chop.header_id = headers.id
-        WHERE cat_ilk_chop.ilk_id = new_diff.ilk_id
+                 LEFT JOIN public.headers ON cat_ilk_chop.header_id = headers.id
+        WHERE cat_ilk_chop.ilk_id = start_at_diff.ilk_id
           AND block_number > diff_block_number);
 BEGIN
     UPDATE api.historical_ilk_state
-    SET chop = new_diff.chop
+    SET chop = new_chop
     WHERE historical_ilk_state.ilk_identifier = diff_ilk_identifier
-      AND historical_ilk_state.block_number > diff_block_number
+      AND historical_ilk_state.block_number >= diff_block_number
       AND (next_chop_diff_block IS NULL
         OR historical_ilk_state.block_number < next_chop_diff_block);
     RETURN NULL;
@@ -801,12 +899,17 @@ $$
 -- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.insert_ilk_chops() RETURNS TRIGGER
+CREATE OR REPLACE FUNCTION maker.update_ilk_chops() RETURNS TRIGGER
 AS
 $$
 BEGIN
-    PERFORM maker.insert_new_chop(NEW);
-    PERFORM maker.update_later_chops(NEW);
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_new_chop(NEW);
+        PERFORM maker.update_chops_until_next_diff(NEW, NEW.chop);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.update_chops_until_next_diff(OLD, ilk_chop_before_block(OLD.ilk_id, OLD.header_id));
+        PERFORM maker.delete_redundant_ilk_state(OLD.ilk_id, OLD.header_id);
+    END IF;
     RETURN NULL;
 END
 $$
@@ -814,10 +917,10 @@ $$
 -- +goose StatementEnd
 
 CREATE TRIGGER ilk_chop
-    AFTER INSERT OR UPDATE
+    AFTER INSERT OR UPDATE OR DELETE
     ON maker.cat_ilk_chop
     FOR EACH ROW
-EXECUTE PROCEDURE maker.insert_ilk_chops();
+EXECUTE PROCEDURE maker.update_ilk_chops();
 
 
 -- +goose StatementBegin
@@ -833,14 +936,14 @@ DECLARE
         SELECT api.epoch_to_datetime(block_timestamp)
         FROM public.headers
         WHERE id = new_diff.header_id);
-    diff_block_number NUMERIC := (
+    diff_block_number    NUMERIC   := (
         SELECT block_number
         FROM public.headers
         WHERE id = new_diff.header_id);
 BEGIN
     INSERT
-    INTO api.historical_ilk_state (ilk_identifier, block_number, rate, art, spot, line, dust, chop, lump, flip, rho, duty,
-                                pip, mat, created, updated)
+    INTO api.historical_ilk_state (ilk_identifier, block_number, rate, art, spot, line, dust, chop, lump, flip, rho,
+                                   duty, pip, mat, created, updated)
     VALUES (diff_ilk_identifier,
             diff_block_number,
             ilk_rate_before_block(new_diff.ilk_id, new_diff.header_id),
@@ -866,29 +969,29 @@ $$
 -- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.update_later_lumps(new_diff maker.cat_ilk_lump) RETURNS maker.cat_ilk_lump
+CREATE OR REPLACE FUNCTION maker.update_lumps_until_next_diff(start_at_diff maker.cat_ilk_lump, new_lump NUMERIC) RETURNS maker.cat_ilk_lump
 AS
 $$
 DECLARE
     diff_ilk_identifier  TEXT   := (
         SELECT identifier
         FROM maker.ilks
-        WHERE ilks.id = new_diff.ilk_id);
-    diff_block_number BIGINT := (
+        WHERE ilks.id = start_at_diff.ilk_id);
+    diff_block_number    BIGINT := (
         SELECT block_number
         FROM public.headers
-        WHERE id = new_diff.header_id);
+        WHERE id = start_at_diff.header_id);
     next_lump_diff_block BIGINT := (
         SELECT MIN(block_number)
         FROM maker.cat_ilk_lump
-            LEFT JOIN public.headers ON cat_ilk_lump.header_id = headers.id
-        WHERE cat_ilk_lump.ilk_id = new_diff.ilk_id
+                 LEFT JOIN public.headers ON cat_ilk_lump.header_id = headers.id
+        WHERE cat_ilk_lump.ilk_id = start_at_diff.ilk_id
           AND block_number > diff_block_number);
 BEGIN
     UPDATE api.historical_ilk_state
-    SET lump = new_diff.lump
+    SET lump = new_lump
     WHERE historical_ilk_state.ilk_identifier = diff_ilk_identifier
-      AND historical_ilk_state.block_number > diff_block_number
+      AND historical_ilk_state.block_number >= diff_block_number
       AND (next_lump_diff_block IS NULL
         OR historical_ilk_state.block_number < next_lump_diff_block);
     RETURN NULL;
@@ -898,12 +1001,17 @@ $$
 -- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.insert_ilk_lumps() RETURNS TRIGGER
+CREATE OR REPLACE FUNCTION maker.update_ilk_lumps() RETURNS TRIGGER
 AS
 $$
 BEGIN
-    PERFORM maker.insert_new_lump(NEW);
-    PERFORM maker.update_later_lumps(NEW);
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_new_lump(NEW);
+        PERFORM maker.update_lumps_until_next_diff(NEW, NEW.lump);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.update_lumps_until_next_diff(OLD, ilk_lump_before_block(OLD.ilk_id, OLD.header_id));
+        PERFORM maker.delete_redundant_ilk_state(OLD.ilk_id, OLD.header_id);
+    END IF;
     RETURN NULL;
 END
 $$
@@ -911,10 +1019,10 @@ $$
 -- +goose StatementEnd
 
 CREATE TRIGGER ilk_lump
-    AFTER INSERT OR UPDATE
+    AFTER INSERT OR UPDATE OR DELETE
     ON maker.cat_ilk_lump
     FOR EACH ROW
-EXECUTE PROCEDURE maker.insert_ilk_lumps();
+EXECUTE PROCEDURE maker.update_ilk_lumps();
 
 
 -- +goose StatementBegin
@@ -930,14 +1038,14 @@ DECLARE
         SELECT api.epoch_to_datetime(block_timestamp)
         FROM public.headers
         WHERE id = new_diff.header_id);
-    diff_block_number NUMERIC := (
+    diff_block_number    NUMERIC   := (
         SELECT block_number
         FROM public.headers
         WHERE id = new_diff.header_id);
 BEGIN
     INSERT
-    INTO api.historical_ilk_state (ilk_identifier, block_number, rate, art, spot, line, dust, chop, lump, flip, rho, duty,
-                                pip, mat, created, updated)
+    INTO api.historical_ilk_state (ilk_identifier, block_number, rate, art, spot, line, dust, chop, lump, flip, rho,
+                                   duty, pip, mat, created, updated)
     VALUES (diff_ilk_identifier,
             diff_block_number,
             ilk_rate_before_block(new_diff.ilk_id, new_diff.header_id),
@@ -963,29 +1071,29 @@ $$
 -- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.update_later_flips(new_diff maker.cat_ilk_flip) RETURNS maker.cat_ilk_flip
+CREATE OR REPLACE FUNCTION maker.update_flips_until_next_diff(start_at_diff maker.cat_ilk_flip, new_flip TEXT) RETURNS maker.cat_ilk_flip
 AS
 $$
 DECLARE
     diff_ilk_identifier  TEXT   := (
         SELECT identifier
         FROM maker.ilks
-        WHERE ilks.id = new_diff.ilk_id);
-    diff_block_number BIGINT := (
+        WHERE ilks.id = start_at_diff.ilk_id);
+    diff_block_number    BIGINT := (
         SELECT block_number
         FROM public.headers
-        WHERE id = new_diff.header_id);
+        WHERE id = start_at_diff.header_id);
     next_flip_diff_block BIGINT := (
         SELECT MIN(block_number)
         FROM maker.cat_ilk_flip
-            LEFT JOIN public.headers ON cat_ilk_flip.header_id = headers.id
-        WHERE cat_ilk_flip.ilk_id = new_diff.ilk_id
+                 LEFT JOIN public.headers ON cat_ilk_flip.header_id = headers.id
+        WHERE cat_ilk_flip.ilk_id = start_at_diff.ilk_id
           AND block_number > diff_block_number);
 BEGIN
     UPDATE api.historical_ilk_state
-    SET flip = new_diff.flip
+    SET flip = new_flip
     WHERE historical_ilk_state.ilk_identifier = diff_ilk_identifier
-      AND historical_ilk_state.block_number > diff_block_number
+      AND historical_ilk_state.block_number >= diff_block_number
       AND (next_flip_diff_block IS NULL
         OR historical_ilk_state.block_number < next_flip_diff_block);
     RETURN NULL;
@@ -995,12 +1103,17 @@ $$
 -- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.insert_ilk_flips() RETURNS TRIGGER
+CREATE OR REPLACE FUNCTION maker.update_ilk_flips() RETURNS TRIGGER
 AS
 $$
 BEGIN
-    PERFORM maker.insert_new_flip(NEW);
-    PERFORM maker.update_later_flips(NEW);
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_new_flip(NEW);
+        PERFORM maker.update_flips_until_next_diff(NEW, NEW.flip);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.update_flips_until_next_diff(OLD, ilk_flip_before_block(OLD.ilk_id, OLD.header_id));
+        PERFORM maker.delete_redundant_ilk_state(OLD.ilk_id, OLD.header_id);
+    END IF;
     RETURN NULL;
 END
 $$
@@ -1008,10 +1121,10 @@ $$
 -- +goose StatementEnd
 
 CREATE TRIGGER ilk_flip
-    AFTER INSERT OR UPDATE
+    AFTER INSERT OR UPDATE OR DELETE
     ON maker.cat_ilk_flip
     FOR EACH ROW
-EXECUTE PROCEDURE maker.insert_ilk_flips();
+EXECUTE PROCEDURE maker.update_ilk_flips();
 
 
 -- +goose StatementBegin
@@ -1027,14 +1140,14 @@ DECLARE
         SELECT api.epoch_to_datetime(block_timestamp)
         FROM public.headers
         WHERE id = new_diff.header_id);
-    diff_block_number NUMERIC := (
+    diff_block_number    NUMERIC   := (
         SELECT block_number
         FROM public.headers
         WHERE id = new_diff.header_id);
 BEGIN
     INSERT
-    INTO api.historical_ilk_state (ilk_identifier, block_number, rate, art, spot, line, dust, chop, lump, flip, rho, duty,
-                                pip, mat, created, updated)
+    INTO api.historical_ilk_state (ilk_identifier, block_number, rate, art, spot, line, dust, chop, lump, flip, rho,
+                                   duty, pip, mat, created, updated)
     VALUES (diff_ilk_identifier,
             diff_block_number,
             ilk_rate_before_block(new_diff.ilk_id, new_diff.header_id),
@@ -1060,29 +1173,29 @@ $$
 -- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.update_later_rhos(new_diff maker.jug_ilk_rho) RETURNS maker.jug_ilk_rho
+CREATE OR REPLACE FUNCTION maker.update_rhos_until_next_diff(start_at_diff maker.jug_ilk_rho, new_rho NUMERIC) RETURNS maker.jug_ilk_rho
 AS
 $$
 DECLARE
     diff_ilk_identifier TEXT   := (
         SELECT identifier
         FROM maker.ilks
-        WHERE ilks.id = new_diff.ilk_id);
-    diff_block_number BIGINT := (
+        WHERE ilks.id = start_at_diff.ilk_id);
+    diff_block_number   BIGINT := (
         SELECT block_number
         FROM public.headers
-        WHERE id = new_diff.header_id);
+        WHERE id = start_at_diff.header_id);
     next_rho_diff_block BIGINT := (
         SELECT MIN(block_number)
         FROM maker.jug_ilk_rho
-            LEFT JOIN public.headers ON jug_ilk_rho.header_id = headers.id
-        WHERE jug_ilk_rho.ilk_id = new_diff.ilk_id
+                 LEFT JOIN public.headers ON jug_ilk_rho.header_id = headers.id
+        WHERE jug_ilk_rho.ilk_id = start_at_diff.ilk_id
           AND block_number > diff_block_number);
 BEGIN
     UPDATE api.historical_ilk_state
-    SET rho = new_diff.rho
+    SET rho = new_rho
     WHERE historical_ilk_state.ilk_identifier = diff_ilk_identifier
-      AND historical_ilk_state.block_number > diff_block_number
+      AND historical_ilk_state.block_number >= diff_block_number
       AND (next_rho_diff_block IS NULL
         OR historical_ilk_state.block_number < next_rho_diff_block);
     RETURN NULL;
@@ -1092,12 +1205,17 @@ $$
 -- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.insert_ilk_rhos() RETURNS TRIGGER
+CREATE OR REPLACE FUNCTION maker.update_ilk_rhos() RETURNS TRIGGER
 AS
 $$
 BEGIN
-    PERFORM maker.insert_new_rho(NEW);
-    PERFORM maker.update_later_rhos(NEW);
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_new_rho(NEW);
+        PERFORM maker.update_rhos_until_next_diff(NEW, NEW.rho);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.update_rhos_until_next_diff(OLD, ilk_rho_before_block(OLD.ilk_id, OLD.header_id));
+        PERFORM maker.delete_redundant_ilk_state(OLD.ilk_id, OLD.header_id);
+    END IF;
     RETURN NULL;
 END
 $$
@@ -1105,10 +1223,10 @@ $$
 -- +goose StatementEnd
 
 CREATE TRIGGER ilk_rho
-    AFTER INSERT OR UPDATE
+    AFTER INSERT OR UPDATE OR DELETE
     ON maker.jug_ilk_rho
     FOR EACH ROW
-EXECUTE PROCEDURE maker.insert_ilk_rhos();
+EXECUTE PROCEDURE maker.update_ilk_rhos();
 
 
 -- +goose StatementBegin
@@ -1124,14 +1242,14 @@ DECLARE
         SELECT api.epoch_to_datetime(block_timestamp)
         FROM public.headers
         WHERE id = new_diff.header_id);
-    diff_block_number NUMERIC := (
+    diff_block_number    NUMERIC   := (
         SELECT block_number
         FROM public.headers
         WHERE id = new_diff.header_id);
 BEGIN
     INSERT
-    INTO api.historical_ilk_state (ilk_identifier, block_number, rate, art, spot, line, dust, chop, lump, flip, rho, duty,
-                                pip, mat, created, updated)
+    INTO api.historical_ilk_state (ilk_identifier, block_number, rate, art, spot, line, dust, chop, lump, flip, rho,
+                                   duty, pip, mat, created, updated)
     VALUES (diff_ilk_identifier,
             diff_block_number,
             ilk_rate_before_block(new_diff.ilk_id, new_diff.header_id),
@@ -1157,29 +1275,29 @@ $$
 -- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.update_later_duties(new_diff maker.jug_ilk_duty) RETURNS maker.jug_ilk_duty
+CREATE OR REPLACE FUNCTION maker.update_duties_until_next_diff(start_at_diff maker.jug_ilk_duty, new_duty NUMERIC) RETURNS maker.jug_ilk_duty
 AS
 $$
 DECLARE
     diff_ilk_identifier  TEXT   := (
         SELECT identifier
         FROM maker.ilks
-        WHERE ilks.id = new_diff.ilk_id);
-    diff_block_number BIGINT := (
+        WHERE ilks.id = start_at_diff.ilk_id);
+    diff_block_number    BIGINT := (
         SELECT block_number
         FROM public.headers
-        WHERE id = new_diff.header_id);
+        WHERE id = start_at_diff.header_id);
     next_duty_diff_block BIGINT := (
         SELECT MIN(block_number)
         FROM maker.jug_ilk_duty
-            LEFT JOIN public.headers ON jug_ilk_duty.header_id = headers.id
-        WHERE jug_ilk_duty.ilk_id = new_diff.ilk_id
+                 LEFT JOIN public.headers ON jug_ilk_duty.header_id = headers.id
+        WHERE jug_ilk_duty.ilk_id = start_at_diff.ilk_id
           AND block_number > diff_block_number);
 BEGIN
     UPDATE api.historical_ilk_state
-    SET duty = new_diff.duty
+    SET duty = new_duty
     WHERE historical_ilk_state.ilk_identifier = diff_ilk_identifier
-      AND historical_ilk_state.block_number > diff_block_number
+      AND historical_ilk_state.block_number >= diff_block_number
       AND (next_duty_diff_block IS NULL
         OR historical_ilk_state.block_number < next_duty_diff_block);
     RETURN NULL;
@@ -1189,12 +1307,17 @@ $$
 -- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.insert_ilk_duties() RETURNS TRIGGER
+CREATE OR REPLACE FUNCTION maker.update_ilk_duties() RETURNS TRIGGER
 AS
 $$
 BEGIN
-    PERFORM maker.insert_new_duty(NEW);
-    PERFORM maker.update_later_duties(NEW);
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_new_duty(NEW);
+        PERFORM maker.update_duties_until_next_diff(NEW, NEW.duty);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.update_duties_until_next_diff(OLD, ilk_duty_before_block(OLD.ilk_id, OLD.header_id));
+        PERFORM maker.delete_redundant_ilk_state(OLD.ilk_id, OLD.header_id);
+    END IF;
     RETURN NULL;
 END
 $$
@@ -1202,10 +1325,10 @@ $$
 -- +goose StatementEnd
 
 CREATE TRIGGER ilk_duty
-    AFTER INSERT OR UPDATE
+    AFTER INSERT OR UPDATE OR DELETE
     ON maker.jug_ilk_duty
     FOR EACH ROW
-EXECUTE PROCEDURE maker.insert_ilk_duties();
+EXECUTE PROCEDURE maker.update_ilk_duties();
 
 
 -- +goose StatementBegin
@@ -1221,14 +1344,14 @@ DECLARE
         SELECT api.epoch_to_datetime(block_timestamp)
         FROM public.headers
         WHERE id = new_diff.header_id);
-    diff_block_number NUMERIC := (
+    diff_block_number    NUMERIC   := (
         SELECT block_number
         FROM public.headers
         WHERE id = new_diff.header_id);
 BEGIN
     INSERT
-    INTO api.historical_ilk_state (ilk_identifier, block_number, rate, art, spot, line, dust, chop, lump, flip, rho, duty,
-                                pip, mat, created, updated)
+    INTO api.historical_ilk_state (ilk_identifier, block_number, rate, art, spot, line, dust, chop, lump, flip, rho,
+                                   duty, pip, mat, created, updated)
     VALUES (diff_ilk_identifier,
             diff_block_number,
             ilk_rate_before_block(new_diff.ilk_id, new_diff.header_id),
@@ -1254,29 +1377,29 @@ $$
 -- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.update_later_pips(new_diff maker.spot_ilk_pip) RETURNS maker.spot_ilk_pip
+CREATE OR REPLACE FUNCTION maker.update_pips_until_next_diff(start_at_diff maker.spot_ilk_pip, new_pip TEXT) RETURNS maker.spot_ilk_pip
 AS
 $$
 DECLARE
     diff_ilk_identifier TEXT   := (
         SELECT identifier
         FROM maker.ilks
-        WHERE ilks.id = new_diff.ilk_id);
-    diff_block_number BIGINT := (
+        WHERE ilks.id = start_at_diff.ilk_id);
+    diff_block_number   BIGINT := (
         SELECT block_number
         FROM public.headers
-        WHERE id = new_diff.header_id);
+        WHERE id = start_at_diff.header_id);
     next_pip_diff_block BIGINT := (
         SELECT MIN(block_number)
         FROM maker.spot_ilk_pip
-            LEFT JOIN public.headers ON spot_ilk_pip.header_id = headers.id
-        WHERE spot_ilk_pip.ilk_id = new_diff.ilk_id
+                 LEFT JOIN public.headers ON spot_ilk_pip.header_id = headers.id
+        WHERE spot_ilk_pip.ilk_id = start_at_diff.ilk_id
           AND block_number > diff_block_number);
 BEGIN
     UPDATE api.historical_ilk_state
-    SET pip = new_diff.pip
+    SET pip = new_pip
     WHERE historical_ilk_state.ilk_identifier = diff_ilk_identifier
-      AND historical_ilk_state.block_number > diff_block_number
+      AND historical_ilk_state.block_number >= diff_block_number
       AND (next_pip_diff_block IS NULL
         OR historical_ilk_state.block_number < next_pip_diff_block);
     RETURN NULL;
@@ -1286,12 +1409,17 @@ $$
 -- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.insert_ilk_pips() RETURNS TRIGGER
+CREATE OR REPLACE FUNCTION maker.update_ilk_pips() RETURNS TRIGGER
 AS
 $$
 BEGIN
-    PERFORM maker.insert_new_pip(NEW);
-    PERFORM maker.update_later_pips(NEW);
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_new_pip(NEW);
+        PERFORM maker.update_pips_until_next_diff(NEW, NEW.pip);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.update_pips_until_next_diff(OLD, ilk_pip_before_block(OLD.ilk_id, OLD.header_id));
+        PERFORM maker.delete_redundant_ilk_state(OLD.ilk_id, OLD.header_id);
+    END IF;
     RETURN NULL;
 END
 $$
@@ -1299,10 +1427,10 @@ $$
 -- +goose StatementEnd
 
 CREATE TRIGGER ilk_pip
-    AFTER INSERT OR UPDATE
+    AFTER INSERT OR UPDATE OR DELETE
     ON maker.spot_ilk_pip
     FOR EACH ROW
-EXECUTE PROCEDURE maker.insert_ilk_pips();
+EXECUTE PROCEDURE maker.update_ilk_pips();
 
 
 -- +goose StatementBegin
@@ -1318,14 +1446,14 @@ DECLARE
         SELECT api.epoch_to_datetime(block_timestamp)
         FROM public.headers
         WHERE id = new_diff.header_id);
-    diff_block_number NUMERIC := (
+    diff_block_number    NUMERIC   := (
         SELECT block_number
         FROM public.headers
         WHERE id = new_diff.header_id);
 BEGIN
     INSERT
-    INTO api.historical_ilk_state (ilk_identifier, block_number, rate, art, spot, line, dust, chop, lump, flip, rho, duty,
-                                pip, mat, created, updated)
+    INTO api.historical_ilk_state (ilk_identifier, block_number, rate, art, spot, line, dust, chop, lump, flip, rho,
+                                   duty, pip, mat, created, updated)
     VALUES (diff_ilk_identifier,
             diff_block_number,
             ilk_rate_before_block(new_diff.ilk_id, new_diff.header_id),
@@ -1351,29 +1479,29 @@ $$
 -- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.update_later_mats(new_diff maker.spot_ilk_mat) RETURNS maker.spot_ilk_mat
+CREATE OR REPLACE FUNCTION maker.update_mats_until_next_diff(start_at_diff maker.spot_ilk_mat, new_mat NUMERIC) RETURNS maker.spot_ilk_mat
 AS
 $$
 DECLARE
     diff_ilk_identifier TEXT   := (
         SELECT identifier
         FROM maker.ilks
-        WHERE ilks.id = new_diff.ilk_id);
-    diff_block_number BIGINT := (
+        WHERE ilks.id = start_at_diff.ilk_id);
+    diff_block_number   BIGINT := (
         SELECT block_number
         FROM public.headers
-        WHERE id = new_diff.header_id);
+        WHERE id = start_at_diff.header_id);
     next_mat_diff_block BIGINT := (
         SELECT MIN(block_number)
         FROM maker.spot_ilk_mat
-            LEFT JOIN public.headers ON spot_ilk_mat.header_id = headers.id
-        WHERE spot_ilk_mat.ilk_id = new_diff.ilk_id
+                 LEFT JOIN public.headers ON spot_ilk_mat.header_id = headers.id
+        WHERE spot_ilk_mat.ilk_id = start_at_diff.ilk_id
           AND block_number > diff_block_number);
 BEGIN
     UPDATE api.historical_ilk_state
-    SET mat = new_diff.mat
+    SET mat = new_mat
     WHERE historical_ilk_state.ilk_identifier = diff_ilk_identifier
-      AND historical_ilk_state.block_number > diff_block_number
+      AND historical_ilk_state.block_number >= diff_block_number
       AND (next_mat_diff_block IS NULL
         OR historical_ilk_state.block_number < next_mat_diff_block);
     RETURN NULL;
@@ -1383,12 +1511,17 @@ $$
 -- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.insert_ilk_mats() RETURNS TRIGGER
+CREATE OR REPLACE FUNCTION maker.update_ilk_mats() RETURNS TRIGGER
 AS
 $$
 BEGIN
-    PERFORM maker.insert_new_mat(NEW);
-    PERFORM maker.update_later_mats(NEW);
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_new_mat(NEW);
+        PERFORM maker.update_mats_until_next_diff(NEW, NEW.mat);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.update_mats_until_next_diff(OLD, ilk_mat_before_block(OLD.ilk_id, OLD.header_id));
+        PERFORM maker.delete_redundant_ilk_state(OLD.ilk_id, OLD.header_id);
+    END IF;
     RETURN NULL;
 END
 $$
@@ -1396,25 +1529,25 @@ $$
 -- +goose StatementEnd
 
 CREATE TRIGGER ilk_mat
-    AFTER INSERT OR UPDATE
+    AFTER INSERT OR UPDATE OR DELETE
     ON maker.spot_ilk_mat
     FOR EACH ROW
-EXECUTE PROCEDURE maker.insert_ilk_mats();
+EXECUTE PROCEDURE maker.update_ilk_mats();
 
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.update_time_created() RETURNS TRIGGER
+CREATE OR REPLACE FUNCTION maker.insert_new_time_created(new_event maker.vat_init) RETURNS maker.vat_init
 AS
 $$
 DECLARE
     diff_ilk_identifier TEXT      := (
         SELECT identifier
         FROM maker.ilks
-        WHERE ilks.id = NEW.ilk_id);
+        WHERE ilks.id = new_event.ilk_id);
     diff_timestamp      TIMESTAMP := (
         SELECT api.epoch_to_datetime(block_timestamp)
         FROM public.headers
-        WHERE headers.id = NEW.header_id);
+        WHERE headers.id = new_event.header_id);
 BEGIN
     UPDATE api.historical_ilk_state
     SET created = diff_timestamp
@@ -1428,8 +1561,40 @@ $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
 
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION maker.clear_time_created(old_event maker.vat_init) RETURNS maker.vat_init
+AS
+$$
+BEGIN
+    UPDATE api.historical_ilk_state
+    SET created = ilk_time_created(old_event.ilk_id)
+    FROM maker.ilks
+    WHERE ilks.identifier = historical_ilk_state.ilk_identifier
+      AND ilks.id = old_event.ilk_id;
+    RETURN NULL;
+END
+$$
+    LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION maker.update_time_created() RETURNS TRIGGER
+AS
+$$
+BEGIN
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_new_time_created(NEW);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.clear_time_created(OLD);
+    END IF;
+    RETURN NULL;
+END
+$$
+    LANGUAGE plpgsql;
+-- +goose StatementEnd
+
 CREATE TRIGGER ilk_init
-    AFTER INSERT OR UPDATE
+    AFTER INSERT OR UPDATE OR DELETE
     ON maker.vat_init
     FOR EACH ROW
 EXECUTE PROCEDURE maker.update_time_created();
@@ -1450,33 +1615,35 @@ DROP TRIGGER ilk_spot ON maker.vat_ilk_spot;
 DROP TRIGGER ilk_art ON maker.vat_ilk_art;
 DROP TRIGGER ilk_rate ON maker.vat_ilk_rate;
 
-DROP FUNCTION maker.insert_ilk_mats();
-DROP FUNCTION maker.insert_ilk_pips();
-DROP FUNCTION maker.insert_ilk_duties();
-DROP FUNCTION maker.insert_ilk_rhos();
-DROP FUNCTION maker.insert_ilk_flips();
-DROP FUNCTION maker.insert_ilk_lumps();
-DROP FUNCTION maker.insert_ilk_chops();
-DROP FUNCTION maker.insert_ilk_dusts();
-DROP FUNCTION maker.insert_ilk_lines();
-DROP FUNCTION maker.insert_ilk_spots();
-DROP FUNCTION maker.insert_ilk_arts();
-DROP FUNCTION maker.insert_ilk_rates();
-
 DROP FUNCTION maker.update_time_created();
-DROP FUNCTION maker.update_later_mats(maker.spot_ilk_mat);
-DROP FUNCTION maker.update_later_pips(maker.spot_ilk_pip);
-DROP FUNCTION maker.update_later_duties(maker.jug_ilk_duty);
-DROP FUNCTION maker.update_later_rhos(maker.jug_ilk_rho);
-DROP FUNCTION maker.update_later_flips(maker.cat_ilk_flip);
-DROP FUNCTION maker.update_later_lumps(maker.cat_ilk_lump);
-DROP FUNCTION maker.update_later_chops(maker.cat_ilk_chop);
-DROP FUNCTION maker.update_later_dusts(maker.vat_ilk_dust);
-DROP FUNCTION maker.update_later_lines(maker.vat_ilk_line);
-DROP FUNCTION maker.update_later_spots(maker.vat_ilk_spot);
-DROP FUNCTION maker.update_later_arts(maker.vat_ilk_art);
-DROP FUNCTION maker.update_later_rates(maker.vat_ilk_rate);
+DROP FUNCTION maker.update_ilk_mats();
+DROP FUNCTION maker.update_ilk_pips();
+DROP FUNCTION maker.update_ilk_duties();
+DROP FUNCTION maker.update_ilk_rhos();
+DROP FUNCTION maker.update_ilk_flips();
+DROP FUNCTION maker.update_ilk_lumps();
+DROP FUNCTION maker.update_ilk_chops();
+DROP FUNCTION maker.update_ilk_dusts();
+DROP FUNCTION maker.update_ilk_lines();
+DROP FUNCTION maker.update_ilk_spots();
+DROP FUNCTION maker.update_ilk_arts();
+DROP FUNCTION maker.update_ilk_rates();
 
+DROP FUNCTION maker.clear_time_created(maker.vat_init);
+DROP FUNCTION maker.update_mats_until_next_diff(maker.spot_ilk_mat, NUMERIC);
+DROP FUNCTION maker.update_pips_until_next_diff(maker.spot_ilk_pip, TEXT);
+DROP FUNCTION maker.update_duties_until_next_diff(maker.jug_ilk_duty, NUMERIC);
+DROP FUNCTION maker.update_rhos_until_next_diff(maker.jug_ilk_rho, NUMERIC);
+DROP FUNCTION maker.update_flips_until_next_diff(maker.cat_ilk_flip, TEXT);
+DROP FUNCTION maker.update_lumps_until_next_diff(maker.cat_ilk_lump, NUMERIC);
+DROP FUNCTION maker.update_chops_until_next_diff(maker.cat_ilk_chop, NUMERIC);
+DROP FUNCTION maker.update_dusts_until_next_diff(maker.vat_ilk_dust, NUMERIC);
+DROP FUNCTION maker.update_lines_until_next_diff(maker.vat_ilk_line, NUMERIC);
+DROP FUNCTION maker.update_spots_until_next_diff(maker.vat_ilk_spot, NUMERIC);
+DROP FUNCTION maker.update_arts_until_next_diff(maker.vat_ilk_art, NUMERIC);
+DROP FUNCTION maker.update_rates_until_next_diff(maker.vat_ilk_rate, NUMERIC);
+
+DROP FUNCTION maker.insert_new_time_created(maker.vat_init);
 DROP FUNCTION maker.insert_new_mat(maker.spot_ilk_mat);
 DROP FUNCTION maker.insert_new_pip(maker.spot_ilk_pip);
 DROP FUNCTION maker.insert_new_duty(maker.jug_ilk_duty);
@@ -1489,6 +1656,8 @@ DROP FUNCTION maker.insert_new_line(maker.vat_ilk_line);
 DROP FUNCTION maker.insert_new_spot(maker.vat_ilk_spot);
 DROP FUNCTION maker.insert_new_art(maker.vat_ilk_art);
 DROP FUNCTION maker.insert_new_rate(maker.vat_ilk_rate);
+
+DROP FUNCTION maker.delete_redundant_ilk_state(INTEGER, INTEGER);
 
 DROP FUNCTION ilk_time_created(INTEGER);
 DROP FUNCTION ilk_mat_before_block(INTEGER, INTEGER);

--- a/transformers/storage/cat/repository_test.go
+++ b/transformers/storage/cat/repository_test.go
@@ -166,6 +166,7 @@ var _ = Describe("Cat storage repository", func() {
 				Metadata:      utils.GetStorageValueMetadata(cat.IlkFlip, map[utils.Key]string{constants.Ilk: test_helpers.FakeIlk.Hex}, utils.Address),
 				PropertyName:  "Flip",
 				PropertyValue: fakeAddress,
+				TableName:     "maker.cat_ilk_flip",
 			})
 		})
 
@@ -210,6 +211,7 @@ var _ = Describe("Cat storage repository", func() {
 				Metadata:      utils.GetStorageValueMetadata(cat.IlkChop, map[utils.Key]string{constants.Ilk: test_helpers.FakeIlk.Hex}, utils.Uint256),
 				PropertyName:  "Chop",
 				PropertyValue: strconv.Itoa(rand.Int()),
+				TableName:     "maker.cat_ilk_chop",
 			})
 		})
 
@@ -254,6 +256,7 @@ var _ = Describe("Cat storage repository", func() {
 				Metadata:      utils.GetStorageValueMetadata(cat.IlkLump, map[utils.Key]string{constants.Ilk: test_helpers.FakeIlk.Hex}, utils.Uint256),
 				PropertyName:  "Lump",
 				PropertyValue: strconv.Itoa(rand.Int()),
+				TableName:     "maker.cat_ilk_lump",
 			})
 		})
 	})

--- a/transformers/storage/jug/repository_test.go
+++ b/transformers/storage/jug/repository_test.go
@@ -97,6 +97,7 @@ var _ = Describe("Jug storage repository", func() {
 				Metadata:      utils.GetStorageValueMetadata(jug.IlkRho, map[utils.Key]string{constants.Ilk: test_helpers.FakeIlk.Hex}, utils.Uint256),
 				PropertyName:  "Rho",
 				PropertyValue: strconv.Itoa(rand.Int()),
+				TableName:     "maker.jug_ilk_rho",
 			})
 		})
 
@@ -142,6 +143,7 @@ var _ = Describe("Jug storage repository", func() {
 				Metadata:      utils.GetStorageValueMetadata(jug.IlkDuty, map[utils.Key]string{constants.Ilk: test_helpers.FakeIlk.Hex}, utils.Uint256),
 				PropertyName:  "Duty",
 				PropertyValue: strconv.Itoa(rand.Int()),
+				TableName:     "maker.jug_ilk_duty",
 			})
 		})
 	})

--- a/transformers/storage/spot/repository_test.go
+++ b/transformers/storage/spot/repository_test.go
@@ -97,6 +97,7 @@ var _ = Describe("Spot storage repository", func() {
 				Metadata:      utils.GetStorageValueMetadata(spot.IlkPip, map[utils.Key]string{constants.Ilk: test_helpers.FakeIlk.Hex}, utils.Address),
 				PropertyName:  "Pip",
 				PropertyValue: fakeAddress,
+				TableName:     "maker.spot_ilk_pip",
 			})
 		})
 
@@ -142,6 +143,7 @@ var _ = Describe("Spot storage repository", func() {
 				Metadata:      utils.GetStorageValueMetadata(spot.IlkMat, map[utils.Key]string{constants.Ilk: test_helpers.FakeIlk.Hex}, utils.Uint256),
 				PropertyName:  "Mat",
 				PropertyValue: strconv.Itoa(rand.Int()),
+				TableName:     "maker.spot_ilk_mat",
 			})
 		})
 	})

--- a/transformers/storage/vat/repository_test.go
+++ b/transformers/storage/vat/repository_test.go
@@ -186,6 +186,7 @@ var _ = Describe("Vat storage repository", func() {
 			Metadata:      utils.GetStorageValueMetadata(vat.IlkArt, map[utils.Key]string{constants.Ilk: test_helpers.FakeIlk.Hex}, utils.Uint256),
 			PropertyName:  "Art",
 			PropertyValue: strconv.Itoa(rand.Int()),
+			TableName:     "maker.vat_ilk_art",
 		})
 	})
 
@@ -233,6 +234,7 @@ var _ = Describe("Vat storage repository", func() {
 			Metadata:      utils.GetStorageValueMetadata(vat.IlkDust, map[utils.Key]string{constants.Ilk: test_helpers.FakeIlk.Hex}, utils.Uint256),
 			PropertyName:  "Dust",
 			PropertyValue: strconv.Itoa(rand.Int()),
+			TableName:     "maker.vat_ilk_dust",
 		})
 	})
 
@@ -280,6 +282,7 @@ var _ = Describe("Vat storage repository", func() {
 			Metadata:      utils.GetStorageValueMetadata(vat.IlkLine, map[utils.Key]string{constants.Ilk: test_helpers.FakeIlk.Hex}, utils.Uint256),
 			PropertyName:  "Line",
 			PropertyValue: strconv.Itoa(rand.Int()),
+			TableName:     "maker.vat_ilk_line",
 		})
 	})
 
@@ -327,6 +330,7 @@ var _ = Describe("Vat storage repository", func() {
 			Metadata:      utils.GetStorageValueMetadata(vat.IlkRate, map[utils.Key]string{constants.Ilk: test_helpers.FakeIlk.Hex}, utils.Uint256),
 			PropertyName:  "Rate",
 			PropertyValue: strconv.Itoa(rand.Int()),
+			TableName:     "maker.vat_ilk_rate",
 		})
 	})
 
@@ -374,6 +378,7 @@ var _ = Describe("Vat storage repository", func() {
 			Metadata:      utils.GetStorageValueMetadata(vat.IlkSpot, map[utils.Key]string{constants.Ilk: test_helpers.FakeIlk.Hex}, utils.Uint256),
 			PropertyName:  "Spot",
 			PropertyValue: strconv.Itoa(rand.Int()),
+			TableName:     "maker.vat_ilk_spot",
 		})
 	})
 


### PR DESCRIPTION
When a diff record is deleted, these triggers wipe out that diff's value from the `historical_ilk_state` table. 