### PR TITLE
(VDB-970) urn state history

### DIFF
--- a/db/migrations/20190919141224_create_ilk_state_history_table_and_triggers.sql
+++ b/db/migrations/20190919141224_create_ilk_state_history_table_and_triggers.sql
@@ -266,14 +266,15 @@ CREATE OR REPLACE FUNCTION maker.delete_redundant_ilk_state(ilk_id INTEGER, head
 AS
 $$
 DECLARE
-    associated_ilk TEXT                     := (
+    associated_ilk         TEXT                     := (
         SELECT identifier
         FROM maker.ilks
         WHERE id = delete_redundant_ilk_state.ilk_id);
     ilk_state_block_number BIGINT                   := (
         SELECT block_number
         FROM public.headers
-        WHERE id = header_id);ilk_state      api.historical_ilk_state := (
+        WHERE id = header_id);
+    ilk_state              api.historical_ilk_state := (
         SELECT (ilk_identifier, historical_ilk_state.block_number, rate, art, spot, line, dust, chop, lump, flip, rho,
                 duty, pip, mat, created, updated)
         FROM api.historical_ilk_state

--- a/db/migrations/20191202091203_create_historical_urn_state_table_and_triggers.sql
+++ b/db/migrations/20191202091203_create_historical_urn_state_table_and_triggers.sql
@@ -1,0 +1,318 @@
+-- +goose Up
+CREATE TABLE api.historical_urn_state
+(
+    urn_identifier TEXT,
+    ilk_identifier TEXT,
+    block_height   BIGINT,
+    ink            NUMERIC   DEFAULT NULL,
+    art            NUMERIC   DEFAULT NULL,
+    created        TIMESTAMP DEFAULT NULL,
+    updated        TIMESTAMP NOT NULL,
+    PRIMARY KEY (urn_identifier, ilk_identifier, block_height)
+);
+
+
+CREATE FUNCTION urn_ink_before_block(urn_id INTEGER, header_id INTEGER) RETURNS NUMERIC AS
+$$
+WITH passed_block_number AS (
+    SELECT block_number
+    FROM public.headers
+    WHERE id = header_id)
+SELECT ink
+FROM maker.vat_urn_ink
+         LEFT JOIN public.headers ON vat_urn_ink.header_id = headers.id
+WHERE vat_urn_ink.urn_id = urn_ink_before_block.urn_id
+  AND headers.block_number < (SELECT block_number FROM passed_block_number)
+ORDER BY block_number DESC
+LIMIT 1
+$$
+    LANGUAGE sql;
+
+
+CREATE FUNCTION urn_art_before_block(urn_id INTEGER, header_id INTEGER) RETURNS NUMERIC AS
+$$
+WITH passed_block_number AS (
+    SELECT block_number
+    FROM public.headers
+    WHERE id = header_id)
+SELECT art
+FROM maker.vat_urn_art
+         LEFT JOIN public.headers ON vat_urn_art.header_id = headers.id
+WHERE vat_urn_art.urn_id = urn_art_before_block.urn_id
+  AND headers.block_number < (SELECT block_number FROM passed_block_number)
+ORDER BY block_number DESC
+LIMIT 1
+$$
+    LANGUAGE sql;
+
+
+CREATE FUNCTION urn_time_created(urn_id INTEGER) RETURNS TIMESTAMP AS
+$$
+SELECT api.epoch_to_datetime(MIN(block_timestamp))
+FROM maker.vat_urn_ink
+         LEFT JOIN public.headers ON vat_urn_ink.header_id = headers.id
+WHERE vat_urn_ink.urn_id = urn_time_created.urn_id
+$$
+    LANGUAGE sql;
+
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION maker.delete_obsolete_urn_state(urn_id INTEGER, header_id INTEGER) RETURNS api.historical_urn_state
+    -- deletes row if there are no longer any diffs in that block for the associated urn
+AS
+$$
+DECLARE
+    urn_state_block_number BIGINT := (
+        SELECT block_number
+        FROM public.headers
+        WHERE id = header_id);
+BEGIN
+    DELETE
+    FROM api.historical_urn_state
+        USING maker.urns LEFT JOIN maker.ilks ON urns.ilk_id = ilks.id
+    WHERE historical_urn_state.urn_identifier = urns.identifier
+      AND historical_urn_state.ilk_identifier = ilks.identifier
+      AND urns.id = urn_id
+      AND historical_urn_state.block_height = urn_state_block_number
+      AND NOT (EXISTS(
+            SELECT *
+            FROM maker.vat_urn_ink
+            WHERE vat_urn_ink.urn_id = delete_obsolete_urn_state.urn_id
+              AND vat_urn_ink.header_id = delete_obsolete_urn_state.header_id))
+      AND NOT (EXISTS(
+            SELECT *
+            FROM maker.vat_urn_art
+            WHERE vat_urn_art.urn_id = delete_obsolete_urn_state.urn_id
+              AND vat_urn_art.header_id = delete_obsolete_urn_state.header_id));
+    RETURN NULL;
+END
+$$
+    LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION maker.insert_urn_ink(new_diff maker.vat_urn_ink) RETURNS maker.vat_urn_ink
+AS
+$$
+BEGIN
+    WITH urn AS (
+        SELECT urns.identifier AS urn_identifier, ilks.identifier AS ilk_identifier
+        FROM maker.urns
+                 LEFT JOIN maker.ilks ON urns.ilk_id = ilks.id
+        WHERE urns.id = new_diff.urn_id),
+         new_diff_header AS (
+             SELECT api.epoch_to_datetime(block_timestamp) AS block_timestamp, block_number
+             FROM public.headers
+             WHERE id = new_diff.header_id)
+    INSERT
+    INTO api.historical_urn_state (urn_identifier, ilk_identifier, block_height, ink, art, created, updated)
+    VALUES ((SELECT urn_identifier FROM urn),
+            (SELECT ilk_identifier FROM urn),
+            (SELECT block_number FROM new_diff_header),
+            new_diff.ink,
+            urn_art_before_block(new_diff.urn_id, new_diff.header_id),
+            urn_time_created(new_diff.urn_id),
+            (SELECT block_timestamp FROM new_diff_header))
+    ON CONFLICT (urn_identifier, ilk_identifier, block_height)
+        DO UPDATE SET ink = new_diff.ink;
+    RETURN NULL;
+END
+$$
+    LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION maker.update_urn_inks_until_next_diff(start_at_diff maker.vat_urn_ink, new_ink NUMERIC) RETURNS maker.vat_urn_ink
+AS
+$$
+DECLARE
+    diff_block_number    BIGINT := (
+        SELECT block_number
+        FROM public.headers
+        WHERE id = start_at_diff.header_id);
+    next_rate_diff_block BIGINT := (
+        SELECT MIN(block_number)
+        FROM maker.vat_urn_ink
+                 LEFT JOIN public.headers ON vat_urn_ink.header_id = headers.id
+        WHERE vat_urn_ink.urn_id = start_at_diff.urn_id
+          AND block_number > diff_block_number);
+BEGIN
+    WITH urn AS (
+        SELECT urns.identifier AS urn_identifier, ilks.identifier AS ilk_identifier
+        FROM maker.urns
+                 LEFT JOIN maker.ilks ON urns.ilk_id = ilks.id
+        WHERE urns.id = start_at_diff.urn_id)
+    UPDATE api.historical_urn_state
+    SET ink = new_ink
+    FROM urn
+    WHERE historical_urn_state.urn_identifier = urn.urn_identifier
+      AND historical_urn_state.ilk_identifier = urn.ilk_identifier
+      AND historical_urn_state.block_height >= diff_block_number
+      AND (next_rate_diff_block IS NULL
+        OR historical_urn_state.block_height < next_rate_diff_block);
+    RETURN NULL;
+END
+$$
+    LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION maker.update_urn_created(urn_id INTEGER) RETURNS maker.vat_urn_ink
+AS
+$$
+BEGIN
+    UPDATE api.historical_urn_state
+    SET created = urn_time_created(urn_id)
+    FROM maker.urns
+             LEFT JOIN maker.ilks ON urns.ilk_id = ilks.id
+    WHERE urns.identifier = historical_urn_state.urn_identifier
+      AND ilks.identifier = historical_urn_state.ilk_identifier
+      AND urns.id = urn_id;
+    RETURN NULL;
+END
+$$
+    LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION maker.update_urn_inks() RETURNS TRIGGER
+AS
+$$
+BEGIN
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_urn_ink(NEW);
+        PERFORM maker.update_urn_inks_until_next_diff(NEW, NEW.ink);
+        PERFORM maker.update_urn_created(NEW.urn_id);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.update_urn_inks_until_next_diff(OLD, urn_ink_before_block(OLD.urn_id, OLD.header_id));
+        PERFORM maker.delete_obsolete_urn_state(OLD.urn_id, OLD.header_id);
+        PERFORM maker.update_urn_created(OLD.urn_id);
+    END IF;
+    RETURN NULL;
+END
+$$
+    LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+CREATE TRIGGER urn_ink
+    AFTER INSERT OR UPDATE OR DELETE
+    ON maker.vat_urn_ink
+    FOR EACH ROW
+EXECUTE PROCEDURE maker.update_urn_inks();
+
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION maker.insert_urn_art(new_diff maker.vat_urn_art) RETURNS maker.vat_urn_art
+AS
+$$
+BEGIN
+    WITH urn AS (
+        SELECT urns.identifier AS urn_identifier, ilks.identifier AS ilk_identifier
+        FROM maker.urns
+                 LEFT JOIN maker.ilks ON urns.ilk_id = ilks.id
+        WHERE urns.id = new_diff.urn_id),
+         new_diff_header AS (
+             SELECT api.epoch_to_datetime(block_timestamp) AS block_timestamp, block_number
+             FROM public.headers
+             WHERE id = new_diff.header_id)
+    INSERT
+    INTO api.historical_urn_state (urn_identifier, ilk_identifier, block_height, ink, art, created, updated)
+    VALUES ((SELECT urn_identifier FROM urn),
+            (SELECT ilk_identifier FROM urn),
+            (SELECT block_number FROM new_diff_header),
+            urn_ink_before_block(new_diff.urn_id, new_diff.header_id),
+            new_diff.art,
+            urn_time_created(new_diff.urn_id),
+            (SELECT block_timestamp FROM new_diff_header))
+    ON CONFLICT (urn_identifier, ilk_identifier, block_height)
+        DO UPDATE SET art = new_diff.art;
+    RETURN NULL;
+END
+$$
+    LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION maker.update_urn_arts_until_next_diff(start_at_diff maker.vat_urn_art, new_art NUMERIC) RETURNS maker.vat_urn_art
+AS
+$$
+DECLARE
+    diff_block_number    BIGINT := (
+        SELECT block_number
+        FROM public.headers
+        WHERE id = start_at_diff.header_id);
+    next_rate_diff_block BIGINT := (
+        SELECT MIN(block_number)
+        FROM maker.vat_urn_art
+                 LEFT JOIN public.headers ON vat_urn_art.header_id = headers.id
+        WHERE vat_urn_art.urn_id = start_at_diff.urn_id
+          AND block_number > diff_block_number);
+BEGIN
+    WITH urn AS (
+        SELECT urns.identifier AS urn_identifier, ilks.identifier AS ilk_identifier
+        FROM maker.urns
+                 LEFT JOIN maker.ilks ON urns.ilk_id = ilks.id
+        WHERE urns.id = start_at_diff.urn_id)
+    UPDATE api.historical_urn_state
+    SET art = new_art
+    FROM urn
+    WHERE historical_urn_state.urn_identifier = urn.urn_identifier
+      AND historical_urn_state.ilk_identifier = urn.ilk_identifier
+      AND historical_urn_state.block_height >= diff_block_number
+      AND (next_rate_diff_block IS NULL
+        OR historical_urn_state.block_height < next_rate_diff_block);
+    RETURN NULL;
+END
+$$
+    LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION maker.update_urn_arts() RETURNS TRIGGER
+AS
+$$
+BEGIN
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_urn_art(NEW);
+        PERFORM maker.update_urn_arts_until_next_diff(NEW, NEW.art);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.update_urn_arts_until_next_diff(OLD, urn_art_before_block(OLD.urn_id, OLD.header_id));
+        PERFORM maker.delete_obsolete_urn_state(OLD.urn_id, OLD.header_id);
+    END IF;
+    RETURN NULL;
+END
+$$
+    LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+CREATE TRIGGER urn_art
+    AFTER INSERT OR UPDATE OR DELETE
+    ON maker.vat_urn_art
+    FOR EACH ROW
+EXECUTE PROCEDURE maker.update_urn_arts();
+
+
+-- +goose Down
+DROP TRIGGER urn_art ON maker.vat_urn_art;
+DROP TRIGGER urn_ink ON maker.vat_urn_ink;
+
+DROP FUNCTION maker.update_urn_arts();
+DROP FUNCTION maker.update_urn_inks();
+
+DROP FUNCTION maker.update_urn_created(INTEGER);
+DROP FUNCTION maker.update_urn_arts_until_next_diff(maker.vat_urn_art, NUMERIC);
+DROP FUNCTION maker.update_urn_inks_until_next_diff(maker.vat_urn_ink, NUMERIC);
+
+DROP FUNCTION maker.insert_urn_art(maker.vat_urn_art);
+DROP FUNCTION maker.insert_urn_ink(maker.vat_urn_ink);
+
+DROP FUNCTION maker.delete_obsolete_urn_state(INTEGER, INTEGER);
+
+DROP FUNCTION urn_time_created(INTEGER);
+DROP FUNCTION urn_art_before_block(INTEGER, INTEGER);
+DROP FUNCTION urn_ink_before_block(INTEGER, INTEGER);
+
+DROP TABLE api.historical_urn_state;

--- a/db/migrations/20191203104431_create_historical_urn_state_computed_columns.sql
+++ b/db/migrations/20191203104431_create_historical_urn_state_computed_columns.sql
@@ -1,0 +1,46 @@
+-- +goose Up
+-- SQL in this section is executed when the migration is applied.
+
+CREATE FUNCTION api.historical_urn_state_ilk(state api.historical_urn_state)
+    RETURNS api.ilk_state AS
+$$
+SELECT *
+FROM api.get_ilk(state.ilk_identifier, state.block_height)
+$$
+    LANGUAGE sql
+    STABLE;
+
+CREATE FUNCTION api.historical_urn_state_frobs(state api.historical_urn_state, max_results INTEGER DEFAULT NULL,
+                                               result_offset INTEGER DEFAULT 0)
+    RETURNS SETOF api.frob_event AS
+$$
+SELECT *
+FROM api.urn_frobs(state.ilk_identifier, state.urn_identifier)
+WHERE block_height <= state.block_height
+LIMIT historical_urn_state_frobs.max_results
+OFFSET
+historical_urn_state_frobs.result_offset
+$$
+    LANGUAGE sql
+    STABLE;
+
+
+CREATE FUNCTION api.historical_urn_state_bites(state api.historical_urn_state, max_results INTEGER DEFAULT NULL,
+                                               result_offset INTEGER DEFAULT 0)
+    RETURNS SETOF api.bite_event AS
+$$
+SELECT *
+FROM api.urn_bites(state.ilk_identifier, state.urn_identifier)
+WHERE block_height <= state.block_height
+LIMIT historical_urn_state_bites.max_results
+OFFSET
+historical_urn_state_bites.result_offset
+$$
+    LANGUAGE sql
+    STABLE;
+
+-- +goose Down
+-- SQL in this section is executed when the migration is rolled back.
+DROP FUNCTION api.historical_urn_state_bites(api.historical_urn_state, INTEGER, INTEGER);
+DROP FUNCTION api.historical_urn_state_frobs(api.historical_urn_state, INTEGER, INTEGER);
+DROP FUNCTION api.historical_urn_state_ilk(api.historical_urn_state);

--- a/transformers/component_tests/queries/all_urn_states_query_test.go
+++ b/transformers/component_tests/queries/all_urn_states_query_test.go
@@ -46,12 +46,12 @@ var _ = Describe("Urn history query", func() {
 	})
 
 	It("returns a reverse chronological history for the given ilk and urn", func() {
-		urnSetupData := helper.GetUrnSetupData(headerOne)
+		urnSetupData := helper.GetUrnSetupData()
 		urnMetadata := helper.GetUrnMetadata(helper.FakeIlk.Hex, fakeUrn)
-		helper.CreateUrn(urnSetupData, urnMetadata, vatRepo)
+		helper.CreateUrn(urnSetupData, headerOne.Id, urnMetadata, vatRepo)
 
-		inkBlockOne := urnSetupData.Ink
-		artBlockOne := urnSetupData.Art
+		inkBlockOne := urnSetupData[vat.UrnInk]
+		artBlockOne := urnSetupData[vat.UrnArt]
 
 		expectedTimestampOne := helper.GetExpectedTimestamp(timestampOne)
 		expectedUrnBlockOne := helper.UrnState{
@@ -129,13 +129,13 @@ var _ = Describe("Urn history query", func() {
 	Describe("result pagination", func() {
 		var (
 			blockTwo, timestampTwo int
-			urnSetupData           helper.UrnSetupData
+			urnSetupData           map[string]int
 		)
 
 		BeforeEach(func() {
-			urnSetupData = helper.GetUrnSetupData(headerOne)
+			urnSetupData = helper.GetUrnSetupData()
 			urnMetadata := helper.GetUrnMetadata(helper.FakeIlk.Hex, fakeUrn)
-			helper.CreateUrn(urnSetupData, urnMetadata, vatRepo)
+			helper.CreateUrn(urnSetupData, headerOne.Id, urnMetadata, vatRepo)
 
 			// New block
 			blockTwo = blockOne + 1
@@ -143,7 +143,7 @@ var _ = Describe("Urn history query", func() {
 			headerTwo := createHeader(blockTwo, timestampTwo, headerRepo)
 
 			// diff in new block
-			err := vatRepo.Create(headerTwo.Id, urnMetadata.UrnInk, strconv.Itoa(urnSetupData.Ink))
+			err := vatRepo.Create(headerTwo.Id, urnMetadata.UrnInk, strconv.Itoa(urnSetupData[vat.UrnInk]))
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -154,8 +154,8 @@ var _ = Describe("Urn history query", func() {
 				UrnIdentifier: fakeUrn,
 				IlkIdentifier: helper.FakeIlk.Identifier,
 				BlockHeight:   blockTwo,
-				Ink:           strconv.Itoa(urnSetupData.Ink),
-				Art:           strconv.Itoa(urnSetupData.Art),
+				Ink:           strconv.Itoa(urnSetupData[vat.UrnInk]),
+				Art:           strconv.Itoa(urnSetupData[vat.UrnArt]),
 				Created:       helper.GetValidNullString(expectedTimeCreated),
 				Updated:       helper.GetValidNullString(expectedTimeUpdated),
 			}
@@ -177,8 +177,8 @@ var _ = Describe("Urn history query", func() {
 				UrnIdentifier: fakeUrn,
 				IlkIdentifier: helper.FakeIlk.Identifier,
 				BlockHeight:   blockOne,
-				Ink:           strconv.Itoa(urnSetupData.Ink),
-				Art:           strconv.Itoa(urnSetupData.Art),
+				Ink:           strconv.Itoa(urnSetupData[vat.UrnInk]),
+				Art:           strconv.Itoa(urnSetupData[vat.UrnArt]),
 				Created:       helper.GetValidNullString(expectedTimeCreated),
 				Updated:       helper.GetValidNullString(expectedTimeCreated),
 			}

--- a/transformers/component_tests/queries/all_urns_query_test.go
+++ b/transformers/component_tests/queries/all_urns_query_test.go
@@ -54,9 +54,9 @@ var _ = Describe("Urn view", func() {
 	})
 
 	It("gets an urn", func() {
-		setupData := helper.GetUrnSetupData(headerOne)
+		setupData := helper.GetUrnSetupData()
 		metadata := helper.GetUrnMetadata(helper.FakeIlk.Hex, urnOne)
-		helper.CreateUrn(setupData, metadata, vatRepo)
+		helper.CreateUrn(setupData, headerOne.Id, metadata, vatRepo)
 
 		var actualUrn helper.UrnState
 		err = db.Get(&actualUrn, allUrnsQuery, blockOne)
@@ -67,8 +67,8 @@ var _ = Describe("Urn view", func() {
 			UrnIdentifier: urnOne,
 			IlkIdentifier: helper.FakeIlk.Identifier,
 			BlockHeight:   blockOne,
-			Ink:           strconv.Itoa(setupData.Ink),
-			Art:           strconv.Itoa(setupData.Art),
+			Ink:           strconv.Itoa(setupData[vat.UrnInk]),
+			Art:           strconv.Itoa(setupData[vat.UrnArt]),
 			Created:       helper.GetValidNullString(expectedTimestamp),
 			Updated:       helper.GetValidNullString(expectedTimestamp),
 		}
@@ -78,8 +78,8 @@ var _ = Describe("Urn view", func() {
 
 	It("returns the correct data for multiple urns", func() {
 		urnOneMetadata := helper.GetUrnMetadata(helper.FakeIlk.Hex, urnOne)
-		urnOneSetupData := helper.GetUrnSetupData(headerOne)
-		helper.CreateUrn(urnOneSetupData, urnOneMetadata, vatRepo)
+		urnOneSetupData := helper.GetUrnSetupData()
+		helper.CreateUrn(urnOneSetupData, headerOne.Id, urnOneMetadata, vatRepo)
 
 		blockTwo := blockOne + 1
 		timestampTwo := timestampOne + 1
@@ -90,23 +90,23 @@ var _ = Describe("Urn view", func() {
 			UrnIdentifier: urnOne,
 			IlkIdentifier: helper.FakeIlk.Identifier,
 			BlockHeight:   blockTwo,
-			Ink:           strconv.Itoa(urnOneSetupData.Ink),
-			Art:           strconv.Itoa(urnOneSetupData.Art),
+			Ink:           strconv.Itoa(urnOneSetupData[vat.UrnInk]),
+			Art:           strconv.Itoa(urnOneSetupData[vat.UrnArt]),
 			Created:       helper.GetValidNullString(expectedTimestamp),
 			Updated:       helper.GetValidNullString(expectedTimestamp),
 		}
 
 		urnTwoMetadata := helper.GetUrnMetadata(helper.AnotherFakeIlk.Hex, urnTwo)
-		urnTwoSetupData := helper.GetUrnSetupData(headerTwo)
-		helper.CreateUrn(urnTwoSetupData, urnTwoMetadata, vatRepo)
+		urnTwoSetupData := helper.GetUrnSetupData()
+		helper.CreateUrn(urnTwoSetupData, headerTwo.Id, urnTwoMetadata, vatRepo)
 
 		expectedTimestampTwo := helper.GetExpectedTimestamp(timestampTwo)
 		expectedUrnTwo := helper.UrnState{
 			UrnIdentifier: urnTwo,
 			IlkIdentifier: helper.AnotherFakeIlk.Identifier,
 			BlockHeight:   blockTwo,
-			Ink:           strconv.Itoa(urnTwoSetupData.Ink),
-			Art:           strconv.Itoa(urnTwoSetupData.Art),
+			Ink:           strconv.Itoa(urnTwoSetupData[vat.UrnInk]),
+			Art:           strconv.Itoa(urnTwoSetupData[vat.UrnArt]),
 			Created:       helper.GetValidNullString(expectedTimestampTwo),
 			Updated:       helper.GetValidNullString(expectedTimestampTwo),
 		}
@@ -146,15 +146,15 @@ var _ = Describe("Urn view", func() {
 
 	Describe("result pagination", func() {
 		var (
-			urnOneSetupData, urnTwoSetupData helper.UrnSetupData
+			urnOneSetupData, urnTwoSetupData map[string]int
 			timestampTwo                     int
 			blockTwo                         int
 		)
 
 		BeforeEach(func() {
 			urnOneMetadata := helper.GetUrnMetadata(helper.FakeIlk.Hex, urnOne)
-			urnOneSetupData = helper.GetUrnSetupData(headerOne)
-			helper.CreateUrn(urnOneSetupData, urnOneMetadata, vatRepo)
+			urnOneSetupData = helper.GetUrnSetupData()
+			helper.CreateUrn(urnOneSetupData, headerOne.Id, urnOneMetadata, vatRepo)
 
 			// New block
 			blockTwo = blockOne + 1
@@ -162,8 +162,8 @@ var _ = Describe("Urn view", func() {
 			headerTwo := createHeader(blockTwo, timestampTwo, headerRepo)
 
 			urnTwoMetadata := helper.GetUrnMetadata(helper.AnotherFakeIlk.Hex, urnTwo)
-			urnTwoSetupData = helper.GetUrnSetupData(headerTwo)
-			helper.CreateUrn(urnTwoSetupData, urnTwoMetadata, vatRepo)
+			urnTwoSetupData = helper.GetUrnSetupData()
+			helper.CreateUrn(urnTwoSetupData, headerTwo.Id, urnTwoMetadata, vatRepo)
 		})
 
 		It("limits results if max_results argument is provided", func() {
@@ -171,8 +171,8 @@ var _ = Describe("Urn view", func() {
 			expectedUrn := helper.UrnState{
 				UrnIdentifier: urnTwo,
 				IlkIdentifier: helper.AnotherFakeIlk.Identifier,
-				Ink:           strconv.Itoa(urnTwoSetupData.Ink),
-				Art:           strconv.Itoa(urnTwoSetupData.Art),
+				Ink:           strconv.Itoa(urnTwoSetupData[vat.UrnInk]),
+				Art:           strconv.Itoa(urnTwoSetupData[vat.UrnArt]),
 				Created:       helper.GetValidNullString(expectedTimestamp),
 				Updated:       helper.GetValidNullString(expectedTimestamp),
 			}
@@ -192,8 +192,8 @@ var _ = Describe("Urn view", func() {
 			expectedUrn := helper.UrnState{
 				UrnIdentifier: urnOne,
 				IlkIdentifier: helper.FakeIlk.Identifier,
-				Ink:           strconv.Itoa(urnOneSetupData.Ink),
-				Art:           strconv.Itoa(urnOneSetupData.Art),
+				Ink:           strconv.Itoa(urnOneSetupData[vat.UrnInk]),
+				Art:           strconv.Itoa(urnOneSetupData[vat.UrnArt]),
 				Created:       helper.GetValidNullString(expectedTimestamp),
 				Updated:       helper.GetValidNullString(expectedTimestamp),
 			}
@@ -218,14 +218,14 @@ var _ = Describe("Urn view", func() {
 	Describe("it includes diffs only up to given block height", func() {
 		var (
 			actualUrn    helper.UrnState
-			setupDataOne helper.UrnSetupData
+			setupDataOne map[string]int
 			metadata     helper.UrnMetadata
 		)
 
 		BeforeEach(func() {
-			setupDataOne = helper.GetUrnSetupData(headerOne)
+			setupDataOne = helper.GetUrnSetupData()
 			metadata = helper.GetUrnMetadata(helper.FakeIlk.Hex, urnOne)
-			helper.CreateUrn(setupDataOne, metadata, vatRepo)
+			helper.CreateUrn(setupDataOne, headerOne.Id, metadata, vatRepo)
 		})
 
 		It("gets urn state as of block one", func() {
@@ -237,8 +237,8 @@ var _ = Describe("Urn view", func() {
 				UrnIdentifier: urnOne,
 				IlkIdentifier: helper.FakeIlk.Identifier,
 				BlockHeight:   blockOne,
-				Ink:           strconv.Itoa(setupDataOne.Ink),
-				Art:           strconv.Itoa(setupDataOne.Art),
+				Ink:           strconv.Itoa(setupDataOne[vat.UrnInk]),
+				Art:           strconv.Itoa(setupDataOne[vat.UrnArt]),
 				Created:       helper.GetValidNullString(expectedTimestamp),
 				Updated:       helper.GetValidNullString(expectedTimestamp),
 			}
@@ -268,7 +268,7 @@ var _ = Describe("Urn view", func() {
 				IlkIdentifier: helper.FakeIlk.Identifier,
 				BlockHeight:   blockTwo,
 				Ink:           strconv.Itoa(updatedInk),
-				Art:           strconv.Itoa(setupDataOne.Art), // Not changed
+				Art:           strconv.Itoa(setupDataOne[vat.UrnArt]), // Not changed
 				Created:       helper.GetValidNullString(expectedTimestampOne),
 				Updated:       helper.GetValidNullString(expectedTimestampTwo),
 			}

--- a/transformers/component_tests/queries/bite_event_computed_columns_test.go
+++ b/transformers/component_tests/queries/bite_event_computed_columns_test.go
@@ -78,9 +78,9 @@ var _ = Describe("Bite event computed columns", func() {
 	Describe("bite_event_urn", func() {
 		It("returns urn_state for a bite_event", func() {
 			vatRepository.SetDB(db)
-			urnSetupData := test_helpers.GetUrnSetupData(headerOne)
+			urnSetupData := test_helpers.GetUrnSetupData()
 			urnMetadata := test_helpers.GetUrnMetadata(test_helpers.FakeIlk.Hex, fakeGuy)
-			test_helpers.CreateUrn(urnSetupData, urnMetadata, vatRepository)
+			test_helpers.CreateUrn(urnSetupData, headerOne.Id, urnMetadata, vatRepository)
 
 			var actualUrn test_helpers.UrnState
 			err := db.Get(&actualUrn, `

--- a/transformers/component_tests/queries/flip_state_computed_columns_test.go
+++ b/transformers/component_tests/queries/flip_state_computed_columns_test.go
@@ -108,11 +108,11 @@ var _ = Describe("Flip state computed columns", func() {
 
 	Describe("flip_state_urn", func() {
 		It("returns urn_state for a flip_state", func() {
-			urnSetupData := test_helpers.GetUrnSetupData(headerOne)
+			urnSetupData := test_helpers.GetUrnSetupData()
 			urnMetadata := test_helpers.GetUrnMetadata(test_helpers.FakeIlk.Hex, test_data.FlipKickModel().ForeignKeyValues[constants.UrnFK])
 			vatRepository := vat.VatStorageRepository{}
 			vatRepository.SetDB(db)
-			test_helpers.CreateUrn(urnSetupData, urnMetadata, vatRepository)
+			test_helpers.CreateUrn(urnSetupData, headerOne.Id, urnMetadata, vatRepository)
 
 			var actualUrn test_helpers.UrnState
 			getUrnErr := db.Get(&actualUrn, `

--- a/transformers/component_tests/queries/frob_event_computed_columns_test.go
+++ b/transformers/component_tests/queries/frob_event_computed_columns_test.go
@@ -99,10 +99,10 @@ var _ = Describe("Frob event computed columns", func() {
 
 	Describe("frob_event_urn", func() {
 		It("returns urn_state for a frob_event", func() {
-			urnSetupData := test_helpers.GetUrnSetupData(headerOne)
+			urnSetupData := test_helpers.GetUrnSetupData()
 			urnMetadata := test_helpers.GetUrnMetadata(test_helpers.FakeIlk.Hex, fakeGuy)
 			vatRepository.SetDB(db)
-			test_helpers.CreateUrn(urnSetupData, urnMetadata, vatRepository)
+			test_helpers.CreateUrn(urnSetupData, headerOne.Id, urnMetadata, vatRepository)
 
 			var actualUrn test_helpers.UrnState
 			getUrnErr := db.Get(&actualUrn,

--- a/transformers/component_tests/queries/get_urn_query_test.go
+++ b/transformers/component_tests/queries/get_urn_query_test.go
@@ -52,22 +52,22 @@ var _ = Describe("Single urn view", func() {
 		headerTwo := createHeader(blockTwo, timestampOne+1, headerRepo)
 
 		urnOneMetadata := test_helpers.GetUrnMetadata(test_helpers.FakeIlk.Hex, urnOne)
-		urnOneSetupData := test_helpers.GetUrnSetupData(headerOne)
-		test_helpers.CreateUrn(urnOneSetupData, urnOneMetadata, vatRepo)
+		urnOneSetupData := test_helpers.GetUrnSetupData()
+		test_helpers.CreateUrn(urnOneSetupData, headerOne.Id, urnOneMetadata, vatRepo)
 
 		expectedTimestampOne := test_helpers.GetExpectedTimestamp(timestampOne)
 		expectedUrn := test_helpers.UrnState{
 			UrnIdentifier: urnOne,
 			IlkIdentifier: test_helpers.FakeIlk.Identifier,
-			Ink:           strconv.Itoa(urnOneSetupData.Ink),
-			Art:           strconv.Itoa(urnOneSetupData.Art),
+			Ink:           strconv.Itoa(urnOneSetupData[vat.UrnInk]),
+			Art:           strconv.Itoa(urnOneSetupData[vat.UrnArt]),
 			Created:       test_helpers.GetValidNullString(expectedTimestampOne),
 			Updated:       test_helpers.GetValidNullString(expectedTimestampOne),
 		}
 
 		urnTwoMetadata := test_helpers.GetUrnMetadata(test_helpers.AnotherFakeIlk.Hex, urnTwo)
-		urnTwoSetupData := test_helpers.GetUrnSetupData(headerTwo)
-		test_helpers.CreateUrn(urnTwoSetupData, urnTwoMetadata, vatRepo)
+		urnTwoSetupData := test_helpers.GetUrnSetupData()
+		test_helpers.CreateUrn(urnTwoSetupData, headerTwo.Id, urnTwoMetadata, vatRepo)
 
 		var actualUrn test_helpers.UrnState
 		getErr := db.Get(&actualUrn, getUrnQuery, test_helpers.FakeIlk.Identifier, urnOne, blockTwo)
@@ -96,16 +96,16 @@ var _ = Describe("Single urn view", func() {
 	Describe("it includes diffs only up to given block height", func() {
 		var (
 			actualUrn              test_helpers.UrnState
-			setupDataOne           test_helpers.UrnSetupData
+			setupDataOne           map[string]int
 			metadata               test_helpers.UrnMetadata
 			blockTwo, timestampTwo int
 			headerTwo              core.Header
 		)
 
 		BeforeEach(func() {
-			setupDataOne = test_helpers.GetUrnSetupData(headerOne)
+			setupDataOne = test_helpers.GetUrnSetupData()
 			metadata = test_helpers.GetUrnMetadata(test_helpers.FakeIlk.Hex, urnOne)
-			test_helpers.CreateUrn(setupDataOne, metadata, vatRepo)
+			test_helpers.CreateUrn(setupDataOne, headerOne.Id, metadata, vatRepo)
 
 			blockTwo = blockOne + 1
 			timestampTwo = timestampOne + 1
@@ -122,8 +122,8 @@ var _ = Describe("Single urn view", func() {
 			expectedUrn := test_helpers.UrnState{
 				UrnIdentifier: urnOne,
 				IlkIdentifier: test_helpers.FakeIlk.Identifier,
-				Ink:           strconv.Itoa(setupDataOne.Ink),
-				Art:           strconv.Itoa(setupDataOne.Art),
+				Ink:           strconv.Itoa(setupDataOne[vat.UrnInk]),
+				Art:           strconv.Itoa(setupDataOne[vat.UrnArt]),
 				Created:       test_helpers.GetValidNullString(expectedTimestampOne),
 				Updated:       test_helpers.GetValidNullString(expectedTimestampOne),
 			}
@@ -146,7 +146,7 @@ var _ = Describe("Single urn view", func() {
 				UrnIdentifier: urnOne,
 				IlkIdentifier: test_helpers.FakeIlk.Identifier,
 				Ink:           strconv.Itoa(updatedInk),
-				Art:           strconv.Itoa(setupDataOne.Art), // Not changed
+				Art:           strconv.Itoa(setupDataOne[vat.UrnArt]), // Not changed
 				Created:       test_helpers.GetValidNullString(expectedTimestampOne),
 				Updated:       test_helpers.GetValidNullString(expectedTimestampTwo),
 			}

--- a/transformers/component_tests/queries/managed_cdp_computed_columns_test.go
+++ b/transformers/component_tests/queries/managed_cdp_computed_columns_test.go
@@ -86,11 +86,11 @@ var _ = Describe("Managed CDP computed columns", func() {
 
 	Describe("managed_cdp_urn", func() {
 		It("returns urn_state for a managed_cdp", func() {
-			urnSetupData := test_helpers.GetUrnSetupData(headerOne)
+			urnSetupData := test_helpers.GetUrnSetupData()
 			urnMetadata := test_helpers.GetUrnMetadata(test_helpers.FakeIlk.Hex, test_data.FakeUrn)
 			vatRepository := vat.VatStorageRepository{}
 			vatRepository.SetDB(db)
-			test_helpers.CreateUrn(urnSetupData, urnMetadata, vatRepository)
+			test_helpers.CreateUrn(urnSetupData, headerOne.Id, urnMetadata, vatRepository)
 			expectedUrn := test_helpers.UrnState{
 				UrnIdentifier: test_data.FakeUrn,
 				IlkIdentifier: test_helpers.FakeIlk.Identifier,

--- a/transformers/component_tests/queries/total_ink_query_test.go
+++ b/transformers/component_tests/queries/total_ink_query_test.go
@@ -50,81 +50,81 @@ var _ = Describe("total ink query", func() {
 	It("gets the latest ink of a single urn", func() {
 		urnMetadata := test_helpers.GetUrnMetadata(test_helpers.FakeIlk.Hex, urnOne)
 
-		urnSetupDataOne := test_helpers.GetUrnSetupData(headerOne)
-		urnSetupDataOne.Ink = rand.Intn(1000000)
-		test_helpers.CreateUrn(urnSetupDataOne, urnMetadata, vatRepo)
+		urnSetupDataOne := test_helpers.GetUrnSetupData()
+		urnSetupDataOne[vat.UrnInk] = rand.Intn(1000000)
+		test_helpers.CreateUrn(urnSetupDataOne, headerOne.Id, urnMetadata, vatRepo)
 
 		headerTwo := createHeader(blockOne+1, timestampOne+1, headerRepo)
-		urnSetupDataTwo := test_helpers.GetUrnSetupData(headerTwo)
-		urnSetupDataTwo.Ink = rand.Intn(1000000)
-		test_helpers.CreateUrn(urnSetupDataTwo, urnMetadata, vatRepo)
+		urnSetupDataTwo := test_helpers.GetUrnSetupData()
+		urnSetupDataTwo[vat.UrnInk] = rand.Intn(1000000)
+		test_helpers.CreateUrn(urnSetupDataTwo, headerTwo.Id, urnMetadata, vatRepo)
 
 		var totalInk int
 		err := db.Get(&totalInk, `SELECT * FROM api.total_ink($1)`, test_helpers.FakeIlk.Identifier)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(totalInk).To(Equal(urnSetupDataTwo.Ink))
+		Expect(totalInk).To(Equal(urnSetupDataTwo[vat.UrnInk]))
 	})
 
 	It("sums up the latest ink of multiple urns for a given ilk", func() {
 		urnOneMetadata := test_helpers.GetUrnMetadata(test_helpers.FakeIlk.Hex, urnOne)
 
-		urnOneSetupData := test_helpers.GetUrnSetupData(headerOne)
-		urnOneSetupData.Ink = rand.Intn(1000)
-		test_helpers.CreateUrn(urnOneSetupData, urnOneMetadata, vatRepo)
+		urnOneSetupData := test_helpers.GetUrnSetupData()
+		urnOneSetupData[vat.UrnInk] = rand.Intn(1000)
+		test_helpers.CreateUrn(urnOneSetupData, headerOne.Id, urnOneMetadata, vatRepo)
 
 		urnTwoMetadata := test_helpers.GetUrnMetadata(test_helpers.FakeIlk.Hex, urnTwo)
-		urnTwoOldSetupData := test_helpers.GetUrnSetupData(headerOne)
-		urnTwoOldSetupData.Ink = rand.Intn(1000)
-		test_helpers.CreateUrn(urnTwoOldSetupData, urnTwoMetadata, vatRepo)
+		urnTwoOldSetupData := test_helpers.GetUrnSetupData()
+		urnTwoOldSetupData[vat.UrnInk] = rand.Intn(1000)
+		test_helpers.CreateUrn(urnTwoOldSetupData, headerOne.Id, urnTwoMetadata, vatRepo)
 
 		headerTwo := createHeader(blockOne+1, timestampOne+1, headerRepo)
-		urnTwoNewSetupData := test_helpers.GetUrnSetupData(headerTwo)
-		urnTwoNewSetupData.Ink = rand.Intn(1000)
-		test_helpers.CreateUrn(urnTwoNewSetupData, urnTwoMetadata, vatRepo)
+		urnTwoNewSetupData := test_helpers.GetUrnSetupData()
+		urnTwoNewSetupData[vat.UrnInk] = rand.Intn(1000)
+		test_helpers.CreateUrn(urnTwoNewSetupData, headerTwo.Id, urnTwoMetadata, vatRepo)
 
 		var totalInk int
 		err := db.Get(&totalInk, `SELECT * FROM api.total_ink($1)`, test_helpers.FakeIlk.Identifier)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(totalInk).To(Equal(urnOneSetupData.Ink + urnTwoNewSetupData.Ink))
+		Expect(totalInk).To(Equal(urnOneSetupData[vat.UrnInk] + urnTwoNewSetupData[vat.UrnInk]))
 	})
 
 	It("ignores ink after block number if block number is provided", func() {
 		urnOneMetadata := test_helpers.GetUrnMetadata(test_helpers.FakeIlk.Hex, urnOne)
-		urnOneSetupData := test_helpers.GetUrnSetupData(headerOne)
-		urnOneSetupData.Ink = rand.Intn(1000)
-		test_helpers.CreateUrn(urnOneSetupData, urnOneMetadata, vatRepo)
+		urnOneSetupData := test_helpers.GetUrnSetupData()
+		urnOneSetupData[vat.UrnInk] = rand.Intn(1000)
+		test_helpers.CreateUrn(urnOneSetupData, headerOne.Id, urnOneMetadata, vatRepo)
 
 		urnTwoMetadata := test_helpers.GetUrnMetadata(test_helpers.FakeIlk.Hex, urnTwo)
-		urnTwoOldSetupData := test_helpers.GetUrnSetupData(headerOne)
-		urnTwoOldSetupData.Ink = rand.Intn(1000)
-		test_helpers.CreateUrn(urnTwoOldSetupData, urnTwoMetadata, vatRepo)
+		urnTwoOldSetupData := test_helpers.GetUrnSetupData()
+		urnTwoOldSetupData[vat.UrnInk] = rand.Intn(1000)
+		test_helpers.CreateUrn(urnTwoOldSetupData, headerOne.Id, urnTwoMetadata, vatRepo)
 
 		headerTwo := createHeader(blockOne+1, timestampOne+1, headerRepo)
-		urnTwoNewSetupData := test_helpers.GetUrnSetupData(headerTwo)
-		urnTwoNewSetupData.Ink = rand.Intn(1000)
-		test_helpers.CreateUrn(urnTwoNewSetupData, urnTwoMetadata, vatRepo)
+		urnTwoNewSetupData := test_helpers.GetUrnSetupData()
+		urnTwoNewSetupData[vat.UrnInk] = rand.Intn(1000)
+		test_helpers.CreateUrn(urnTwoNewSetupData, headerTwo.Id, urnTwoMetadata, vatRepo)
 
 		var totalInk int
 		err := db.Get(&totalInk, `SELECT * FROM api.total_ink($1, $2)`,
 			test_helpers.FakeIlk.Identifier, blockOne)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(totalInk).To(Equal(urnOneSetupData.Ink + urnTwoOldSetupData.Ink))
+		Expect(totalInk).To(Equal(urnOneSetupData[vat.UrnInk] + urnTwoOldSetupData[vat.UrnInk]))
 	})
 
 	It("ignores ink from urns of different ilks", func() {
 		urnMetadata := test_helpers.GetUrnMetadata(test_helpers.FakeIlk.Hex, urnOne)
-		urnSetupData := test_helpers.GetUrnSetupData(headerOne)
-		urnSetupData.Ink = rand.Intn(1000)
-		test_helpers.CreateUrn(urnSetupData, urnMetadata, vatRepo)
+		urnSetupData := test_helpers.GetUrnSetupData()
+		urnSetupData[vat.UrnInk] = rand.Intn(1000)
+		test_helpers.CreateUrn(urnSetupData, headerOne.Id, urnMetadata, vatRepo)
 
 		irrelevantUrnMetadata := test_helpers.GetUrnMetadata(test_helpers.AnotherFakeIlk.Hex, urnTwo)
-		irrelevantUrnSetupData := test_helpers.GetUrnSetupData(headerOne)
-		test_helpers.CreateUrn(irrelevantUrnSetupData, irrelevantUrnMetadata, vatRepo)
+		irrelevantUrnSetupData := test_helpers.GetUrnSetupData()
+		test_helpers.CreateUrn(irrelevantUrnSetupData, headerOne.Id, irrelevantUrnMetadata, vatRepo)
 
 		var totalInk int
 		err := db.Get(&totalInk, `SELECT * FROM api.total_ink($1)`, test_helpers.FakeIlk.Identifier)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(totalInk).To(Equal(urnSetupData.Ink))
+		Expect(totalInk).To(Equal(urnSetupData[vat.UrnInk]))
 	})
 })
 

--- a/transformers/storage/vat/repository_test.go
+++ b/transformers/storage/vat/repository_test.go
@@ -17,9 +17,11 @@
 package vat_test
 
 import (
+	"database/sql"
 	"math/rand"
 	"strconv"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/component_tests/queries/test_helpers"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
@@ -28,7 +30,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/storage/vat"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data/shared_behaviors"
 	"github.com/makerdao/vulcanizedb/libraries/shared/storage/utils"
-	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
+	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
 	"github.com/makerdao/vulcanizedb/pkg/fakes"
 	. "github.com/onsi/ginkgo"
@@ -37,7 +39,7 @@ import (
 
 var _ = Describe("Vat storage repository", func() {
 	var (
-		db           *postgres.DB
+		db           = test_config.NewTestDB(test_config.NewTestNode())
 		repo         vat.VatStorageRepository
 		fakeGuy      = "fake_urn"
 		fakeUint256  = "12345"
@@ -45,7 +47,6 @@ var _ = Describe("Vat storage repository", func() {
 	)
 
 	BeforeEach(func() {
-		db = test_config.NewTestDB(test_config.NewTestNode())
 		test_config.CleanTestDB(db)
 		repo = vat.VatStorageRepository{}
 		repo.SetDB(db)
@@ -472,6 +473,231 @@ var _ = Describe("Vat storage repository", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError(utils.ErrMetadataMalformed{MissingData: constants.Guy}))
 		})
+
+		Describe("updating historical_ilk_state trigger table", func() {
+			var (
+				blockOne,
+				blockTwo,
+				blockThree int
+				rawTimestampOne, rawTimestampTwo, rawTimestampThree int64
+				headerOne,
+				headerTwo core.Header
+				hashOne        = common.BytesToHash([]byte{1, 2, 3, 4, 5})
+				hashTwo        = common.BytesToHash([]byte{5, 4, 3, 2, 1})
+				hashThree      = common.BytesToHash([]byte{9, 8, 7, 6, 5})
+				getStateQuery  = `SELECT urn_identifier, ilk_identifier, block_height, ink, art, created, updated FROM api.historical_urn_state ORDER BY block_height`
+				getArtQuery    = `SELECT art FROM api.historical_urn_state ORDER BY block_height`
+				insertArtQuery = `INSERT INTO api.historical_urn_state (urn_identifier, ilk_identifier, block_height, art, updated) VALUES ($1, $2, $3, $4, NOW())`
+				deleteRowQuery = `DELETE FROM maker.vat_urn_art WHERE header_id = $1`
+				urnArtMetadata = utils.GetStorageValueMetadata(vat.UrnArt, map[utils.Key]string{constants.Ilk: test_helpers.FakeIlk.Hex, constants.Guy: fakeGuy}, utils.Uint256)
+			)
+
+			BeforeEach(func() {
+				blockOne = rand.Int()
+				blockTwo = blockOne + 1
+				blockThree = blockTwo + 1
+				rawTimestampOne = int64(rand.Int31())
+				rawTimestampTwo = rawTimestampOne + 1
+				rawTimestampThree = rawTimestampTwo + 1
+				headerOne = CreateHeaderWithHash(hashOne.String(), rawTimestampOne, blockOne, db)
+				headerTwo = CreateHeaderWithHash(hashTwo.String(), rawTimestampTwo, blockTwo, db)
+				CreateHeaderWithHash(hashThree.String(), rawTimestampThree, blockThree, db)
+			})
+
+			It("inserts time of first ink diff into created", func() {
+				urnInkMetadata := utils.GetStorageValueMetadata(vat.UrnInk, map[utils.Key]string{constants.Ilk: test_helpers.FakeIlk.Hex, constants.Guy: fakeGuy}, utils.Uint256)
+				setupErrOne := repo.Create(headerOne.Id, urnInkMetadata, strconv.Itoa(rand.Int()))
+				Expect(setupErrOne).NotTo(HaveOccurred())
+				expectedTimeCreated := test_helpers.GetValidNullString(FormatTimestamp(rawTimestampOne))
+
+				err := repo.Create(headerTwo.Id, urnArtMetadata, strconv.Itoa(rand.Int()))
+				Expect(err).NotTo(HaveOccurred())
+
+				var timeCreated sql.NullString
+				queryErr := db.Get(&timeCreated,
+					`SELECT created FROM api.historical_urn_state WHERE block_height = $1`, headerTwo.BlockNumber)
+				Expect(queryErr).NotTo(HaveOccurred())
+				Expect(timeCreated).To(Equal(expectedTimeCreated))
+			})
+
+			It("inserts a row for new urn-block", func() {
+				initialUrnValues := test_helpers.GetUrnSetupData()
+				newArt := rand.Int()
+				test_helpers.CreateUrn(initialUrnValues, headerOne.Id, test_helpers.GetUrnMetadata(test_helpers.FakeIlk.Hex, fakeGuy), repo)
+
+				err := repo.Create(headerTwo.Id, urnArtMetadata, strconv.Itoa(newArt))
+				Expect(err).NotTo(HaveOccurred())
+
+				var urnStates []test_helpers.UrnState
+				queryErr := db.Select(&urnStates, getStateQuery)
+				Expect(queryErr).NotTo(HaveOccurred())
+				Expect(len(urnStates)).To(Equal(2))
+				Expect(urnStates[1].BlockHeight).To(Equal(int(headerTwo.BlockNumber)))
+				Expect(urnStates[1].Ink).To(Equal(strconv.Itoa(initialUrnValues[vat.UrnInk])))
+				Expect(urnStates[1].Art).To(Equal(strconv.Itoa(newArt)))
+				Expect(urnStates[1].Created).To(Equal(test_helpers.GetValidNullString(FormatTimestamp(rawTimestampOne))))
+				Expect(urnStates[1].Updated).To(Equal(test_helpers.GetValidNullString(FormatTimestamp(rawTimestampTwo))))
+			})
+
+			It("updates art if urn-block combination already exists in table", func() {
+				initialUrnValues := test_helpers.GetUrnSetupData()
+				newArt := rand.Int()
+				test_helpers.CreateUrn(initialUrnValues, headerOne.Id, test_helpers.GetUrnMetadata(test_helpers.FakeIlk.Hex, fakeGuy), repo)
+
+				err := repo.Create(headerOne.Id, urnArtMetadata, strconv.Itoa(newArt))
+				Expect(err).NotTo(HaveOccurred())
+
+				var urnStates []test_helpers.UrnState
+				queryErr := db.Select(&urnStates, getStateQuery)
+				Expect(queryErr).NotTo(HaveOccurred())
+				Expect(len(urnStates)).To(Equal(1))
+				Expect(urnStates[0].BlockHeight).To(Equal(int(headerOne.BlockNumber)))
+				Expect(urnStates[0].Ink).To(Equal(strconv.Itoa(initialUrnValues[vat.UrnInk])))
+				Expect(urnStates[0].Art).To(Equal(strconv.Itoa(newArt)))
+				Expect(urnStates[0].Created).To(Equal(test_helpers.GetValidNullString(FormatTimestamp(rawTimestampOne))))
+				Expect(urnStates[0].Updated).To(Equal(test_helpers.GetValidNullString(FormatTimestamp(rawTimestampOne))))
+			})
+
+			It("updates all consecutive arts if record is the latest art diff", func() {
+				initialArt := rand.Int()
+				newArt := initialArt + 1
+				_, setupErr := db.Exec(insertArtQuery,
+					fakeGuy, test_helpers.FakeIlk.Identifier, headerTwo.BlockNumber, initialArt)
+				Expect(setupErr).NotTo(HaveOccurred())
+
+				err := repo.Create(headerOne.Id, urnArtMetadata, strconv.Itoa(newArt))
+				Expect(err).NotTo(HaveOccurred())
+
+				var urnStates []test_helpers.UrnState
+				queryErr := db.Select(&urnStates, getArtQuery)
+				Expect(queryErr).NotTo(HaveOccurred())
+				Expect(len(urnStates)).To(Equal(2))
+				Expect(urnStates[1].Art).To(Equal(strconv.Itoa(newArt)))
+			})
+
+			It("ignores rows from blocks after the next art diff", func() {
+				initialArt := strconv.Itoa(rand.Int())
+				setupErr := repo.Create(headerTwo.Id, urnArtMetadata, initialArt)
+				Expect(setupErr).NotTo(HaveOccurred())
+
+				err := repo.Create(headerOne.Id, urnArtMetadata, strconv.Itoa(rand.Int()))
+				Expect(err).NotTo(HaveOccurred())
+
+				var urnStates []test_helpers.UrnState
+				queryErr := db.Select(&urnStates, getArtQuery)
+				Expect(queryErr).NotTo(HaveOccurred())
+				Expect(len(urnStates)).To(Equal(2))
+				Expect(urnStates[1].Art).To(Equal(initialArt))
+			})
+
+			It("ignores rows from different urn", func() {
+				initialArt := rand.Int()
+				_, setupErr := db.Exec(insertArtQuery,
+					fakeGuy, test_helpers.AnotherFakeIlk.Identifier, headerTwo.BlockNumber, initialArt)
+				Expect(setupErr).NotTo(HaveOccurred())
+
+				err := repo.Create(headerOne.Id, urnArtMetadata, strconv.Itoa(rand.Int()))
+				Expect(err).NotTo(HaveOccurred())
+
+				var urnStates []test_helpers.UrnState
+				queryErr := db.Select(&urnStates, getArtQuery)
+				Expect(queryErr).NotTo(HaveOccurred())
+				Expect(len(urnStates)).To(Equal(2))
+				Expect(urnStates[1].Art).To(Equal(strconv.Itoa(initialArt)))
+			})
+
+			It("ignores rows from earlier blocks", func() {
+				initialArt := rand.Int()
+				_, setupErr := db.Exec(insertArtQuery,
+					fakeGuy, test_helpers.FakeIlk.Identifier, headerOne.BlockNumber, initialArt)
+				Expect(setupErr).NotTo(HaveOccurred())
+
+				err := repo.Create(headerTwo.Id, urnArtMetadata, strconv.Itoa(rand.Int()))
+				Expect(err).NotTo(HaveOccurred())
+
+				var urnStates []test_helpers.UrnState
+				queryErr := db.Select(&urnStates, getArtQuery)
+				Expect(queryErr).NotTo(HaveOccurred())
+				Expect(len(urnStates)).To(Equal(2))
+				Expect(urnStates[0].Art).To(Equal(strconv.Itoa(initialArt)))
+			})
+
+			Describe("when diff is deleted", func() {
+				It("updates art to previous value until block number of next diff", func() {
+					initialArt := rand.Int()
+					setupErrOne := repo.Create(headerOne.Id, urnArtMetadata, strconv.Itoa(initialArt))
+					Expect(setupErrOne).NotTo(HaveOccurred())
+
+					subsequentArt := initialArt + 1
+					setupErrTwo := repo.Create(headerTwo.Id, urnArtMetadata, strconv.Itoa(subsequentArt))
+					Expect(setupErrTwo).NotTo(HaveOccurred())
+					_, setupErrThree := db.Exec(insertArtQuery,
+						fakeGuy, test_helpers.FakeIlk.Identifier, blockThree, subsequentArt)
+					Expect(setupErrThree).NotTo(HaveOccurred())
+
+					_, deleteErr := db.Exec(deleteRowQuery, headerTwo.Id)
+					Expect(deleteErr).NotTo(HaveOccurred())
+
+					var urnStates []test_helpers.UrnState
+					queryErr := db.Select(&urnStates, getArtQuery)
+					Expect(queryErr).NotTo(HaveOccurred())
+					Expect(urnStates[1].Art).To(Equal(strconv.Itoa(initialArt)))
+				})
+
+				It("sets field in subsequent rows to null if no previous diff exists", func() {
+					initialArt := strconv.Itoa(rand.Int())
+					setupErrOne := repo.Create(headerOne.Id, urnArtMetadata, initialArt)
+					Expect(setupErrOne).NotTo(HaveOccurred())
+					_, setupErrTwo := db.Exec(insertArtQuery,
+						fakeGuy, test_helpers.FakeIlk.Identifier, blockTwo, initialArt)
+					Expect(setupErrTwo).NotTo(HaveOccurred())
+
+					_, deleteErr := db.Exec(deleteRowQuery, headerOne.Id)
+					Expect(deleteErr).NotTo(HaveOccurred())
+
+					var actualArts []sql.NullString
+					queryErr := db.Select(&actualArts, getArtQuery)
+					Expect(queryErr).NotTo(HaveOccurred())
+					Expect(len(actualArts)).To(Equal(1))
+					Expect(actualArts[0].Valid).To(BeFalse())
+				})
+
+				It("deletes ilk state associated with diff if identical to previous state", func() {
+					initialArt := rand.Int()
+					setupErrOne := repo.Create(headerOne.Id, urnArtMetadata, strconv.Itoa(initialArt))
+					Expect(setupErrOne).NotTo(HaveOccurred())
+
+					subsequentArt := initialArt + 1
+					setupErrTwo := repo.Create(headerTwo.Id, urnArtMetadata, strconv.Itoa(subsequentArt))
+					Expect(setupErrTwo).NotTo(HaveOccurred())
+					_, setupErrThree := db.Exec(insertArtQuery,
+						fakeGuy, test_helpers.FakeIlk.Identifier, blockThree, subsequentArt)
+					Expect(setupErrThree).NotTo(HaveOccurred())
+
+					_, deleteErr := db.Exec(deleteRowQuery, headerTwo.Id)
+					Expect(deleteErr).NotTo(HaveOccurred())
+
+					var urnStates []test_helpers.UrnState
+					queryErr := db.Select(&urnStates, getArtQuery)
+					Expect(queryErr).NotTo(HaveOccurred())
+					Expect(len(urnStates)).To(Equal(2))
+				})
+
+				It("deletes ilk state associated with diff if it's the earliest state in the table", func() {
+					initialArt := rand.Int()
+					setupErrOne := repo.Create(headerOne.Id, urnArtMetadata, strconv.Itoa(initialArt))
+					Expect(setupErrOne).NotTo(HaveOccurred())
+
+					_, deleteErr := db.Exec(deleteRowQuery, headerOne.Id)
+					Expect(deleteErr).NotTo(HaveOccurred())
+
+					var urnStates []test_helpers.UrnState
+					queryErr := db.Select(&urnStates, getArtQuery)
+					Expect(queryErr).NotTo(HaveOccurred())
+					Expect(len(urnStates)).To(Equal(0))
+				})
+			})
+		})
 	})
 
 	Describe("urn ink", func() {
@@ -525,6 +751,271 @@ var _ = Describe("Vat storage repository", func() {
 
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError(utils.ErrMetadataMalformed{MissingData: constants.Guy}))
+		})
+
+		Describe("updating historical_ilk_state trigger table", func() {
+			var (
+				blockOne,
+				blockTwo,
+				blockThree int
+				rawTimestampOne, rawTimestampTwo, rawTimestampThree int64
+				headerOne,
+				headerTwo core.Header
+				hashOne        = common.BytesToHash([]byte{1, 2, 3, 4, 5})
+				hashTwo        = common.BytesToHash([]byte{5, 4, 3, 2, 1})
+				hashThree      = common.BytesToHash([]byte{9, 8, 7, 6, 5})
+				getStateQuery  = `SELECT urn_identifier, ilk_identifier, block_height, ink, art, created, updated FROM api.historical_urn_state ORDER BY block_height`
+				getInkQuery    = `SELECT ink FROM api.historical_urn_state ORDER BY block_height`
+				insertInkQuery = `INSERT INTO api.historical_urn_state (urn_identifier, ilk_identifier, block_height, ink, updated) VALUES ($1, $2, $3, $4, NOW())`
+				deleteRowQuery = `DELETE FROM maker.vat_urn_ink WHERE header_id = $1`
+				urnInkMetadata = utils.GetStorageValueMetadata(vat.UrnInk, map[utils.Key]string{constants.Ilk: test_helpers.FakeIlk.Hex, constants.Guy: fakeGuy}, utils.Uint256)
+			)
+
+			BeforeEach(func() {
+				blockOne = rand.Int()
+				blockTwo = blockOne + 1
+				blockThree = blockTwo + 1
+				rawTimestampOne = int64(rand.Int31())
+				rawTimestampTwo = rawTimestampOne + 1
+				headerOne = CreateHeaderWithHash(hashOne.String(), rawTimestampOne, blockOne, db)
+				headerTwo = CreateHeaderWithHash(hashTwo.String(), rawTimestampTwo, blockTwo, db)
+				CreateHeaderWithHash(hashThree.String(), rawTimestampThree, blockThree, db)
+			})
+
+			It("inserts time of first ink diff into created", func() {
+				setupErrOne := repo.Create(headerOne.Id, urnInkMetadata, strconv.Itoa(rand.Int()))
+				Expect(setupErrOne).NotTo(HaveOccurred())
+				setupErrTwo := repo.Create(headerTwo.Id, urnInkMetadata, strconv.Itoa(rand.Int()))
+				Expect(setupErrTwo).NotTo(HaveOccurred())
+				expectedTimeCreated := test_helpers.GetValidNullString(FormatTimestamp(rawTimestampOne))
+
+				var timeCreatedValues []sql.NullString
+				queryErr := db.Select(&timeCreatedValues, `SELECT created FROM api.historical_urn_state`)
+				Expect(queryErr).NotTo(HaveOccurred())
+
+				Expect(len(timeCreatedValues)).To(Equal(2))
+				Expect(timeCreatedValues[0]).To(Equal(expectedTimeCreated))
+				Expect(timeCreatedValues[1]).To(Equal(expectedTimeCreated))
+			})
+
+			It("updates time created for all the urn's states when new ink is added", func() {
+				urnArtMetadata := utils.GetStorageValueMetadata(vat.UrnArt, map[utils.Key]string{constants.Ilk: test_helpers.FakeIlk.Hex, constants.Guy: fakeGuy}, utils.Uint256)
+				setupErr := repo.Create(headerOne.Id, urnArtMetadata, strconv.Itoa(rand.Int()))
+				Expect(setupErr).NotTo(HaveOccurred())
+
+				err := repo.Create(headerTwo.Id, urnInkMetadata, strconv.Itoa(rand.Int()))
+				Expect(err).NotTo(HaveOccurred())
+				expectedTimeCreated := test_helpers.GetValidNullString(FormatTimestamp(rawTimestampTwo))
+
+				var timeCreatedValues []sql.NullString
+				queryErr := db.Select(&timeCreatedValues, `SELECT created FROM api.historical_urn_state`)
+				Expect(queryErr).NotTo(HaveOccurred())
+				Expect(len(timeCreatedValues)).To(Equal(2))
+				Expect(timeCreatedValues[0]).To(Equal(expectedTimeCreated))
+				Expect(timeCreatedValues[1]).To(Equal(expectedTimeCreated))
+			})
+
+			It("inserts a row for new urn-block", func() {
+				initialUrnValues := test_helpers.GetUrnSetupData()
+				newInk := rand.Int()
+				test_helpers.CreateUrn(initialUrnValues, headerOne.Id, test_helpers.GetUrnMetadata(test_helpers.FakeIlk.Hex, fakeGuy), repo)
+
+				err := repo.Create(headerTwo.Id, urnInkMetadata, strconv.Itoa(newInk))
+				Expect(err).NotTo(HaveOccurred())
+
+				var urnStates []test_helpers.UrnState
+				queryErr := db.Select(&urnStates, getStateQuery)
+				Expect(queryErr).NotTo(HaveOccurred())
+				Expect(len(urnStates)).To(Equal(2))
+				Expect(urnStates[1].BlockHeight).To(Equal(int(headerTwo.BlockNumber)))
+				Expect(urnStates[1].Ink).To(Equal(strconv.Itoa(newInk)))
+				Expect(urnStates[1].Art).To(Equal(strconv.Itoa(initialUrnValues[vat.UrnArt])))
+				Expect(urnStates[1].Created).To(Equal(test_helpers.GetValidNullString(FormatTimestamp(rawTimestampOne))))
+				Expect(urnStates[1].Updated).To(Equal(test_helpers.GetValidNullString(FormatTimestamp(rawTimestampTwo))))
+			})
+
+			It("updates ink if urn-block combination already exists in table", func() {
+				initialUrnValues := test_helpers.GetUrnSetupData()
+				newInk := rand.Int()
+				test_helpers.CreateUrn(initialUrnValues, headerOne.Id, test_helpers.GetUrnMetadata(test_helpers.FakeIlk.Hex, fakeGuy), repo)
+
+				err := repo.Create(headerOne.Id, urnInkMetadata, strconv.Itoa(newInk))
+				Expect(err).NotTo(HaveOccurred())
+
+				var urnStates []test_helpers.UrnState
+				queryErr := db.Select(&urnStates, getStateQuery)
+				Expect(queryErr).NotTo(HaveOccurred())
+				Expect(len(urnStates)).To(Equal(1))
+				Expect(urnStates[0].BlockHeight).To(Equal(int(headerOne.BlockNumber)))
+				Expect(urnStates[0].Ink).To(Equal(strconv.Itoa(newInk)))
+				Expect(urnStates[0].Art).To(Equal(strconv.Itoa(initialUrnValues[vat.UrnArt])))
+				Expect(urnStates[0].Created).To(Equal(test_helpers.GetValidNullString(FormatTimestamp(rawTimestampOne))))
+				Expect(urnStates[0].Updated).To(Equal(test_helpers.GetValidNullString(FormatTimestamp(rawTimestampOne))))
+			})
+
+			It("updates all consecutive inks if record is the latest ink diff", func() {
+				initialInk := rand.Int()
+				newInk := initialInk + 1
+				_, setupErr := db.Exec(insertInkQuery,
+					fakeGuy, test_helpers.FakeIlk.Identifier, headerTwo.BlockNumber, initialInk)
+				Expect(setupErr).NotTo(HaveOccurred())
+
+				err := repo.Create(headerOne.Id, urnInkMetadata, strconv.Itoa(newInk))
+				Expect(err).NotTo(HaveOccurred())
+
+				var urnStates []test_helpers.UrnState
+				queryErr := db.Select(&urnStates, getInkQuery)
+				Expect(queryErr).NotTo(HaveOccurred())
+				Expect(len(urnStates)).To(Equal(2))
+				Expect(urnStates[1].Ink).To(Equal(strconv.Itoa(newInk)))
+			})
+
+			It("ignores rows from blocks after the next ink diff", func() {
+				initialInk := strconv.Itoa(rand.Int())
+				setupErr := repo.Create(headerTwo.Id, urnInkMetadata, initialInk)
+				Expect(setupErr).NotTo(HaveOccurred())
+
+				err := repo.Create(headerOne.Id, urnInkMetadata, strconv.Itoa(rand.Int()))
+				Expect(err).NotTo(HaveOccurred())
+
+				var urnStates []test_helpers.UrnState
+				queryErr := db.Select(&urnStates, getInkQuery)
+				Expect(queryErr).NotTo(HaveOccurred())
+				Expect(len(urnStates)).To(Equal(2))
+				Expect(urnStates[1].Ink).To(Equal(initialInk))
+			})
+
+			It("ignores rows from different urn", func() {
+				initialInk := rand.Int()
+				_, setupErr := db.Exec(insertInkQuery,
+					fakeGuy, test_helpers.AnotherFakeIlk.Identifier, headerTwo.BlockNumber, initialInk)
+				Expect(setupErr).NotTo(HaveOccurred())
+
+				err := repo.Create(headerOne.Id, urnInkMetadata, strconv.Itoa(rand.Int()))
+				Expect(err).NotTo(HaveOccurred())
+
+				var urnStates []test_helpers.UrnState
+				queryErr := db.Select(&urnStates, getInkQuery)
+				Expect(queryErr).NotTo(HaveOccurred())
+				Expect(len(urnStates)).To(Equal(2))
+				Expect(urnStates[1].Ink).To(Equal(strconv.Itoa(initialInk)))
+			})
+
+			It("ignores rows from earlier blocks", func() {
+				initialInk := rand.Int()
+				_, setupErr := db.Exec(insertInkQuery,
+					fakeGuy, test_helpers.FakeIlk.Identifier, headerOne.BlockNumber, initialInk)
+				Expect(setupErr).NotTo(HaveOccurred())
+
+				err := repo.Create(headerTwo.Id, urnInkMetadata, strconv.Itoa(rand.Int()))
+				Expect(err).NotTo(HaveOccurred())
+
+				var urnStates []test_helpers.UrnState
+				queryErr := db.Select(&urnStates, getInkQuery)
+				Expect(queryErr).NotTo(HaveOccurred())
+				Expect(len(urnStates)).To(Equal(2))
+				Expect(urnStates[0].Ink).To(Equal(strconv.Itoa(initialInk)))
+			})
+
+			Describe("when diff is deleted", func() {
+				It("updates ink to previous value until block number of next diff", func() {
+					initialInk := rand.Int()
+					setupErrOne := repo.Create(headerOne.Id, urnInkMetadata, strconv.Itoa(initialInk))
+					Expect(setupErrOne).NotTo(HaveOccurred())
+
+					subsequentInk := initialInk + 1
+					setupErrTwo := repo.Create(headerTwo.Id, urnInkMetadata, strconv.Itoa(subsequentInk))
+					Expect(setupErrTwo).NotTo(HaveOccurred())
+					_, setupErrThree := db.Exec(insertInkQuery,
+						fakeGuy, test_helpers.FakeIlk.Identifier, blockThree, subsequentInk)
+					Expect(setupErrThree).NotTo(HaveOccurred())
+
+					_, deleteErr := db.Exec(deleteRowQuery, headerTwo.Id)
+					Expect(deleteErr).NotTo(HaveOccurred())
+
+					var urnStates []test_helpers.UrnState
+					queryErr := db.Select(&urnStates, getInkQuery)
+					Expect(queryErr).NotTo(HaveOccurred())
+					Expect(urnStates[1].Ink).To(Equal(strconv.Itoa(initialInk)))
+				})
+
+				It("sets field in subsequent rows to null if no previous diff exists", func() {
+					initialInk := strconv.Itoa(rand.Int())
+					setupErrOne := repo.Create(headerOne.Id, urnInkMetadata, initialInk)
+					Expect(setupErrOne).NotTo(HaveOccurred())
+					_, setupErrTwo := db.Exec(insertInkQuery,
+						fakeGuy, test_helpers.FakeIlk.Identifier, blockTwo, initialInk)
+					Expect(setupErrTwo).NotTo(HaveOccurred())
+
+					_, deleteErr := db.Exec(deleteRowQuery, headerOne.Id)
+					Expect(deleteErr).NotTo(HaveOccurred())
+
+					var actualInks []sql.NullString
+					queryErr := db.Select(&actualInks, getInkQuery)
+					Expect(queryErr).NotTo(HaveOccurred())
+					Expect(len(actualInks)).To(Equal(1))
+					Expect(actualInks[0].Valid).To(BeFalse())
+				})
+
+				It("deletes ilk state associated with diff if identical to previous state", func() {
+					initialInk := rand.Int()
+					setupErrOne := repo.Create(headerOne.Id, urnInkMetadata, strconv.Itoa(initialInk))
+					Expect(setupErrOne).NotTo(HaveOccurred())
+
+					subsequentInk := initialInk + 1
+					setupErrTwo := repo.Create(headerTwo.Id, urnInkMetadata, strconv.Itoa(subsequentInk))
+					Expect(setupErrTwo).NotTo(HaveOccurred())
+					_, setupErrThree := db.Exec(insertInkQuery,
+						fakeGuy, test_helpers.FakeIlk.Identifier, blockThree, subsequentInk)
+					Expect(setupErrThree).NotTo(HaveOccurred())
+
+					_, deleteErr := db.Exec(deleteRowQuery, headerTwo.Id)
+					Expect(deleteErr).NotTo(HaveOccurred())
+
+					var urnStates []test_helpers.UrnState
+					queryErr := db.Select(&urnStates, getInkQuery)
+					Expect(queryErr).NotTo(HaveOccurred())
+					Expect(len(urnStates)).To(Equal(2))
+				})
+
+				It("deletes ilk state associated with diff if it's the earliest state in the table", func() {
+					initialInk := rand.Int()
+					setupErrOne := repo.Create(headerOne.Id, urnInkMetadata, strconv.Itoa(initialInk))
+					Expect(setupErrOne).NotTo(HaveOccurred())
+
+					_, deleteErr := db.Exec(deleteRowQuery, headerOne.Id)
+					Expect(deleteErr).NotTo(HaveOccurred())
+
+					var urnStates []test_helpers.UrnState
+					queryErr := db.Select(&urnStates, getInkQuery)
+					Expect(queryErr).NotTo(HaveOccurred())
+					Expect(len(urnStates)).To(Equal(0))
+				})
+
+				It("updates time created for all urn's states", func() {
+					initialInk := rand.Int()
+					setupErrOne := repo.Create(headerOne.Id, urnInkMetadata, strconv.Itoa(initialInk))
+					Expect(setupErrOne).NotTo(HaveOccurred())
+
+					subsequentInk := initialInk + 1
+					setupErrTwo := repo.Create(headerTwo.Id, urnInkMetadata, strconv.Itoa(subsequentInk))
+					Expect(setupErrTwo).NotTo(HaveOccurred())
+					expectedTimeCreated := test_helpers.GetValidNullString(FormatTimestamp(rawTimestampTwo))
+					_, setupErrThree := db.Exec(insertInkQuery,
+						fakeGuy, test_helpers.FakeIlk.Identifier, blockThree, subsequentInk)
+					Expect(setupErrThree).NotTo(HaveOccurred())
+
+					_, deleteErr := db.Exec(deleteRowQuery, headerOne.Id)
+					Expect(deleteErr).NotTo(HaveOccurred())
+
+					var actualCreatedValues []sql.NullString
+					queryErr := db.Select(&actualCreatedValues, `SELECT created FROM api.historical_urn_state`)
+					Expect(queryErr).NotTo(HaveOccurred())
+					Expect(len(actualCreatedValues)).To(Equal(2))
+					Expect(actualCreatedValues[0]).To(Equal(expectedTimeCreated))
+					Expect(actualCreatedValues[1]).To(Equal(expectedTimeCreated))
+				})
+			})
 		})
 	})
 


### PR DESCRIPTION
Creates a trigger-table exposing all historical states of all urns. Automatically responds to data coming in out of order as well as data being deleted.