### PR TITLE
(VDB-1045) Isolate execute container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,18 @@
 FROM golang:alpine as builder
 
 RUN apk --update --no-cache add make git g++ linux-headers
-# DEBUG
-RUN apk add busybox-extras
 
-ENV GO111MODULE on
-
-# Build statically linked vDB binary (wonky path because of Dep)
-WORKDIR /go/src/github.com/makerdao/vdb-mcd-transformers
-ADD . .
+# Build migration tool
+WORKDIR /go
+RUN GO111MODULE=auto go get -u -d github.com/pressly/goose/cmd/goose
+WORKDIR /go/src/github.com/pressly/goose/cmd/goose
+RUN GO111MODULE=auto go build -a -ldflags '-s' -tags='no_mysql no_sqlite' -o goose
 
 ARG VDB_VERSION=staging
+ENV GO111MODULE on
+
+WORKDIR /go/src/github.com/makerdao/vdb-mcd-transformers
+ADD . .
 
 WORKDIR /go/src/github.com/makerdao
 RUN git clone https://github.com/makerdao/vulcanizedb.git
@@ -20,20 +22,12 @@ RUN go build
 
 # build mcd with local vdb
 WORKDIR /go/src/github.com/makerdao/vdb-mcd-transformers
-
 RUN go mod edit -replace=github.com/makerdao/vulcanizedb=/go/src/github.com/makerdao/vulcanizedb/
 RUN make plugin PACKAGE=github.com/makerdao/vdb-mcd-transformers
-
-# Build migration tool
-WORKDIR /go
-RUN GO111MODULE=auto go get -u -d github.com/pressly/goose/cmd/goose
-WORKDIR /go/src/github.com/pressly/goose/cmd/goose
-RUN GO111MODULE=auto go build -a -ldflags '-s' -tags='no_mysql no_sqlite' -o goose
 
 
 # app container
 FROM golang:alpine
-# workdir needs to match gopath for building file to correct path
 WORKDIR /go/src/github.com/makerdao/vulcanizedb
 
 # add certificates for node requests via https
@@ -46,38 +40,18 @@ RUN apk update \
 # add go so we can build the plugin
 RUN apk add --update --no-cache git g++ linux-headers
 
-ARG USER
-ARG config_file=environments/docker.toml
-ARG vdb_connect
-
-# setup environment
-ENV GOPATH $HOME/go
-ENV GO111MODULE on
-ENV VDB_PG_CONNECT="$vdb_connect"
+ARG CONFIG_FILE=environments/docker.toml
 
 # Direct logs to stdout for docker log driver
 RUN ln -sf /dev/stdout /go/src/github.com/makerdao/vulcanizedb/vulcanizedb.log
 
-RUN adduser -Su 5000 $USER
-# container needs to be writable for plugin execution
-RUN chown 5000:5000 /go/src/github.com/makerdao/vulcanizedb
-
-USER $USER
-
-# chown first so dir is writable
-# note: using $USER is merged, but not in the stable release yet
-COPY --chown=5000:5000 --from=builder /go/src/github.com/makerdao/vulcanizedb .
-COPY --chown=5000:5000 --from=builder /go/src/github.com/makerdao/vdb-mcd-transformers /go/src/github.com/makerdao/vdb-mcd-transformers
-
 # keep binaries immutable
-COPY --from=builder /go/src/github.com/makerdao/vdb-mcd-transformers/$config_file config.toml
+COPY --from=builder /go/src/github.com/makerdao/vulcanizedb .
+COPY --from=builder /go/src/github.com/makerdao/vdb-mcd-transformers/$CONFIG_FILE config.toml
 COPY --from=builder /go/src/github.com/makerdao/vdb-mcd-transformers/dockerfiles/startup_script.sh .
 COPY --from=builder /go/src/github.com/pressly/goose/cmd/goose/goose goose
 COPY --from=builder /go/src/github.com/makerdao/vdb-mcd-transformers/db/migrations/* db/migrations/
 COPY --from=builder /go/src/github.com/makerdao/vdb-mcd-transformers/plugins/transformerExporter.so plugins/transformerExporter.so
-
-# DEBUG
-COPY --from=builder /usr/bin/telnet /bin/telnet
 
 # need to execute with a shell to access env variables
 CMD ["./startup_script.sh"]

--- a/dockerfiles/startup_script.sh
+++ b/dockerfiles/startup_script.sh
@@ -1,10 +1,7 @@
 #!/bin/sh
-# Runs the migrations and starts the headerSync and continuousLogSync services
+# Runs the migrations and executes transformers
 
 MISSING_VAR_MESSAGE=" is required and no value was given"
-
-# DEBUG
-set -x
 
 function testDatabaseVariables() {
   for a in DATABASE_NAME DATABASE_HOSTNAME DATABASE_PORT DATABASE_USER DATABASE_PASSWORD
@@ -38,35 +35,6 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
-
-if test -z "$STARTING_BLOCK_NUMBER"
-then
-    echo STARTING_BLOCK_NUMBER $MISSING_VAR_MESSAGE
-    exit 1
-fi
-
-
-echo "Starting headerSync and executing the transformers..."
-# Fire up the services
-if [ $? -eq 0 ]; then
-  # Fire up the services
-  ./vulcanizedb headerSync --config config.toml -s $STARTING_BLOCK_NUMBER &
-  ./vulcanizedb execute --config config.toml &
-fi
-
-
-# Check every 60 seconds to see if either process has excited.
-# If grepping for process names finds something, they exit with 0 status. If they are not both 0, then one of the processes has already excited.
-
-while sleep 10; do
-  ps aux | grep headerSync | grep -q -v grep
-  HEADER_SYNC_STATUS=$?
-
-  ps aux | grep execute | grep -q -v grep
-  EXECUTE_STATUS=$?
-
-  if [ $HEADER_SYNC_STATUS -ne 0 -o $EXECUTE_STATUS -ne 0 ]; then
-    echo "One of the processes has already exited."
-    exit 1
-  fi
-done
+echo "Starting transformer execution..."
+# Fire up execute
+./vulcanizedb execute --config config.toml

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/ethereum/go-ethereum v1.9.8
+	github.com/go-sql-driver/mysql v1.4.1
 	github.com/howeyc/fsnotify v0.9.0 // indirect
 	github.com/jmoiron/sqlx v0.0.0-20181024163419-82935fac6c1a
 	github.com/magiconair/properties v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,7 @@ github.com/go-logfmt/logfmt v0.4.0 h1:MP4Eh7ZCb31lleYCFuwm0oe4/YGak+5l1vA2NOE80n
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-sql-driver/mysql v1.4.0 h1:7LxgVwFb2hIQtMm87NdgAVfXjnt4OePseqT1tKx+opk=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
+github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -145,9 +146,14 @@ github.com/makerdao/vulcanizedb v0.0.12-0.20191217170804-b8630b4df341 h1:2qojvNJ
 github.com/makerdao/vulcanizedb v0.0.12-0.20191217170804-b8630b4df341/go.mod h1:FZZ/SKy+7Ejdc+4Wa5oTGrr2cFuaCgGBxc2xoifaEoY=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
+github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
+github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW10=
+github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW10=
+github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-runewidth v0.0.6 h1:V2iyH+aX9C5fsYCpK60U8BYIvmhqxuOL3JZcqc1NB7k=
 github.com/mattn/go-runewidth v0.0.6/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
@@ -169,9 +175,11 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/olekukonko/tablewriter v0.0.3 h1:i0LBnzgiChAWHJYTQAZJDOgf8MNxAVYZJ2m63SIDimI=
 github.com/olekukonko/tablewriter v0.0.3/go.mod h1:YZeBtGzYYEsCHp2LST/u/0NDwGkRoBtmn1cIWCJiS6M=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.7.0 h1:WSHQ+IS43OoUrWtD1/bbclrwK8TTH5hzp+umCiuxHgs=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.10.1 h1:q/mM8GF/n0shIN8SaAZ0V+jnLPzen6WIVZdiwrRlMlo=
 github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/gomega v1.4.3 h1:RE1xgDvH7imwFD45h+u2SgIfERHlS2yNG4DObb5BSKU=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.0 h1:XPnZz8VVBHjVsy1vzJmRwIcSwiUO+JFfrv/xGiigmME=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -186,6 +194,7 @@ github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtP
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pierrec/lz4 v0.0.0-20190327172049-315a67e90e41/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
+github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -268,6 +277,7 @@ golang.org/x/net v0.0.0-20181011144130-49bb7cea24b1/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190603091049-60506f45cf65 h1:+rhAzEzT3f4JtomfC371qB+0Ola2caSKcY69NUBZrRQ=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/plugins/transformerExporter.go
+++ b/plugins/transformerExporter.go
@@ -17,8 +17,16 @@ import (
 	jug_file_ilk "github.com/makerdao/vdb-mcd-transformers/transformers/events/jug_file/ilk/initializer"
 	jug_file_vow "github.com/makerdao/vdb-mcd-transformers/transformers/events/jug_file/vow/initializer"
 	jug_init "github.com/makerdao/vdb-mcd-transformers/transformers/events/jug_init/initializer"
+	log_value "github.com/makerdao/vdb-mcd-transformers/transformers/events/log_value/initializer"
 	new_cdp "github.com/makerdao/vdb-mcd-transformers/transformers/events/new_cdp/initializer"
+	pot_cage "github.com/makerdao/vdb-mcd-transformers/transformers/events/pot_cage/initializer"
+	pot_drip "github.com/makerdao/vdb-mcd-transformers/transformers/events/pot_drip/initializer"
+	pot_exit "github.com/makerdao/vdb-mcd-transformers/transformers/events/pot_exit/initializer"
+	pot_file_dsr "github.com/makerdao/vdb-mcd-transformers/transformers/events/pot_file/dsr/initializer"
+	pot_file_vow "github.com/makerdao/vdb-mcd-transformers/transformers/events/pot_file/vow/initializer"
+	pot_join "github.com/makerdao/vdb-mcd-transformers/transformers/events/pot_join/initializer"
 	spot_file_mat "github.com/makerdao/vdb-mcd-transformers/transformers/events/spot_file/mat/initializer"
+	spot_file_par "github.com/makerdao/vdb-mcd-transformers/transformers/events/spot_file/par/initializer"
 	spot_file_pip "github.com/makerdao/vdb-mcd-transformers/transformers/events/spot_file/pip/initializer"
 	spot_poke "github.com/makerdao/vdb-mcd-transformers/transformers/events/spot_poke/initializer"
 	tend "github.com/makerdao/vdb-mcd-transformers/transformers/events/tend/initializer"
@@ -47,6 +55,7 @@ import (
 	sai_flip "github.com/makerdao/vdb-mcd-transformers/transformers/storage/flip/initializers/sai_flip"
 	flop_storage "github.com/makerdao/vdb-mcd-transformers/transformers/storage/flop/initializer"
 	jug "github.com/makerdao/vdb-mcd-transformers/transformers/storage/jug/initializer"
+	pot "github.com/makerdao/vdb-mcd-transformers/transformers/storage/pot/initializer"
 	spot "github.com/makerdao/vdb-mcd-transformers/transformers/storage/spot/initializer"
 	vat "github.com/makerdao/vdb-mcd-transformers/transformers/storage/vat/initializer"
 	vow "github.com/makerdao/vdb-mcd-transformers/transformers/storage/vow/initializer"
@@ -71,14 +80,24 @@ func (e exporter) Export() ([]interface1.EventTransformerInitializer, []interfac
 			jug_drip.EventTransformerInitializer,
 			jug_file_base.EventTransformerInitializer,
 			jug_file_ilk.EventTransformerInitializer,
-			jug_init.EventTransformerInitializer,
 			jug_file_vow.EventTransformerInitializer,
+			jug_init.EventTransformerInitializer,
+			log_value.EventTransformerInitializer,
 			new_cdp.EventTransformerInitializer,
+			pot_cage.EventTransformerInitializer,
+			pot_drip.EventTransformerInitializer,
+			pot_exit.EventTransformerInitializer,
+			pot_file_dsr.EventTransformerInitializer,
+			pot_file_vow.EventTransformerInitializer,
+			pot_join.EventTransformerInitializer,
 			spot_file_mat.EventTransformerInitializer,
+			spot_file_par.EventTransformerInitializer,
 			spot_file_pip.EventTransformerInitializer,
 			spot_poke.EventTransformerInitializer,
 			tend.EventTransformerInitializer,
 			tick.EventTransformerInitializer,
+			vat_file_debt_ceiling.EventTransformerInitializer,
+			vat_file_ilk.EventTransformerInitializer,
 			vat_flux.EventTransformerInitializer,
 			vat_fold.EventTransformerInitializer,
 			vat_fork.EventTransformerInitializer,
@@ -91,8 +110,6 @@ func (e exporter) Export() ([]interface1.EventTransformerInitializer, []interfac
 			vat_suck.EventTransformerInitializer,
 			vow_fess.EventTransformerInitializer,
 			vow_file.EventTransformerInitializer,
-			vat_file_debt_ceiling.EventTransformerInitializer,
-			vat_file_ilk.EventTransformerInitializer,
 			vow_flog.EventTransformerInitializer,
 			yank.EventTransformerInitializer,
 		},
@@ -104,6 +121,7 @@ func (e exporter) Export() ([]interface1.EventTransformerInitializer, []interfac
 			flap_storage.StorageTransformerInitializer,
 			flop_storage.StorageTransformerInitializer,
 			jug.StorageTransformerInitializer,
+			pot.StorageTransformerInitializer,
 			sai_flip.StorageTransformerInitializer,
 			spot.StorageTransformerInitializer,
 			vat.StorageTransformerInitializer,


### PR DESCRIPTION
- Remove headerSync so it can run in a separate container

This includes a change to point at vdb staging and makes associated changes to the deps, which is necessary to use the new storage repository interface. I'd be fine with cutting a new version of vdb whenever we're ready (potentially awaiting open PRs over there) and then updating things here accordingly.

When I run this locally with a config file that includes storage transformers but without a valid path to the CSV, "Waiting for  to appear" spams the logs. Thinking that shouldn't be an issue when actually running this because you'd either include a valid path or turn off the storage transformers.