### PR TITLE
(VDB-1050) add missing indexes

### DIFF
--- a/db/migrations/00014_create_receipts_table.sql
+++ b/db/migrations/00014_create_receipts_table.sql
@@ -11,6 +11,10 @@ CREATE TABLE full_sync_receipts
     tx_hash             VARCHAR(66)
 );
 
+CREATE INDEX full_sync_receipts_contract_address
+    ON full_sync_receipts (contract_address_id);
+
 
 -- +goose Down
+DROP INDEX full_sync_receipts_contract_address;
 DROP TABLE full_sync_receipts;

--- a/db/migrations/00016_add_receipts_fk_to_logs.sql
+++ b/db/migrations/00016_add_receipts_fk_to_logs.sql
@@ -8,8 +8,13 @@ ALTER TABLE full_sync_logs
             REFERENCES full_sync_receipts (id)
             ON DELETE CASCADE;
 
+CREATE INDEX full_sync_logs_receipt
+    ON full_sync_logs (receipt_id);
+
 
 -- +goose Down
+DROP INDEX full_sync_logs_receipt;
+
 ALTER TABLE full_sync_logs
     DROP CONSTRAINT receipts_fk;
 

--- a/db/migrations/00021_associate_receipts_with_blocks.sql
+++ b/db/migrations/00021_associate_receipts_with_blocks.sql
@@ -19,8 +19,13 @@ ON DELETE CASCADE;
 ALTER TABLE full_sync_receipts
   DROP COLUMN transaction_id;
 
+CREATE INDEX full_sync_receipts_block
+    ON full_sync_receipts (block_id);
+
 
 -- +goose Down
+DROP INDEX full_sync_receipts_block;
+
 ALTER TABLE full_sync_receipts
   ADD COLUMN transaction_id INT;
 

--- a/db/migrations/00022_create_headers_table.sql
+++ b/db/migrations/00022_create_headers_table.sql
@@ -13,6 +13,7 @@ CREATE TABLE public.headers
 
 -- Index is removed when table is
 CREATE INDEX headers_block_number ON public.headers (block_number);
+CREATE INDEX headers_eth_node ON public.headers (eth_node_id);
 
 
 -- +goose Down

--- a/db/migrations/00026_create_header_sync_transactions_table.sql
+++ b/db/migrations/00026_create_header_sync_transactions_table.sql
@@ -14,5 +14,9 @@ CREATE TABLE header_sync_transactions (
   "value"     NUMERIC
 );
 
+CREATE INDEX header_sync_transactions_header
+    ON header_sync_transactions (header_id);
+
 -- +goose Down
+DROP INDEX header_sync_transactions_header;
 DROP TABLE header_sync_transactions;

--- a/db/migrations/00027_create_header_sync_receipts_table.sql
+++ b/db/migrations/00027_create_header_sync_receipts_table.sql
@@ -14,6 +14,13 @@ CREATE TABLE header_sync_receipts
     UNIQUE (header_id, transaction_id)
 );
 
+CREATE INDEX header_sync_receipts_contract_address
+    ON header_sync_receipts (contract_address_id);
+CREATE INDEX header_sync_receipts_transaction
+    ON header_sync_receipts (transaction_id);
+
 
 -- +goose Down
+DROP INDEX header_sync_receipts_transaction;
+DROP INDEX header_sync_receipts_contract_address;
 DROP TABLE header_sync_receipts;

--- a/db/migrations/00028_create_uncles_table.sql
+++ b/db/migrations/00028_create_uncles_table.sql
@@ -11,5 +11,9 @@ CREATE TABLE public.uncles (
   UNIQUE (block_id, hash)
 );
 
+CREATE INDEX uncles_eth_node
+    ON uncles (eth_node_id);
+
 -- +goose Down
+DROP INDEX uncles_eth_node;
 DROP TABLE public.uncles;

--- a/db/migrations/00029_create_header_sync_logs_table.sql
+++ b/db/migrations/00029_create_header_sync_logs_table.sql
@@ -17,6 +17,13 @@ CREATE TABLE header_sync_logs
     UNIQUE (header_id, tx_index, log_index)
 );
 
+CREATE INDEX header_sync_logs_address
+    ON header_sync_logs (address);
+CREATE INDEX header_sync_logs_transaction
+    ON header_sync_logs (tx_hash);
+
 -- +goose Down
 -- SQL in this section is executed when the migration is rolled back.
+DROP INDEX header_sync_logs_transaction;
+DROP INDEX header_sync_logs_address;
 DROP TABLE header_sync_logs;

--- a/db/migrations/20180724233839_create_flip_kick.sql
+++ b/db/migrations/20180724233839_create_flip_kick.sql
@@ -21,12 +21,15 @@ CREATE INDEX flip_kick_header_index
     ON maker.flip_kick (header_id);
 CREATE INDEX flip_kick_bid_id_index
     ON maker.flip_kick (bid_id);
-CREATE INDEX flip_kick_address_id_index
+CREATE INDEX flip_kick_address_index
     ON maker.flip_kick (address_id);
+CREATE INDEX flip_kick_log_index
+    ON maker.flip_kick (log_id);
 
 
 -- +goose Down
-DROP INDEX maker.flip_kick_address_id_index;
+DROP INDEX maker.flip_kick_log_index;
+DROP INDEX maker.flip_kick_address_index;
 DROP INDEX maker.flip_kick_bid_id_index;
 DROP INDEX maker.flip_kick_header_index;
 

--- a/db/migrations/20180809214845_create_vat_frob.sql
+++ b/db/migrations/20180809214845_create_vat_frob.sql
@@ -14,13 +14,15 @@ CREATE TABLE maker.vat_frob
 
 CREATE INDEX vat_frob_header_index
     ON maker.vat_frob (header_id);
-
+CREATE INDEX vat_frob_log_index
+    ON maker.vat_frob (log_id);
 CREATE INDEX vat_frob_urn_index
     ON maker.vat_frob (urn_id);
 
 
 -- +goose Down
 DROP INDEX maker.vat_frob_header_index;
+DROP INDEX maker.vat_frob_log_index;
 DROP INDEX maker.vat_frob_urn_index;
 
 DROP TABLE maker.vat_frob;

--- a/db/migrations/20180815031512_create_tend.sql
+++ b/db/migrations/20180815031512_create_tend.sql
@@ -13,9 +13,15 @@ CREATE TABLE maker.tend
 
 CREATE INDEX tend_header_index
     ON maker.tend (header_id);
+CREATE INDEX tend_log_index
+    ON maker.tend (log_id);
+CREATE INDEX tend_address_index
+    ON maker.tend (address_id);
 
 
 -- +goose Down
+DROP INDEX maker.tend_address_index;
+DROP INDEX maker.tend_log_index;
 DROP INDEX maker.tend_header_index;
 
 DROP TABLE maker.tend;

--- a/db/migrations/20180815031513_create_bite.sql
+++ b/db/migrations/20180815031513_create_bite.sql
@@ -20,13 +20,15 @@ COMMENT ON COLUMN maker.bite.id
 
 CREATE INDEX bite_header_index
     ON maker.bite (header_id);
-
+CREATE INDEX bite_log_index
+    ON maker.bite (log_id);
 CREATE INDEX bite_urn_index
     ON maker.bite (urn_id);
 
 
 -- +goose Down
 DROP INDEX maker.bite_header_index;
+DROP INDEX maker.bite_log_index;
 DROP INDEX maker.bite_urn_index;
 
 DROP TABLE maker.bite;

--- a/db/migrations/20180820230607_create_dent.sql
+++ b/db/migrations/20180820230607_create_dent.sql
@@ -13,9 +13,15 @@ CREATE TABLE maker.dent
 
 CREATE INDEX dent_header_index
     ON maker.dent (header_id);
+CREATE INDEX dent_log_index
+    ON maker.dent (log_id);
+CREATE INDEX dent_address_index
+    ON maker.dent (address_id);
 
 
 -- +goose Down
 DROP INDEX maker.dent_header_index;
+DROP INDEX maker.dent_log_index;
+DROP INDEX maker.dent_address_index;
 
 DROP TABLE maker.dent;

--- a/db/migrations/20180831002535_create_vat_file.sql
+++ b/db/migrations/20180831002535_create_vat_file.sql
@@ -12,7 +12,8 @@ CREATE TABLE maker.vat_file_ilk
 
 CREATE INDEX vat_file_ilk_header_index
     ON maker.vat_file_ilk (header_id);
-
+CREATE INDEX vat_file_ilk_log_index
+    ON maker.vat_file_ilk (log_id);
 CREATE INDEX vat_file_ilk_ilk_index
     ON maker.vat_file_ilk (ilk_id);
 
@@ -28,12 +29,16 @@ CREATE TABLE maker.vat_file_debt_ceiling
 
 CREATE INDEX vat_file_debt_ceiling_header_index
     ON maker.vat_file_debt_ceiling (header_id);
+CREATE INDEX vat_file_debt_ceiling_log_index
+    ON maker.vat_file_debt_ceiling (log_id);
 
 
 -- +goose Down
 DROP INDEX maker.vat_file_ilk_header_index;
+DROP INDEX maker.vat_file_ilk_log_index;
 DROP INDEX maker.vat_file_ilk_ilk_index;
 DROP INDEX maker.vat_file_debt_ceiling_header_index;
+DROP INDEX maker.vat_file_debt_ceiling_log_index;
 
 DROP TABLE maker.vat_file_ilk;
 DROP TABLE maker.vat_file_debt_ceiling;

--- a/db/migrations/20180906225956_create_vat_init.sql
+++ b/db/migrations/20180906225956_create_vat_init.sql
@@ -10,13 +10,15 @@ CREATE TABLE maker.vat_init
 
 CREATE INDEX vat_init_header_index
     ON maker.vat_init (header_id);
-
+CREATE INDEX vat_init_log_index
+    ON maker.vat_init (log_id);
 CREATE INDEX vat_init_ilk_index
     ON maker.vat_init (ilk_id);
 
 
 -- +goose Down
 DROP INDEX maker.vat_init_header_index;
+DROP INDEX maker.vat_init_log_index;
 DROP INDEX maker.vat_init_ilk_index;
 
 DROP TABLE maker.vat_init;

--- a/db/migrations/20180910202607_create_jug_file.sql
+++ b/db/migrations/20180910202607_create_jug_file.sql
@@ -11,6 +11,8 @@ CREATE TABLE maker.jug_file_base
 
 CREATE INDEX jug_file_base_header_index
     ON maker.jug_file_base (header_id);
+CREATE INDEX jug_file_base_log_index
+    ON maker.jug_file_base (log_id);
 
 CREATE TABLE maker.jug_file_ilk
 (
@@ -25,7 +27,8 @@ CREATE TABLE maker.jug_file_ilk
 
 CREATE INDEX jug_file_ilk_header_index
     ON maker.jug_file_ilk (header_id);
-
+CREATE INDEX jug_file_ilk_log_index
+    ON maker.jug_file_ilk (log_id);
 CREATE INDEX jug_file_ilk_ilk_index
     ON maker.jug_file_ilk (ilk_id);
 
@@ -41,13 +44,18 @@ CREATE TABLE maker.jug_file_vow
 
 CREATE INDEX jug_file_vow_header_index
     ON maker.jug_file_vow (header_id);
+CREATE INDEX jug_file_vow_log_index
+    ON maker.jug_file_vow (log_id);
 
 
 -- +goose Down
 DROP INDEX maker.jug_file_base_header_index;
+DROP INDEX maker.jug_file_base_log_index;
 DROP INDEX maker.jug_file_ilk_header_index;
+DROP INDEX maker.jug_file_ilk_log_index;
 DROP INDEX maker.jug_file_ilk_ilk_index;
 DROP INDEX maker.jug_file_vow_header_index;
+DROP INDEX maker.jug_file_vow_log_index;
 
 DROP TABLE maker.jug_file_ilk;
 DROP TABLE maker.jug_file_base;

--- a/db/migrations/20180910233720_create_deal.sql
+++ b/db/migrations/20180910233720_create_deal.sql
@@ -11,15 +11,18 @@ CREATE TABLE maker.deal
 
 CREATE INDEX deal_header_index
     ON maker.deal (header_id);
+CREATE INDEX deal_log_index
+    ON maker.deal (log_id);
 CREATE INDEX deal_bid_id_index
     ON maker.deal (bid_id);
-CREATE INDEX deal_address_id_index
+CREATE INDEX deal_address_index
     ON maker.deal (address_id);
 
 
 -- +goose Down
-DROP INDEX maker.deal_address_id_index;
+DROP INDEX maker.deal_address_index;
 DROP INDEX maker.deal_bid_id_index;
+DROP INDEX maker.deal_log_index;
 DROP INDEX maker.deal_header_index;
 
 DROP TABLE maker.deal;

--- a/db/migrations/20180912015839_create_jug_drip.sql
+++ b/db/migrations/20180912015839_create_jug_drip.sql
@@ -10,13 +10,15 @@ CREATE TABLE maker.jug_drip
 
 CREATE INDEX jug_drip_header_index
     ON maker.jug_drip (header_id);
-
+CREATE INDEX jug_drip_log_index
+    ON maker.jug_drip (log_id);
 CREATE INDEX jug_drip_ilk_index
     ON maker.jug_drip (ilk_id);
 
 
 -- +goose Down
 DROP INDEX maker.jug_drip_header_index;
+DROP INDEX maker.jug_drip_log_index;
 DROP INDEX maker.jug_drip_ilk_index;
 
 DROP TABLE maker.jug_drip;

--- a/db/migrations/20180912171047_create_cat_file.sql
+++ b/db/migrations/20180912171047_create_cat_file.sql
@@ -12,7 +12,8 @@ CREATE TABLE maker.cat_file_chop_lump
 
 CREATE INDEX cat_file_chop_lump_header_index
     ON maker.cat_file_chop_lump (header_id);
-
+CREATE INDEX cat_file_chop_lump_log_index
+    ON maker.cat_file_chop_lump (log_id);
 CREATE INDEX cat_file_chop_lump_ilk_index
     ON maker.cat_file_chop_lump (ilk_id);
 
@@ -29,7 +30,8 @@ CREATE TABLE maker.cat_file_flip
 
 CREATE INDEX cat_file_flip_header_index
     ON maker.cat_file_flip (header_id);
-
+CREATE INDEX cat_file_flip_log_index
+    ON maker.cat_file_flip (log_id);
 CREATE INDEX cat_file_flip_ilk_index
     ON maker.cat_file_flip (ilk_id);
 
@@ -45,14 +47,19 @@ CREATE TABLE maker.cat_file_vow
 
 CREATE INDEX cat_file_vow_header_index
     ON maker.cat_file_vow (header_id);
+CREATE INDEX cat_file_vow_log_index
+    ON maker.cat_file_vow (log_id);
 
 
 -- +goose Down
 DROP INDEX maker.cat_file_chop_lump_header_index;
+DROP INDEX maker.cat_file_chop_lump_log_index;
 DROP INDEX maker.cat_file_chop_lump_ilk_index;
 DROP INDEX maker.cat_file_flip_header_index;
+DROP INDEX maker.cat_file_flip_log_index;
 DROP INDEX maker.cat_file_flip_ilk_index;
 DROP INDEX maker.cat_file_vow_header_index;
+DROP INDEX maker.cat_file_vow_log_index;
 
 DROP TABLE maker.cat_file_chop_lump;
 DROP TABLE maker.cat_file_flip;

--- a/db/migrations/20180914182849_create_flop_kick.sql
+++ b/db/migrations/20180914182849_create_flop_kick.sql
@@ -17,8 +17,14 @@ COMMENT ON TABLE maker.flop_kick IS E'@name flopKickEvent';
 
 CREATE INDEX flop_kick_header_index
     ON maker.flop_kick (header_id);
+CREATE INDEX flop_kick_log_index
+    ON maker.flop_kick (log_id);
+CREATE INDEX flop_kick_address_index
+    ON maker.flop_kick (address_id);
 
 
 -- +goose Down
+DROP INDEX maker.flop_kick_address_index;
+DROP INDEX maker.flop_kick_log_index;
 DROP INDEX maker.flop_kick_header_index;
 DROP TABLE maker.flop_kick;

--- a/db/migrations/20181001142655_create_vat_move.sql
+++ b/db/migrations/20181001142655_create_vat_move.sql
@@ -12,8 +12,11 @@ CREATE TABLE maker.vat_move
 
 CREATE INDEX vat_move_header_index
     ON maker.vat_move (header_id);
+CREATE INDEX vat_move_log_index
+    ON maker.vat_move (log_id);
 
 
 -- +goose Down
+DROP INDEX maker.vat_move_log_index;
 DROP INDEX maker.vat_move_header_index;
 DROP TABLE maker.vat_move;

--- a/db/migrations/20181002220302_create_vat_fold.sql
+++ b/db/migrations/20181002220302_create_vat_fold.sql
@@ -12,13 +12,15 @@ CREATE TABLE maker.vat_fold
 
 CREATE INDEX vat_fold_header_index
     ON maker.vat_fold (header_id);
-
+CREATE INDEX vat_fold_log_index
+    ON maker.vat_fold (log_id);
 CREATE INDEX vat_fold_ilk_index
     ON maker.vat_fold (ilk_id);
 
 
 -- +goose Down
 DROP INDEX maker.vat_fold_header_index;
+DROP INDEX maker.vat_fold_log_index;
 DROP INDEX maker.vat_fold_ilk_index;
 
 DROP TABLE maker.vat_fold;

--- a/db/migrations/20181004184028_create_vat_heal.sql
+++ b/db/migrations/20181004184028_create_vat_heal.sql
@@ -10,8 +10,11 @@ CREATE TABLE maker.vat_heal
 
 CREATE INDEX vat_heal_header_index
     ON maker.vat_heal (header_id);
+CREATE INDEX vat_heal_log_index
+    ON maker.vat_heal (log_id);
 
 
 -- +goose Down
+DROP INDEX maker.vat_heal_log_index;
 DROP INDEX maker.vat_heal_header_index;
 DROP TABLE maker.vat_heal;

--- a/db/migrations/20181008232020_create_vat_grab.sql
+++ b/db/migrations/20181008232020_create_vat_grab.sql
@@ -14,13 +14,15 @@ CREATE TABLE maker.vat_grab
 
 CREATE INDEX vat_grab_header_index
     ON maker.vat_grab (header_id);
-
+CREATE INDEX vat_grab_log_index
+    ON maker.vat_grab (log_id);
 CREATE INDEX vat_grab_urn_index
     ON maker.vat_grab (urn_id);
 
 
 -- +goose Down
 DROP INDEX maker.vat_grab_header_index;
+DROP INDEX maker.vat_grab_log_index;
 DROP INDEX maker.vat_grab_urn_index;
 
 DROP TABLE maker.vat_grab;

--- a/db/migrations/20181011184449_create_vat_flux.sql
+++ b/db/migrations/20181011184449_create_vat_flux.sql
@@ -13,12 +13,14 @@ CREATE TABLE maker.vat_flux
 
 CREATE INDEX vat_flux_header_index
     ON maker.vat_flux (header_id);
-
+CREATE INDEX vat_flux_log_index
+    ON maker.vat_flux (log_id);
 CREATE INDEX vat_flux_ilk_index
     ON maker.vat_flux (ilk_id);
 
 -- +goose Down
 DROP INDEX maker.vat_flux_header_index;
+DROP INDEX maker.vat_flux_log_index;
 DROP INDEX maker.vat_flux_ilk_index;
 
 DROP TABLE maker.vat_flux;

--- a/db/migrations/20181015231509_create_vat_slip.sql
+++ b/db/migrations/20181015231509_create_vat_slip.sql
@@ -12,13 +12,15 @@ CREATE TABLE maker.vat_slip
 
 CREATE INDEX vat_slip_header_index
     ON maker.vat_slip (header_id);
-
+CREATE INDEX vat_slip_log_index
+    ON maker.vat_slip (log_id);
 CREATE INDEX vat_slip_ilk_index
     ON maker.vat_slip (ilk_id);
 
 
 -- +goose Down
 DROP INDEX maker.vat_slip_header_index;
+DROP INDEX maker.vat_slip_log_index;
 DROP INDEX maker.vat_slip_ilk_index;
 
 DROP TABLE maker.vat_slip;

--- a/db/migrations/20181023141856_create_vow_flog.sql
+++ b/db/migrations/20181023141856_create_vow_flog.sql
@@ -10,13 +10,15 @@ CREATE TABLE maker.vow_flog
 
 CREATE INDEX vow_flog_era_index
     ON maker.vow_flog (era);
-
+CREATE INDEX vow_flog_log_index
+    ON maker.vow_flog (log_id);
 CREATE INDEX vow_flog_header_index
     ON maker.vow_flog (header_id);
 
 
 -- +goose Down
 DROP INDEX maker.vow_flog_era_index;
+DROP INDEX maker.vow_flog_log_index;
 DROP INDEX maker.vow_flog_header_index;
 
 DROP TABLE maker.vow_flog;

--- a/db/migrations/20181106183140_create_flap_kick.sql
+++ b/db/migrations/20181106183140_create_flap_kick.sql
@@ -16,8 +16,14 @@ COMMENT ON TABLE maker.flap_kick IS E'@name flapKickEvent';
 
 CREATE INDEX flap_kick_header_index
     ON maker.flap_kick (header_id);
+CREATE INDEX flap_kick_log_index
+    ON maker.flap_kick (log_id);
+CREATE INDEX flap_kick_address_index
+    ON maker.flap_kick (address_id);
 
 
 -- +goose Down
+DROP INDEX maker.flap_kick_address_index;
+DROP INDEX maker.flap_kick_log_index;
 DROP INDEX maker.flap_kick_header_index;
 DROP TABLE maker.flap_kick;

--- a/db/migrations/20181114200131_create_vat_storage_tables.sql
+++ b/db/migrations/20181114200131_create_vat_storage_tables.sql
@@ -8,6 +8,9 @@ CREATE TABLE maker.vat_debt
     UNIQUE (diff_id, header_id, debt)
 );
 
+CREATE INDEX vat_debt_header_id_index
+    ON maker.vat_debt (header_id);
+
 CREATE TABLE maker.vat_vice
 (
     id        SERIAL PRIMARY KEY,
@@ -16,6 +19,9 @@ CREATE TABLE maker.vat_vice
     vice      NUMERIC NOT NULL,
     UNIQUE (diff_id, header_id, vice)
 );
+
+CREATE INDEX vat_vice_header_id_index
+    ON maker.vat_vice (header_id);
 
 CREATE TABLE maker.vat_ilk_art
 (
@@ -133,6 +139,8 @@ CREATE TABLE maker.vat_gem
     UNIQUE (diff_id, header_id, ilk_id, guy, gem)
 );
 
+CREATE INDEX vat_gem_header_id_index
+    ON maker.vat_gem (header_id);
 CREATE INDEX vat_gem_ilk_index
     ON maker.vat_gem (ilk_id);
 
@@ -146,6 +154,9 @@ CREATE TABLE maker.vat_dai
     UNIQUE (diff_id, header_id, guy, dai)
 );
 
+CREATE INDEX vat_dai_header_id_index
+    ON maker.vat_dai (header_id);
+
 CREATE TABLE maker.vat_sin
 (
     id        SERIAL PRIMARY KEY,
@@ -156,6 +167,9 @@ CREATE TABLE maker.vat_sin
     UNIQUE (diff_id, header_id, guy, sin)
 );
 
+CREATE INDEX vat_sin_header_id_index
+    ON maker.vat_sin (header_id);
+
 CREATE TABLE maker.vat_line
 (
     id        SERIAL PRIMARY KEY,
@@ -164,6 +178,9 @@ CREATE TABLE maker.vat_line
     line      NUMERIC NOT NULL,
     UNIQUE (diff_id, header_id, line)
 );
+
+CREATE INDEX vat_line_header_id_index
+    ON maker.vat_line (header_id);
 
 CREATE TABLE maker.vat_live
 (
@@ -174,7 +191,12 @@ CREATE TABLE maker.vat_live
     UNIQUE (diff_id, header_id, live)
 );
 
+CREATE INDEX vat_live_header_id_index
+    ON maker.vat_live (header_id);
+
 -- +goose Down
+DROP INDEX maker.vat_debt_header_id_index;
+DROP INDEX maker.vat_vice_header_id_index;
 DROP INDEX maker.vat_ilk_art_header_id_index;
 DROP INDEX maker.vat_ilk_art_ilk_index;
 DROP INDEX maker.vat_ilk_dust_header_id_index;
@@ -189,7 +211,12 @@ DROP INDEX maker.vat_urn_art_header_id_index;
 DROP INDEX maker.vat_urn_art_urn_index;
 DROP INDEX maker.vat_urn_ink_header_id_index;
 DROP INDEX maker.vat_urn_ink_urn_index;
+DROP INDEX maker.vat_gem_header_id_index;
 DROP INDEX maker.vat_gem_ilk_index;
+DROP INDEX maker.vat_dai_header_id_index;
+DROP INDEX maker.vat_sin_header_id_index;
+DROP INDEX maker.vat_line_header_id_index;
+DROP INDEX maker.vat_live_header_id_index;
 
 DROP TABLE maker.vat_debt;
 DROP TABLE maker.vat_vice;

--- a/db/migrations/20181114200132_create_vow_storage_tables.sql
+++ b/db/migrations/20181114200132_create_vow_storage_tables.sql
@@ -8,6 +8,9 @@ CREATE TABLE maker.vow_vat
     UNIQUE (diff_id, header_id, vat)
 );
 
+CREATE INDEX vow_vat_header_id_index
+    ON maker.vow_vat (header_id);
+
 CREATE TABLE maker.vow_flapper
 (
     id        SERIAL PRIMARY KEY,
@@ -16,6 +19,9 @@ CREATE TABLE maker.vow_flapper
     flapper   TEXT,
     UNIQUE (diff_id, header_id, flapper)
 );
+
+CREATE INDEX vow_flapper_header_id_index
+    ON maker.vow_flapper (header_id);
 
 CREATE TABLE maker.vow_flopper
 (
@@ -26,6 +32,9 @@ CREATE TABLE maker.vow_flopper
     UNIQUE (diff_id, header_id, flopper)
 );
 
+CREATE INDEX vow_flopper_header_id_index
+    ON maker.vow_flopper (header_id);
+
 CREATE TABLE maker.vow_sin_integer
 (
     id        SERIAL PRIMARY KEY,
@@ -34,6 +43,9 @@ CREATE TABLE maker.vow_sin_integer
     sin       numeric,
     UNIQUE (diff_id, header_id, sin)
 );
+
+CREATE INDEX vow_sin_integer_header_id_index
+    ON maker.vow_sin_integer (header_id);
 
 CREATE TABLE maker.vow_sin_mapping
 (
@@ -45,6 +57,8 @@ CREATE TABLE maker.vow_sin_mapping
     UNIQUE (diff_id, header_id, era, tab)
 );
 
+CREATE INDEX vow_sin_mapping_header_id_index
+    ON maker.vow_sin_mapping (header_id);
 CREATE INDEX vow_sin_mapping_era_index
     ON maker.vow_sin_mapping (era);
 
@@ -57,6 +71,9 @@ CREATE TABLE maker.vow_ash
     UNIQUE (diff_id, header_id, ash)
 );
 
+CREATE INDEX vow_ash_header_id_index
+    ON maker.vow_ash (header_id);
+
 CREATE TABLE maker.vow_wait
 (
     id        SERIAL PRIMARY KEY,
@@ -65,6 +82,9 @@ CREATE TABLE maker.vow_wait
     wait      numeric,
     UNIQUE (diff_id, header_id, wait)
 );
+
+CREATE INDEX vow_wait_header_id_index
+    ON maker.vow_wait (header_id);
 
 CREATE TABLE maker.vow_dump
 (
@@ -75,6 +95,9 @@ CREATE TABLE maker.vow_dump
     UNIQUE (diff_id, header_id, dump)
 );
 
+CREATE INDEX vow_dump_header_id_index
+    ON maker.vow_dump (header_id);
+
 CREATE TABLE maker.vow_sump
 (
     id        SERIAL PRIMARY KEY,
@@ -83,6 +106,9 @@ CREATE TABLE maker.vow_sump
     sump      numeric,
     UNIQUE (diff_id, header_id, sump)
 );
+
+CREATE INDEX vow_sump_header_id_index
+    ON maker.vow_sump (header_id);
 
 CREATE TABLE maker.vow_bump
 (
@@ -93,6 +119,9 @@ CREATE TABLE maker.vow_bump
     UNIQUE (diff_id, header_id, bump)
 );
 
+CREATE INDEX vow_bump_header_id_index
+    ON maker.vow_bump (header_id);
+
 CREATE TABLE maker.vow_hump
 (
     id        SERIAL PRIMARY KEY,
@@ -102,8 +131,22 @@ CREATE TABLE maker.vow_hump
     UNIQUE (diff_id, header_id, hump)
 );
 
+CREATE INDEX vow_hump_header_id_index
+    ON maker.vow_hump (header_id);
+
 -- +goose Down
+DROP INDEX maker.vow_vat_header_id_index;
+DROP INDEX maker.vow_flapper_header_id_index;
+DROP INDEX maker.vow_flopper_header_id_index;
+DROP INDEX maker.vow_sin_integer_header_id_index;
+DROP INDEX maker.vow_sin_mapping_header_id_index;
 DROP INDEX maker.vow_sin_mapping_era_index;
+DROP INDEX maker.vow_ash_header_id_index;
+DROP INDEX maker.vow_wait_header_id_index;
+DROP INDEX maker.vow_dump_header_id_index;
+DROP INDEX maker.vow_sump_header_id_index;
+DROP INDEX maker.vow_bump_header_id_index;
+DROP INDEX maker.vow_hump_header_id_index;
 
 DROP TABLE maker.vow_vat;
 DROP TABLE maker.vow_flapper;

--- a/db/migrations/20190214200343_create_jug_storage_tables.sql
+++ b/db/migrations/20190214200343_create_jug_storage_tables.sql
@@ -38,6 +38,9 @@ CREATE TABLE maker.jug_vat
     UNIQUE (diff_id, header_id, vat)
 );
 
+CREATE INDEX jug_vat_header_id_index
+    ON maker.jug_vat (header_id);
+
 CREATE TABLE maker.jug_vow
 (
     id        SERIAL PRIMARY KEY,
@@ -46,6 +49,9 @@ CREATE TABLE maker.jug_vow
     vow       TEXT,
     UNIQUE (diff_id, header_id, vow)
 );
+
+CREATE INDEX jug_vow_header_id_index
+    ON maker.jug_vow (header_id);
 
 CREATE TABLE maker.jug_base
 (
@@ -56,11 +62,17 @@ CREATE TABLE maker.jug_base
     UNIQUE (diff_id, header_id, base)
 );
 
+CREATE INDEX jug_base_header_id_index
+    ON maker.jug_base (header_id);
+
 -- +goose Down
 DROP INDEX maker.jug_ilk_rho_header_id_index;
 DROP INDEX maker.jug_ilk_rho_ilk_index;
 DROP INDEX maker.jug_ilk_duty_header_id_index;
 DROP INDEX maker.jug_ilk_duty_ilk_index;
+DROP INDEX maker.jug_vat_header_id_index;
+DROP INDEX maker.jug_vow_header_id_index;
+DROP INDEX maker.jug_base_header_id_index;
 
 DROP TABLE maker.jug_ilk_rho;
 DROP TABLE maker.jug_ilk_duty;

--- a/db/migrations/20190215160236_create_cat_storage_tables.sql
+++ b/db/migrations/20190215160236_create_cat_storage_tables.sql
@@ -8,6 +8,9 @@ CREATE TABLE maker.cat_live
     UNIQUE (diff_id, header_id, live)
 );
 
+CREATE INDEX cat_live_header_id_index
+    ON maker.cat_live (header_id);
+
 CREATE TABLE maker.cat_vat
 (
     id        SERIAL PRIMARY KEY,
@@ -17,6 +20,9 @@ CREATE TABLE maker.cat_vat
     UNIQUE (diff_id, header_id, vat)
 );
 
+CREATE INDEX cat_vat_header_id_index
+    ON maker.cat_vat (header_id);
+
 CREATE TABLE maker.cat_vow
 (
     id        SERIAL PRIMARY KEY,
@@ -25,6 +31,9 @@ CREATE TABLE maker.cat_vow
     vow       TEXT,
     UNIQUE (diff_id, header_id, vow)
 );
+
+CREATE INDEX cat_vow_header_id_index
+    ON maker.cat_vow (header_id);
 
 CREATE TABLE maker.cat_ilk_flip
 (
@@ -73,6 +82,9 @@ CREATE INDEX cat_ilk_lump_ilk_index
 
 
 -- +goose Down
+DROP INDEX maker.cat_live_header_id_index;
+DROP INDEX maker.cat_vat_header_id_index;
+DROP INDEX maker.cat_vow_header_id_index;
 DROP INDEX maker.cat_ilk_flip_header_id_index;
 DROP INDEX maker.cat_ilk_flip_ilk_index;
 DROP INDEX maker.cat_ilk_chop_header_id_index;

--- a/db/migrations/20190215160237_create_spot_storage_tables.sql
+++ b/db/migrations/20190215160237_create_spot_storage_tables.sql
@@ -39,6 +39,9 @@ CREATE TABLE maker.spot_vat
     UNIQUE (diff_id, header_id, vat)
 );
 
+CREATE INDEX spot_vat_header_id_index
+    ON maker.spot_vat (header_id);
+
 CREATE TABLE maker.spot_par
 (
     id        SERIAL PRIMARY KEY,
@@ -48,12 +51,17 @@ CREATE TABLE maker.spot_par
     UNIQUE (diff_id, header_id, par)
 );
 
+CREATE INDEX spot_par_header_id_index
+    ON maker.spot_par (header_id);
+
 -- +goose Down
 -- SQL in this section is executed when the migration is rolled back.
 DROP INDEX maker.spot_ilk_pip_header_id_index;
 DROP INDEX maker.spot_ilk_pip_ilk_index;
 DROP INDEX maker.spot_ilk_mat_header_id_index;
 DROP INDEX maker.spot_ilk_mat_ilk_index;
+DROP INDEX maker.spot_vat_header_id_index;
+DROP INDEX maker.spot_par_header_id_index;
 
 DROP TABLE maker.spot_par;
 DROP TABLE maker.spot_vat;

--- a/db/migrations/20190314092030_create_vow_fess.sql
+++ b/db/migrations/20190314092030_create_vow_fess.sql
@@ -10,8 +10,11 @@ CREATE TABLE maker.vow_fess
 
 CREATE INDEX vow_fess_header_index
     ON maker.vow_fess (header_id);
+CREATE INDEX vow_fess_log_index
+    ON maker.vow_fess (log_id);
 
 
 -- +goose Down
+DROP INDEX maker.vow_fess_log_index;
 DROP INDEX maker.vow_fess_header_index;
 DROP TABLE maker.vow_fess;

--- a/db/migrations/20190318000000_create_spot_file.sql
+++ b/db/migrations/20190318000000_create_spot_file.sql
@@ -12,7 +12,8 @@ CREATE TABLE maker.spot_file_mat
 
 CREATE INDEX spot_file_mat_header_index
     ON maker.spot_file_mat (header_id);
-
+CREATE INDEX spot_file_mat_log_index
+    ON maker.spot_file_mat (log_id);
 CREATE INDEX spot_file_mat_ilk_index
     ON maker.spot_file_mat (ilk_id);
 
@@ -29,15 +30,18 @@ CREATE TABLE maker.spot_file_pip
 
 CREATE INDEX spot_file_pip_ilk_index
     ON maker.spot_file_pip (ilk_id);
-
+CREATE INDEX spot_file_pip_log_index
+    ON maker.spot_file_pip (log_id);
 CREATE INDEX spot_file_pip_header_index
     ON maker.spot_file_pip (header_id);
 
 
 -- +goose Down
 DROP INDEX maker.spot_file_mat_header_index;
+DROP INDEX maker.spot_file_mat_log_index;
 DROP INDEX maker.spot_file_mat_ilk_index;
 DROP INDEX maker.spot_file_pip_header_index;
+DROP INDEX maker.spot_file_pip_log_index;
 DROP INDEX maker.spot_file_pip_ilk_index;
 
 DROP TABLE maker.spot_file_mat;

--- a/db/migrations/20190411132246_create_spot_poke_table.sql
+++ b/db/migrations/20190411132246_create_spot_poke_table.sql
@@ -13,7 +13,8 @@ CREATE TABLE maker.spot_poke
 
 CREATE INDEX spot_poke_header_index
     ON maker.spot_poke (header_id);
-
+CREATE INDEX spot_poke_log_index
+    ON maker.spot_poke (log_id);
 CREATE INDEX spot_poke_ilk_index
     ON maker.spot_poke (ilk_id);
 
@@ -21,6 +22,7 @@ CREATE INDEX spot_poke_ilk_index
 -- +goose Down
 -- SQL in this section is executed when the migration is rolled back.
 DROP INDEX maker.spot_poke_header_index;
+DROP INDEX maker.spot_poke_log_index;
 DROP INDEX maker.spot_poke_ilk_index;
 
 DROP TABLE maker.spot_poke;

--- a/db/migrations/20190516193142_create_vow_file.sql
+++ b/db/migrations/20190516193142_create_vow_file.sql
@@ -11,9 +11,12 @@ CREATE TABLE maker.vow_file
 
 CREATE INDEX vow_file_header_index
     ON maker.vow_file (header_id);
+CREATE INDEX vow_file_log_index
+    ON maker.vow_file (log_id);
 
 
 -- +goose Down
+DROP INDEX maker.vow_file_log_index;
 DROP INDEX maker.vow_file_header_index;
 
 DROP TABLE maker.vow_file;

--- a/db/migrations/20190530184028_create_vat_suck.sql
+++ b/db/migrations/20190530184028_create_vat_suck.sql
@@ -12,8 +12,11 @@ CREATE TABLE maker.vat_suck
 
 CREATE INDEX vat_suck_header_index
     ON maker.vat_suck (header_id);
+CREATE INDEX vat_suck_log_index
+    ON maker.vat_suck (log_id);
 
 
 -- +goose Down
+DROP INDEX maker.vat_suck_log_index;
 DROP INDEX maker.vat_suck_header_index;
 DROP TABLE maker.vat_suck;

--- a/db/migrations/20190603061542_create_vat_fork.sql
+++ b/db/migrations/20190603061542_create_vat_fork.sql
@@ -14,13 +14,15 @@ CREATE TABLE maker.vat_fork
 
 CREATE INDEX vat_fork_header_index
     ON maker.vat_fork (header_id);
-
+CREATE INDEX vat_fork_log_index
+    ON maker.vat_fork (log_id);
 CREATE INDEX vat_fork_ilk_index
     ON maker.vat_fork (ilk_id);
 
 
 -- +goose Down
 DROP INDEX maker.vat_fork_header_index;
+DROP INDEX maker.vat_fork_log_index;
 DROP INDEX maker.vat_fork_ilk_index;
 
 DROP TABLE maker.vat_fork;

--- a/db/migrations/20190604105839_create_jug_init.sql
+++ b/db/migrations/20190604105839_create_jug_init.sql
@@ -8,14 +8,16 @@ CREATE TABLE maker.jug_init
     UNIQUE (header_id, log_id)
 );
 
+CREATE INDEX jug_init_log_index
+    ON maker.jug_init (log_id);
 CREATE INDEX jug_init_header_index
     ON maker.jug_init (header_id);
-
 CREATE INDEX jug_init_ilk_index
     ON maker.jug_init (ilk_id);
 
 
 -- +goose Down
+DROP INDEX maker.jug_init_log_index;
 DROP INDEX maker.jug_init_header_index;
 DROP INDEX maker.jug_init_ilk_index;
 

--- a/db/migrations/20190702113043_create_yank.sql
+++ b/db/migrations/20190702113043_create_yank.sql
@@ -12,9 +12,12 @@ CREATE TABLE maker.yank
 
 CREATE INDEX yank_header_index
     ON maker.yank (header_id);
-
+CREATE INDEX yank_log_index
+    ON maker.yank (log_id);
 CREATE INDEX yank_bid_id_index
     on maker.yank (bid_id);
+CREATE INDEX yank_address_index
+    on maker.yank (address_id);
 
 ALTER TABLE public.checked_headers
     ADD COLUMN yank INTEGER NOT NULL DEFAULT 0;
@@ -22,6 +25,8 @@ ALTER TABLE public.checked_headers
 -- +goose Down
 -- SQL in this section is executed when the migration is rolled back.
 DROP INDEX maker.yank_header_index;
+DROP INDEX maker.yank_log_index;
 DROP INDEX maker.yank_bid_id_index;
+DROP INDEX maker.yank_address_index;
 
 DROP TABLE maker.yank;

--- a/db/migrations/20190702230607_create_tick.sql
+++ b/db/migrations/20190702230607_create_tick.sql
@@ -11,12 +11,16 @@ CREATE TABLE maker.tick
 
 CREATE INDEX tick_header_index
     ON maker.tick (header_id);
-
-
+CREATE INDEX tick_log_index
+    ON maker.tick (log_id);
 CREATE INDEX tick_bid_id_index
     ON maker.tick (bid_id);
+CREATE INDEX tick_address_index
+    ON maker.tick (address_id);
 
 -- +goose Down
 DROP INDEX maker.tick_header_index;
+DROP INDEX maker.tick_log_index;
 DROP INDEX maker.tick_bid_id_index;
+DROP INDEX maker.tick_address_index;
 DROP TABLE maker.tick;

--- a/db/migrations/20190709160237_create_flip_storage_tables.sql
+++ b/db/migrations/20190709160237_create_flip_storage_tables.sql
@@ -11,9 +11,11 @@ CREATE TABLE maker.flip_bid_bid
     UNIQUE (diff_id, header_id, bid_id, address_id, bid)
 );
 
+CREATE INDEX flip_bid_bid_header_id_index
+    ON maker.flip_bid_bid (header_id);
 CREATE INDEX flip_bid_bid_bid_id_index
     ON maker.flip_bid_bid (bid_id);
-CREATE INDEX flip_bid_bid_address_id_index
+CREATE INDEX flip_bid_bid_address_index
     ON maker.flip_bid_bid (address_id);
 
 CREATE TABLE maker.flip_bid_lot
@@ -27,9 +29,11 @@ CREATE TABLE maker.flip_bid_lot
     UNIQUE (diff_id, header_id, bid_id, address_id, lot)
 );
 
+CREATE INDEX flip_bid_lot_header_id_index
+    ON maker.flip_bid_lot (header_id);
 CREATE INDEX flip_bid_lot_bid_id_index
     ON maker.flip_bid_lot (bid_id);
-CREATE INDEX flip_bid_lot_address_id_index
+CREATE INDEX flip_bid_lot_address_index
     ON maker.flip_bid_lot (address_id);
 
 CREATE TABLE maker.flip_bid_guy
@@ -43,9 +47,11 @@ CREATE TABLE maker.flip_bid_guy
     UNIQUE (diff_id, header_id, bid_id, address_id, guy)
 );
 
+CREATE INDEX flip_bid_guy_header_id_index
+    ON maker.flip_bid_guy (header_id);
 CREATE INDEX flip_bid_guy_bid_id_index
     ON maker.flip_bid_guy (bid_id);
-CREATE INDEX flip_bid_guy_address_id_index
+CREATE INDEX flip_bid_guy_address_index
     ON maker.flip_bid_guy (address_id);
 
 CREATE TABLE maker.flip_bid_tic
@@ -59,9 +65,11 @@ CREATE TABLE maker.flip_bid_tic
     UNIQUE (diff_id, header_id, bid_id, address_id, tic)
 );
 
+CREATE INDEX flip_bid_tic_header_id_index
+    ON maker.flip_bid_tic (header_id);
 CREATE INDEX flip_bid_tic_bid_id_index
     ON maker.flip_bid_tic (bid_id);
-CREATE INDEX flip_bid_tic_address_id_index
+CREATE INDEX flip_bid_tic_address_index
     ON maker.flip_bid_tic (address_id);
 
 CREATE TABLE maker.flip_bid_end
@@ -75,9 +83,11 @@ CREATE TABLE maker.flip_bid_end
     UNIQUE (diff_id, header_id, bid_id, address_id, "end")
 );
 
+CREATE INDEX flip_bid_end_header_id_index
+    ON maker.flip_bid_end (header_id);
 CREATE INDEX flip_bid_end_bid_id_index
     ON maker.flip_bid_end (bid_id);
-CREATE INDEX flip_bid_end_address_id_index
+CREATE INDEX flip_bid_end_address_index
     ON maker.flip_bid_end (address_id);
 
 CREATE TABLE maker.flip_bid_usr
@@ -91,9 +101,11 @@ CREATE TABLE maker.flip_bid_usr
     UNIQUE (diff_id, header_id, bid_id, address_id, usr)
 );
 
+CREATE INDEX flip_bid_usr_header_id_index
+    ON maker.flip_bid_usr (header_id);
 CREATE INDEX flip_bid_usr_bid_id_index
     ON maker.flip_bid_usr (bid_id);
-CREATE INDEX flip_bid_usr_address_id_index
+CREATE INDEX flip_bid_usr_address_index
     ON maker.flip_bid_usr (address_id);
 
 CREATE TABLE maker.flip_bid_gal
@@ -107,9 +119,11 @@ CREATE TABLE maker.flip_bid_gal
     UNIQUE (diff_id, header_id, bid_id, address_id, gal)
 );
 
+CREATE INDEX flip_bid_gal_header_id_index
+    ON maker.flip_bid_gal (header_id);
 CREATE INDEX flip_bid_gal_bid_id_index
     ON maker.flip_bid_gal (bid_id);
-CREATE INDEX flip_bid_gal_address_id_index
+CREATE INDEX flip_bid_gal_address_index
     ON maker.flip_bid_gal (address_id);
 
 CREATE TABLE maker.flip_bid_tab
@@ -123,9 +137,11 @@ CREATE TABLE maker.flip_bid_tab
     UNIQUE (diff_id, header_id, bid_id, address_id, tab)
 );
 
+CREATE INDEX flip_bid_tab_header_id_index
+    ON maker.flip_bid_tab (header_id);
 CREATE INDEX flip_bid_tab_bid_id_index
     ON maker.flip_bid_tab (bid_id);
-CREATE INDEX flip_bid_tab_address_id_index
+CREATE INDEX flip_bid_tab_address_index
     ON maker.flip_bid_tab (address_id);
 
 CREATE TABLE maker.flip_vat
@@ -138,6 +154,11 @@ CREATE TABLE maker.flip_vat
     UNIQUE (diff_id, header_id, address_id, vat)
 );
 
+CREATE INDEX flip_vat_header_id_index
+    ON maker.flip_vat (header_id);
+CREATE INDEX flip_vat_address_index
+    ON maker.flip_vat (address_id);
+
 CREATE TABLE maker.flip_ilk
 (
     id         SERIAL PRIMARY KEY,
@@ -148,8 +169,12 @@ CREATE TABLE maker.flip_ilk
     UNIQUE (diff_id, header_id, address_id, ilk_id)
 );
 
+CREATE INDEX flip_ilk_header_id_index
+    ON maker.flip_ilk (header_id);
 CREATE INDEX flip_ilk_ilk_id_index
     ON maker.flip_ilk (ilk_id);
+CREATE INDEX flip_ilk_address_index
+    ON maker.flip_ilk (address_id);
 
 CREATE TABLE maker.flip_beg
 (
@@ -161,6 +186,11 @@ CREATE TABLE maker.flip_beg
     UNIQUE (diff_id, header_id, address_id, beg)
 );
 
+CREATE INDEX flip_beg_header_id_index
+    ON maker.flip_beg (header_id);
+CREATE INDEX flip_beg_address_index
+    ON maker.flip_beg (address_id);
+
 CREATE TABLE maker.flip_ttl
 (
     id         SERIAL PRIMARY KEY,
@@ -170,6 +200,11 @@ CREATE TABLE maker.flip_ttl
     ttl        NUMERIC NOT NULL,
     UNIQUE (diff_id, header_id, address_id, ttl)
 );
+
+CREATE INDEX flip_ttl_header_id_index
+    ON maker.flip_ttl (header_id);
+CREATE INDEX flip_ttl_address_index
+    ON maker.flip_ttl (address_id);
 
 CREATE TABLE maker.flip_tau
 (
@@ -181,6 +216,11 @@ CREATE TABLE maker.flip_tau
     UNIQUE (diff_id, header_id, address_id, tau)
 );
 
+CREATE INDEX flip_tau_header_id_index
+    ON maker.flip_tau (header_id);
+CREATE INDEX flip_tau_address_index
+    ON maker.flip_tau (address_id);
+
 CREATE TABLE maker.flip_kicks
 (
     id         SERIAL PRIMARY KEY,
@@ -191,9 +231,9 @@ CREATE TABLE maker.flip_kicks
     UNIQUE (diff_id, header_id, address_id, kicks)
 );
 
-CREATE INDEX flip_kicks_kicks_index
-    ON maker.flip_kicks (kicks);
-CREATE INDEX flip_kicks_address_id_index
+CREATE INDEX flip_kicks_header_id_index
+    ON maker.flip_kicks (header_id);
+CREATE INDEX flip_kicks_address_index
     ON maker.flip_kicks (address_id);
 
 -- prevent naming conflict with maker.flip_kick in postgraphile
@@ -201,25 +241,43 @@ COMMENT ON TABLE maker.flip_kicks IS E'@name flipKicksStorage';
 
 -- +goose Down
 -- SQL in this section is executed when the migration is rolled back.
-DROP INDEX maker.flip_kicks_address_id_index;
-DROP INDEX maker.flip_kicks_kicks_index;
+DROP INDEX maker.flip_kicks_address_index;
+DROP INDEX maker.flip_kicks_header_id_index;
+DROP INDEX maker.flip_tau_address_index;
+DROP INDEX maker.flip_tau_header_id_index;
+DROP INDEX maker.flip_ttl_address_index;
+DROP INDEX maker.flip_ttl_header_id_index;
+DROP INDEX maker.flip_beg_address_index;
+DROP INDEX maker.flip_beg_header_id_index;
+DROP INDEX maker.flip_ilk_address_index;
 DROP INDEX maker.flip_ilk_ilk_id_index;
-DROP INDEX maker.flip_bid_tab_address_id_index;
+DROP INDEX maker.flip_ilk_header_id_index;
+DROP INDEX maker.flip_vat_address_index;
+DROP INDEX maker.flip_vat_header_id_index;
+DROP INDEX maker.flip_bid_tab_address_index;
 DROP INDEX maker.flip_bid_tab_bid_id_index;
-DROP INDEX maker.flip_bid_gal_address_id_index;
+DROP INDEX maker.flip_bid_tab_header_id_index;
+DROP INDEX maker.flip_bid_gal_address_index;
 DROP INDEX maker.flip_bid_gal_bid_id_index;
-DROP INDEX maker.flip_bid_usr_address_id_index;
+DROP INDEX maker.flip_bid_gal_header_id_index;
+DROP INDEX maker.flip_bid_usr_address_index;
 DROP INDEX maker.flip_bid_usr_bid_id_index;
-DROP INDEX maker.flip_bid_end_address_id_index;
+DROP INDEX maker.flip_bid_usr_header_id_index;
+DROP INDEX maker.flip_bid_end_address_index;
 DROP INDEX maker.flip_bid_end_bid_id_index;
-DROP INDEX maker.flip_bid_tic_address_id_index;
+DROP INDEX maker.flip_bid_end_header_id_index;
+DROP INDEX maker.flip_bid_tic_address_index;
 DROP INDEX maker.flip_bid_tic_bid_id_index;
-DROP INDEX maker.flip_bid_guy_address_id_index;
+DROP INDEX maker.flip_bid_tic_header_id_index;
+DROP INDEX maker.flip_bid_guy_address_index;
 DROP INDEX maker.flip_bid_guy_bid_id_index;
-DROP INDEX maker.flip_bid_lot_address_id_index;
+DROP INDEX maker.flip_bid_guy_header_id_index;
+DROP INDEX maker.flip_bid_lot_address_index;
 DROP INDEX maker.flip_bid_lot_bid_id_index;
-DROP INDEX maker.flip_bid_bid_address_id_index;
+DROP INDEX maker.flip_bid_lot_header_id_index;
+DROP INDEX maker.flip_bid_bid_address_index;
 DROP INDEX maker.flip_bid_bid_bid_id_index;
+DROP INDEX maker.flip_bid_bid_header_id_index;
 
 DROP TABLE maker.flip_kicks;
 DROP TABLE maker.flip_tau;

--- a/db/migrations/20190711084519_create_flap_storage_tables.sql
+++ b/db/migrations/20190711084519_create_flap_storage_tables.sql
@@ -10,8 +10,9 @@ CREATE TABLE maker.flap_bid_bid
     bid        NUMERIC NOT NULL,
     UNIQUE (diff_id, header_id, address_id, bid_id, bid)
 );
+CREATE INDEX flap_bid_bid_header_id_index ON maker.flap_bid_bid (header_id);
 CREATE INDEX flap_bid_bid_bid_id_index ON maker.flap_bid_bid (bid_id);
-CREATE INDEX flap_bid_bid_address_id_index ON maker.flap_bid_bid (address_id);
+CREATE INDEX flap_bid_bid_address_index ON maker.flap_bid_bid (address_id);
 
 CREATE TABLE maker.flap_bid_lot
 (
@@ -23,8 +24,9 @@ CREATE TABLE maker.flap_bid_lot
     lot        NUMERIC NOT NULL,
     UNIQUE (diff_id, header_id, address_id, bid_id, lot)
 );
+CREATE INDEX flap_bid_lot_header_id_index ON maker.flap_bid_lot (header_id);
 CREATE INDEX flap_bid_lot_bid_id_index ON maker.flap_bid_lot (bid_id);
-CREATE INDEX flap_bid_lot_bid_address_id_index ON maker.flap_bid_lot (address_id);
+CREATE INDEX flap_bid_lot_bid_address_index ON maker.flap_bid_lot (address_id);
 
 CREATE TABLE maker.flap_bid_guy
 (
@@ -36,8 +38,9 @@ CREATE TABLE maker.flap_bid_guy
     guy        TEXT    NOT NULL,
     UNIQUE (diff_id, header_id, address_id, bid_id, guy)
 );
+CREATE INDEX flap_bid_guy_header_id_index ON maker.flap_bid_guy (header_id);
 CREATE INDEX flap_bid_guy_bid_id_index ON maker.flap_bid_guy (bid_id);
-CREATE INDEX flap_bid_guy_bid_address_id_index ON maker.flap_bid_guy (address_id);
+CREATE INDEX flap_bid_guy_bid_address_index ON maker.flap_bid_guy (address_id);
 
 CREATE TABLE maker.flap_bid_tic
 (
@@ -49,8 +52,9 @@ CREATE TABLE maker.flap_bid_tic
     tic        BIGINT  NOT NULL,
     UNIQUE (diff_id, header_id, address_id, bid_id, tic)
 );
+CREATE INDEX flap_bid_tic_header_id_index ON maker.flap_bid_tic (header_id);
 CREATE INDEX flap_bid_tic_bid_id_index ON maker.flap_bid_tic (bid_id);
-CREATE INDEX flap_bid_tic_bid_address_id_index ON maker.flap_bid_tic (address_id);
+CREATE INDEX flap_bid_tic_bid_address_index ON maker.flap_bid_tic (address_id);
 
 CREATE TABLE maker.flap_bid_end
 (
@@ -62,8 +66,9 @@ CREATE TABLE maker.flap_bid_end
     "end"      BIGINT  NOT NULL,
     UNIQUE (diff_id, header_id, address_id, bid_id, "end")
 );
+CREATE INDEX flap_bid_end_header_id_index ON maker.flap_bid_end (header_id);
 CREATE INDEX flap_bid_end_bid_id_index ON maker.flap_bid_end (bid_id);
-CREATE INDEX flap_bid_end_bid_address_id_index ON maker.flap_bid_end (address_id);
+CREATE INDEX flap_bid_end_bid_address_index ON maker.flap_bid_end (address_id);
 
 CREATE TABLE maker.flap_vat
 (
@@ -75,6 +80,11 @@ CREATE TABLE maker.flap_vat
     UNIQUE (diff_id, header_id, address_id, vat)
 );
 
+CREATE INDEX flap_vat_header_id_index
+    ON maker.flap_vat (header_id);
+CREATE INDEX flap_vat_address_index
+    ON maker.flap_vat (address_id);
+
 CREATE TABLE maker.flap_gem
 (
     id         SERIAL PRIMARY KEY,
@@ -84,6 +94,11 @@ CREATE TABLE maker.flap_gem
     gem        TEXT    NOT NULL,
     UNIQUE (diff_id, header_id, address_id, gem)
 );
+
+CREATE INDEX flap_gem_header_id_index
+    ON maker.flap_gem (header_id);
+CREATE INDEX flap_gem_address_index
+    ON maker.flap_gem (address_id);
 
 CREATE TABLE maker.flap_beg
 (
@@ -95,6 +110,11 @@ CREATE TABLE maker.flap_beg
     UNIQUE (diff_id, header_id, address_id, beg)
 );
 
+CREATE INDEX flap_beg_header_id_index
+    ON maker.flap_beg (header_id);
+CREATE INDEX flap_beg_address_index
+    ON maker.flap_beg (address_id);
+
 CREATE TABLE maker.flap_ttl
 (
     id         SERIAL PRIMARY KEY,
@@ -104,6 +124,11 @@ CREATE TABLE maker.flap_ttl
     ttl        INT     NOT NULL,
     UNIQUE (diff_id, header_id, address_id, ttl)
 );
+
+CREATE INDEX flap_ttl_header_id_index
+    ON maker.flap_ttl (header_id);
+CREATE INDEX flap_ttl_address_index
+    ON maker.flap_ttl (address_id);
 
 CREATE TABLE maker.flap_tau
 (
@@ -115,6 +140,11 @@ CREATE TABLE maker.flap_tau
     UNIQUE (diff_id, header_id, address_id, tau)
 );
 
+CREATE INDEX flap_tau_header_id_index
+    ON maker.flap_tau (header_id);
+CREATE INDEX flap_tau_address_index
+    ON maker.flap_tau (address_id);
+
 CREATE TABLE maker.flap_kicks
 (
     id         SERIAL PRIMARY KEY,
@@ -125,8 +155,8 @@ CREATE TABLE maker.flap_kicks
     UNIQUE (diff_id, header_id, address_id, kicks)
 );
 
-CREATE INDEX flap_kicks_kicks_index ON maker.flap_kicks (kicks);
-CREATE INDEX flap_kicks_address_id_index ON maker.flap_kicks (address_id);
+CREATE INDEX flap_kicks_header_id_index ON maker.flap_kicks (header_id);
+CREATE INDEX flap_kicks_address_index ON maker.flap_kicks (address_id);
 
 -- prevent naming conflict with maker.flap_kick in postgraphile
 COMMENT ON TABLE maker.flap_kicks IS E'@name flapKicksStorage';
@@ -141,20 +171,42 @@ CREATE TABLE maker.flap_live
     UNIQUE (diff_id, header_id, address_id, live)
 );
 
+CREATE INDEX flap_live_header_id_index
+    ON maker.flap_live (header_id);
+CREATE INDEX flap_live_address_index
+    ON maker.flap_live (address_id);
+
 -- +goose Down
 -- SQL in this section is executed when the migration is rolled back.
-DROP INDEX maker.flap_kicks_address_id_index;
-DROP INDEX maker.flap_kicks_kicks_index;
-DROP INDEX maker.flap_bid_bid_address_id_index;
+DROP INDEX maker.flap_live_address_index;
+DROP INDEX maker.flap_live_header_id_index;
+DROP INDEX maker.flap_kicks_address_index;
+DROP INDEX maker.flap_kicks_header_id_index;
+DROP INDEX maker.flap_tau_address_index;
+DROP INDEX maker.flap_tau_header_id_index;
+DROP INDEX maker.flap_ttl_address_index;
+DROP INDEX maker.flap_ttl_header_id_index;
+DROP INDEX maker.flap_beg_address_index;
+DROP INDEX maker.flap_beg_header_id_index;
+DROP INDEX maker.flap_gem_address_index;
+DROP INDEX maker.flap_gem_header_id_index;
+DROP INDEX maker.flap_vat_address_index;
+DROP INDEX maker.flap_vat_header_id_index;
+DROP INDEX maker.flap_bid_bid_address_index;
 DROP INDEX maker.flap_bid_bid_bid_id_index;
-DROP INDEX maker.flap_bid_lot_bid_address_id_index;
+DROP INDEX maker.flap_bid_bid_header_id_index;
+DROP INDEX maker.flap_bid_lot_bid_address_index;
 DROP INDEX maker.flap_bid_lot_bid_id_index;
-DROP INDEX maker.flap_bid_guy_bid_address_id_index;
+DROP INDEX maker.flap_bid_lot_header_id_index;
+DROP INDEX maker.flap_bid_guy_bid_address_index;
 DROP INDEX maker.flap_bid_guy_bid_id_index;
-DROP INDEX maker.flap_bid_tic_bid_address_id_index;
+DROP INDEX maker.flap_bid_guy_header_id_index;
+DROP INDEX maker.flap_bid_tic_bid_address_index;
 DROP INDEX maker.flap_bid_tic_bid_id_index;
-DROP INDEX maker.flap_bid_end_bid_address_id_index;
+DROP INDEX maker.flap_bid_tic_header_id_index;
+DROP INDEX maker.flap_bid_end_bid_address_index;
 DROP INDEX maker.flap_bid_end_bid_id_index;
+DROP INDEX maker.flap_bid_end_header_id_index;
 
 DROP TABLE maker.flap_bid_bid;
 DROP TABLE maker.flap_bid_lot;

--- a/db/migrations/20190711091453_create_flip_table.sql
+++ b/db/migrations/20190711091453_create_flip_table.sql
@@ -18,6 +18,9 @@ CREATE TABLE maker.flip
     UNIQUE (block_number, bid_id)
 );
 
+CREATE INDEX flip_address_index
+    ON maker.flip (address_id);
+
 CREATE FUNCTION get_latest_flip_bid_guy(bid_id numeric) RETURNS TEXT AS
 $$
 SELECT guy
@@ -28,6 +31,9 @@ ORDER BY block_number DESC
 LIMIT 1
 $$
     LANGUAGE sql;
+
+COMMENT ON FUNCTION get_latest_flip_bid_guy
+    IS E'@omit';
 
 CREATE FUNCTION get_latest_flip_bid_tic(bid_id numeric) RETURNS BIGINT AS
 $$
@@ -40,6 +46,9 @@ LIMIT 1
 $$
     LANGUAGE sql;
 
+COMMENT ON FUNCTION get_latest_flip_bid_tic
+    IS E'@omit';
+
 CREATE FUNCTION get_latest_flip_bid_end(bid_id numeric) RETURNS BIGINT AS
 $$
 SELECT "end"
@@ -50,6 +59,9 @@ ORDER BY block_number DESC
 LIMIT 1
 $$
     LANGUAGE sql;
+
+COMMENT ON FUNCTION get_latest_flip_bid_end
+    IS E'@omit';
 
 CREATE FUNCTION get_latest_flip_bid_lot(bid_id numeric) RETURNS NUMERIC AS
 $$
@@ -62,6 +74,9 @@ LIMIT 1
 $$
     LANGUAGE sql;
 
+COMMENT ON FUNCTION get_latest_flip_bid_lot
+    IS E'@omit';
+
 CREATE FUNCTION get_latest_flip_bid_bid(bid_id numeric) RETURNS NUMERIC AS
 $$
 SELECT bid
@@ -72,6 +87,9 @@ ORDER BY block_number DESC
 LIMIT 1
 $$
     LANGUAGE sql;
+
+COMMENT ON FUNCTION get_latest_flip_bid_bid
+    IS E'@omit';
 
 CREATE FUNCTION get_latest_flip_bid_gal(bid_id numeric) RETURNS TEXT AS
 $$
@@ -84,6 +102,9 @@ LIMIT 1
 $$
     LANGUAGE sql;
 
+COMMENT ON FUNCTION get_latest_flip_bid_gal
+    IS E'@omit';
+
 CREATE FUNCTION get_latest_flip_bid_tab(bid_id numeric) RETURNS NUMERIC AS
 $$
 SELECT tab
@@ -94,6 +115,9 @@ ORDER BY block_number DESC
 LIMIT 1
 $$
     LANGUAGE sql;
+
+COMMENT ON FUNCTION get_latest_flip_bid_tab
+    IS E'@omit';
 
 
 -- +goose StatementBegin
@@ -449,4 +473,6 @@ DROP FUNCTION get_latest_flip_bid_end(numeric);
 DROP FUNCTION get_latest_flip_bid_lot(numeric);
 DROP FUNCTION get_latest_flip_bid_gal(numeric);
 DROP FUNCTION get_latest_flip_bid_tab(numeric);
+
+DROP INDEX maker.flip_address_index;
 DROP TABLE maker.flip;

--- a/db/migrations/20190711091456_create_flop_storage_tables.sql
+++ b/db/migrations/20190711091456_create_flop_storage_tables.sql
@@ -11,9 +11,11 @@ CREATE TABLE maker.flop_bid_bid
     UNIQUE (diff_id, header_id, bid_id, address_id, bid)
 );
 
+CREATE INDEX flop_bid_bid_header_id_index
+    ON maker.flop_bid_bid (header_id);
 CREATE INDEX flop_bid_bid_bid_id_index
     ON maker.flop_bid_bid (bid_id);
-CREATE INDEX flop_bid_bid_address_id_index
+CREATE INDEX flop_bid_bid_address_index
     ON maker.flop_bid_bid (address_id);
 
 CREATE TABLE maker.flop_bid_lot
@@ -27,9 +29,11 @@ CREATE TABLE maker.flop_bid_lot
     UNIQUE (diff_id, header_id, bid_id, address_id, lot)
 );
 
+CREATE INDEX flop_bid_lot_header_id_index
+    ON maker.flop_bid_lot (header_id);
 CREATE INDEX flop_bid_lot_bid_id_index
     ON maker.flop_bid_lot (bid_id);
-CREATE INDEX flop_bid_lot_bid_address_id_index
+CREATE INDEX flop_bid_lot_bid_address_index
     ON maker.flop_bid_lot (address_id);
 
 CREATE TABLE maker.flop_bid_guy
@@ -43,9 +47,11 @@ CREATE TABLE maker.flop_bid_guy
     UNIQUE (diff_id, header_id, bid_id, address_id, guy)
 );
 
+CREATE INDEX flop_bid_guy_header_id_index
+    ON maker.flop_bid_guy (header_id);
 CREATE INDEX flop_bid_guy_bid_id_index
     ON maker.flop_bid_guy (bid_id);
-CREATE INDEX flop_bid_guy_bid_address_id_index
+CREATE INDEX flop_bid_guy_bid_address_index
     ON maker.flop_bid_guy (address_id);
 
 CREATE TABLE maker.flop_bid_tic
@@ -59,9 +65,11 @@ CREATE TABLE maker.flop_bid_tic
     UNIQUE (diff_id, header_id, bid_id, address_id, tic)
 );
 
+CREATE INDEX flop_bid_tic_header_id_index
+    ON maker.flop_bid_tic (header_id);
 CREATE INDEX flop_bid_tic_bid_id_index
     ON maker.flop_bid_tic (bid_id);
-CREATE INDEX flop_bid_tic_bid_address_id_index
+CREATE INDEX flop_bid_tic_bid_address_index
     ON maker.flop_bid_tic (address_id);
 
 CREATE TABLE maker.flop_bid_end
@@ -75,9 +83,11 @@ CREATE TABLE maker.flop_bid_end
     UNIQUE (diff_id, header_id, bid_id, address_id, "end")
 );
 
+CREATE INDEX flop_bid_end_header_id_index
+    ON maker.flop_bid_end (header_id);
 CREATE INDEX flop_bid_end_bid_id_index
     ON maker.flop_bid_end (bid_id);
-CREATE INDEX flop_bid_end_bid_address_id_index
+CREATE INDEX flop_bid_end_bid_address_index
     ON maker.flop_bid_end (address_id);
 
 CREATE TABLE maker.flop_vat
@@ -90,6 +100,11 @@ CREATE TABLE maker.flop_vat
     UNIQUE (diff_id, header_id, address_id, vat)
 );
 
+CREATE INDEX flop_vat_header_id_index
+    ON maker.flop_vat (header_id);
+CREATE INDEX flop_vat_address_index
+    ON maker.flop_vat (address_id);
+
 CREATE TABLE maker.flop_gem
 (
     id         SERIAL PRIMARY KEY,
@@ -99,6 +114,11 @@ CREATE TABLE maker.flop_gem
     gem        TEXT,
     UNIQUE (diff_id, header_id, address_id, gem)
 );
+
+CREATE INDEX flop_gem_header_id_index
+    ON maker.flop_gem (header_id);
+CREATE INDEX flop_gem_address_index
+    ON maker.flop_gem (address_id);
 
 CREATE TABLE maker.flop_beg
 (
@@ -110,6 +130,11 @@ CREATE TABLE maker.flop_beg
     UNIQUE (diff_id, header_id, address_id, beg)
 );
 
+CREATE INDEX flop_beg_header_id_index
+    ON maker.flop_beg (header_id);
+CREATE INDEX flop_beg_address_index
+    ON maker.flop_beg (address_id);
+
 CREATE TABLE maker.flop_pad
 (
     id         SERIAL PRIMARY KEY,
@@ -119,6 +144,11 @@ CREATE TABLE maker.flop_pad
     pad        NUMERIC NOT NULL,
     UNIQUE (diff_id, header_id, address_id, pad)
 );
+
+CREATE INDEX flop_pad_header_id_index
+    ON maker.flop_pad (header_id);
+CREATE INDEX flop_pad_address_index
+    ON maker.flop_pad (address_id);
 
 CREATE TABLE maker.flop_ttl
 (
@@ -130,6 +160,11 @@ CREATE TABLE maker.flop_ttl
     UNIQUE (diff_id, header_id, address_id, ttl)
 );
 
+CREATE INDEX flop_ttl_header_id_index
+    ON maker.flop_ttl (header_id);
+CREATE INDEX flop_ttl_address_index
+    ON maker.flop_ttl (address_id);
+
 CREATE TABLE maker.flop_tau
 (
     id         SERIAL PRIMARY KEY,
@@ -139,6 +174,11 @@ CREATE TABLE maker.flop_tau
     tau        NUMERIC NOT NULL,
     UNIQUE (diff_id, header_id, address_id, tau)
 );
+
+CREATE INDEX flop_tau_header_id_index
+    ON maker.flop_tau (header_id);
+CREATE INDEX flop_tau_address_index
+    ON maker.flop_tau (address_id);
 
 CREATE TABLE maker.flop_kicks
 (
@@ -150,9 +190,9 @@ CREATE TABLE maker.flop_kicks
     UNIQUE (diff_id, header_id, address_id, kicks)
 );
 
-CREATE INDEX flop_kicks_kicks_index
-    ON maker.flop_kicks (kicks);
-CREATE INDEX flop_kicks_address_id_index
+CREATE INDEX flop_kicks_header_id_index
+    ON maker.flop_kicks (header_id);
+CREATE INDEX flop_kicks_address_index
     ON maker.flop_kicks (address_id);
 
 -- prevent naming conflict with maker.flop_kick in postgraphile
@@ -168,20 +208,44 @@ CREATE TABLE maker.flop_live
     UNIQUE (diff_id, header_id, address_id, live)
 );
 
+CREATE INDEX flop_live_header_id_index
+    ON maker.flop_live (header_id);
+CREATE INDEX flop_live_address_index
+    ON maker.flop_live (address_id);
+
 -- +goose Down
 -- SQL in this section is executed when the migration is rolled back.
-DROP INDEX maker.flop_kicks_address_id_index;
-DROP INDEX maker.flop_kicks_kicks_index;
-DROP INDEX maker.flop_bid_end_bid_address_id_index;
+DROP INDEX maker.flop_live_address_index;
+DROP INDEX maker.flop_live_header_id_index;
+DROP INDEX maker.flop_kicks_address_index;
+DROP INDEX maker.flop_kicks_header_id_index;
+DROP INDEX maker.flop_tau_address_index;
+DROP INDEX maker.flop_tau_header_id_index;
+DROP INDEX maker.flop_ttl_address_index;
+DROP INDEX maker.flop_ttl_header_id_index;
+DROP INDEX maker.flop_pad_address_index;
+DROP INDEX maker.flop_pad_header_id_index;
+DROP INDEX maker.flop_beg_address_index;
+DROP INDEX maker.flop_beg_header_id_index;
+DROP INDEX maker.flop_gem_address_index;
+DROP INDEX maker.flop_gem_header_id_index;
+DROP INDEX maker.flop_vat_address_index;
+DROP INDEX maker.flop_vat_header_id_index;
+DROP INDEX maker.flop_bid_end_bid_address_index;
 DROP INDEX maker.flop_bid_end_bid_id_index;
-DROP INDEX maker.flop_bid_tic_bid_address_id_index;
+DROP INDEX maker.flop_bid_end_header_id_index;
+DROP INDEX maker.flop_bid_tic_bid_address_index;
 DROP INDEX maker.flop_bid_tic_bid_id_index;
-DROP INDEX maker.flop_bid_guy_bid_address_id_index;
+DROP INDEX maker.flop_bid_tic_header_id_index;
+DROP INDEX maker.flop_bid_guy_bid_address_index;
 DROP INDEX maker.flop_bid_guy_bid_id_index;
-DROP INDEX maker.flop_bid_lot_bid_address_id_index;
+DROP INDEX maker.flop_bid_guy_header_id_index;
+DROP INDEX maker.flop_bid_lot_bid_address_index;
 DROP INDEX maker.flop_bid_lot_bid_id_index;
-DROP INDEX maker.flop_bid_bid_address_id_index;
+DROP INDEX maker.flop_bid_lot_header_id_index;
+DROP INDEX maker.flop_bid_bid_address_index;
 DROP INDEX maker.flop_bid_bid_bid_id_index;
+DROP INDEX maker.flop_bid_bid_header_id_index;
 
 DROP TABLE maker.flop_live;
 DROP TABLE maker.flop_kicks;

--- a/db/migrations/20190720000000_create_flop_table_and_triggers.sql
+++ b/db/migrations/20190720000000_create_flop_table_and_triggers.sql
@@ -16,6 +16,9 @@ CREATE TABLE maker.flop
     UNIQUE (block_number, bid_id)
 );
 
+CREATE INDEX flop_address_index
+    ON maker.flop (address_id);
+
 
 CREATE FUNCTION get_latest_flop_bid_bid(bid_id numeric) RETURNS NUMERIC AS
 $$
@@ -27,6 +30,9 @@ ORDER BY block_number DESC
 LIMIT 1
 $$
     LANGUAGE sql;
+
+COMMENT ON FUNCTION get_latest_flop_bid_bid
+    IS E'@omit';
 
 
 CREATE FUNCTION get_latest_flop_bid_guy(bid_id numeric) RETURNS TEXT AS
@@ -40,6 +46,9 @@ LIMIT 1
 $$
     LANGUAGE sql;
 
+COMMENT ON FUNCTION get_latest_flop_bid_guy
+    IS E'@omit';
+
 CREATE FUNCTION get_latest_flop_bid_tic(bid_id numeric) RETURNS BIGINT AS
 $$
 SELECT tic
@@ -50,6 +59,9 @@ ORDER BY block_number DESC
 LIMIT 1
 $$
     LANGUAGE sql;
+
+COMMENT ON FUNCTION get_latest_flop_bid_tic
+    IS E'@omit';
 
 CREATE FUNCTION get_latest_flop_bid_end(bid_id numeric) RETURNS BIGINT AS
 $$
@@ -62,6 +74,9 @@ LIMIT 1
 $$
     LANGUAGE sql;
 
+COMMENT ON FUNCTION get_latest_flop_bid_end
+    IS E'@omit';
+
 CREATE FUNCTION get_latest_flop_bid_lot(bid_id numeric) RETURNS NUMERIC AS
 $$
 SELECT lot
@@ -72,6 +87,9 @@ ORDER BY block_number DESC
 LIMIT 1
 $$
     LANGUAGE sql;
+
+COMMENT ON FUNCTION get_latest_flop_bid_lot
+    IS E'@omit';
 
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.insert_updated_flop_bid() RETURNS TRIGGER
@@ -330,4 +348,6 @@ DROP FUNCTION get_latest_flop_bid_bid(numeric);
 DROP FUNCTION get_latest_flop_bid_tic(numeric);
 DROP FUNCTION get_latest_flop_bid_end(numeric);
 DROP FUNCTION get_latest_flop_bid_lot(numeric);
+
+DROP INDEX maker.flop_address_index;
 DROP TABLE maker.flop;

--- a/db/migrations/20190726141224_create_flap_table_and_triggers.sql
+++ b/db/migrations/20190726141224_create_flap_table_and_triggers.sql
@@ -19,6 +19,9 @@ CREATE TABLE maker.flap
     UNIQUE (block_number, bid_id)
 );
 
+CREATE INDEX flap_address_index
+    ON maker.flap (address_id);
+
 CREATE FUNCTION get_latest_flap_bid_guy(bid_id numeric) RETURNS TEXT AS
 $$
 SELECT guy
@@ -29,6 +32,9 @@ ORDER BY block_number DESC
 LIMIT 1
 $$
     LANGUAGE sql;
+
+COMMENT ON FUNCTION get_latest_flap_bid_guy
+    IS E'@omit';
 
 CREATE FUNCTION get_latest_flap_bid_bid(bid_id numeric) RETURNS NUMERIC AS
 $$
@@ -41,6 +47,9 @@ LIMIT 1
 $$
     LANGUAGE sql;
 
+COMMENT ON FUNCTION get_latest_flap_bid_bid
+    IS E'@omit';
+
 CREATE FUNCTION get_latest_flap_bid_tic(bid_id numeric) RETURNS BIGINT AS
 $$
 SELECT tic
@@ -51,6 +60,9 @@ ORDER BY block_number DESC
 LIMIT 1
 $$
     LANGUAGE sql;
+
+COMMENT ON FUNCTION get_latest_flap_bid_tic
+    IS E'@omit';
 
 CREATE FUNCTION get_latest_flap_bid_end(bid_id numeric) RETURNS BIGINT AS
 $$
@@ -63,6 +75,9 @@ LIMIT 1
 $$
     LANGUAGE sql;
 
+COMMENT ON FUNCTION get_latest_flap_bid_end
+    IS E'@omit';
+
 CREATE FUNCTION get_latest_flap_bid_lot(bid_id numeric) RETURNS NUMERIC AS
 $$
 SELECT lot
@@ -73,6 +88,9 @@ ORDER BY block_number DESC
 LIMIT 1
 $$
     LANGUAGE sql;
+
+COMMENT ON FUNCTION get_latest_flap_bid_lot
+    IS E'@omit';
 
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.insert_updated_flap_bid() RETURNS TRIGGER
@@ -330,4 +348,6 @@ DROP FUNCTION get_latest_flap_bid_bid(numeric);
 DROP FUNCTION get_latest_flap_bid_tic(numeric);
 DROP FUNCTION get_latest_flap_bid_end(numeric);
 DROP FUNCTION get_latest_flap_bid_lot(numeric);
+
+DROP INDEX maker.flap_address_index;
 DROP TABLE maker.flap;

--- a/db/migrations/20190809160237_create_cdp_manager_storage_tables.sql
+++ b/db/migrations/20190809160237_create_cdp_manager_storage_tables.sql
@@ -9,6 +9,9 @@ CREATE TABLE maker.cdp_manager_vat
     UNIQUE (diff_id, header_id, vat)
 );
 
+CREATE INDEX cdp_manager_vat_header_id_index
+    ON maker.cdp_manager_vat (header_id);
+
 CREATE TABLE maker.cdp_manager_cdpi
 (
     id        SERIAL PRIMARY KEY,
@@ -18,8 +21,8 @@ CREATE TABLE maker.cdp_manager_cdpi
     UNIQUE (diff_id, header_id, cdpi)
 );
 
-CREATE INDEX cdp_manager_cdpi_cdpi_index
-    ON maker.cdp_manager_cdpi (cdpi);
+CREATE INDEX cdp_manager_cdpi_header_id_index
+    ON maker.cdp_manager_cdpi (header_id);
 
 CREATE TABLE maker.cdp_manager_urns
 (
@@ -31,10 +34,10 @@ CREATE TABLE maker.cdp_manager_urns
     UNIQUE (diff_id, header_id, cdpi, urn)
 );
 
+CREATE INDEX cdp_manager_urns_header_id_index
+    ON maker.cdp_manager_urns (header_id);
 CREATE INDEX cdp_manager_urns_urn_index
     ON maker.cdp_manager_urns (urn);
-CREATE INDEX cdp_manager_urns_cdpi_index
-    ON maker.cdp_manager_urns (cdpi);
 
 CREATE TABLE maker.cdp_manager_list_prev
 (
@@ -46,6 +49,9 @@ CREATE TABLE maker.cdp_manager_list_prev
     UNIQUE (diff_id, header_id, cdpi, prev)
 );
 
+CREATE INDEX cdp_manager_list_prev_header_id_index
+    ON maker.cdp_manager_list_prev (header_id);
+
 CREATE TABLE maker.cdp_manager_list_next
 (
     id        SERIAL PRIMARY KEY,
@@ -55,6 +61,9 @@ CREATE TABLE maker.cdp_manager_list_next
     next      NUMERIC NOT NULL,
     UNIQUE (diff_id, header_id, cdpi, next)
 );
+
+CREATE INDEX cdp_manager_list_next_header_id_index
+    ON maker.cdp_manager_list_next (header_id);
 
 CREATE TABLE maker.cdp_manager_owns
 (
@@ -66,8 +75,8 @@ CREATE TABLE maker.cdp_manager_owns
     UNIQUE (diff_id, header_id, cdpi, owner)
 );
 
-CREATE INDEX cdp_manager_owns_cdpi_index
-    ON maker.cdp_manager_owns (cdpi);
+CREATE INDEX cdp_manager_owns_header_id_index
+    ON maker.cdp_manager_owns (header_id);
 CREATE INDEX cdp_manager_owns_owner_index
     ON maker.cdp_manager_owns (owner);
 
@@ -81,8 +90,8 @@ CREATE TABLE maker.cdp_manager_ilks
     UNIQUE (diff_id, header_id, cdpi, ilk_id)
 );
 
-CREATE INDEX cdp_manager_ilks_cdpi_index
-    ON maker.cdp_manager_ilks (cdpi);
+CREATE INDEX cdp_manager_ilks_header_id_index
+    ON maker.cdp_manager_ilks (header_id);
 CREATE INDEX cdp_manager_ilks_ilk_id_index
     ON maker.cdp_manager_ilks (ilk_id);
 
@@ -96,6 +105,9 @@ CREATE TABLE maker.cdp_manager_first
     UNIQUE (diff_id, header_id, owner, first)
 );
 
+CREATE INDEX cdp_manager_first_header_id_index
+    ON maker.cdp_manager_first (header_id);
+
 CREATE TABLE maker.cdp_manager_last
 (
     id        SERIAL PRIMARY KEY,
@@ -105,6 +117,9 @@ CREATE TABLE maker.cdp_manager_last
     last      NUMERIC NOT NULL,
     UNIQUE (diff_id, header_id, owner, last)
 );
+
+CREATE INDEX cdp_manager_last_header_id_index
+    ON maker.cdp_manager_last (header_id);
 
 CREATE TABLE maker.cdp_manager_count
 (
@@ -116,15 +131,24 @@ CREATE TABLE maker.cdp_manager_count
     UNIQUE (diff_id, header_id, owner, count)
 );
 
+CREATE INDEX cdp_manager_count_header_id_index
+    ON maker.cdp_manager_count (header_id);
+
 -- +goose Down
 -- SQL in this section is executed when the migration is rolled back.
-DROP INDEX maker.cdp_manager_ilks_cdpi_index;
-DROP INDEX maker.cdp_manager_ilks_ilk_id_index;
-DROP INDEX maker.cdp_manager_owns_cdpi_index;
-DROP INDEX maker.cdp_manager_owns_owner_index;
+DROP INDEX maker.cdp_manager_cdpi_header_id_index;
+DROP INDEX maker.cdp_manager_vat_header_id_index;
+DROP INDEX maker.cdp_manager_urns_header_id_index;
 DROP INDEX maker.cdp_manager_urns_urn_index;
-DROP INDEX maker.cdp_manager_urns_cdpi_index;
-DROP INDEX maker.cdp_manager_cdpi_cdpi_index;
+DROP INDEX maker.cdp_manager_list_prev_header_id_index;
+DROP INDEX maker.cdp_manager_list_next_header_id_index;
+DROP INDEX maker.cdp_manager_owns_header_id_index;
+DROP INDEX maker.cdp_manager_owns_owner_index;
+DROP INDEX maker.cdp_manager_ilks_header_id_index;
+DROP INDEX maker.cdp_manager_ilks_ilk_id_index;
+DROP INDEX maker.cdp_manager_first_header_id_index;
+DROP INDEX maker.cdp_manager_last_header_id_index;
+DROP INDEX maker.cdp_manager_count_header_id_index;
 
 DROP TABLE maker.cdp_manager_cdpi;
 DROP TABLE maker.cdp_manager_vat;

--- a/db/migrations/20190826130548_create_new_cdp.sql
+++ b/db/migrations/20190826130548_create_new_cdp.sql
@@ -13,10 +13,14 @@ CREATE TABLE maker.new_cdp
 COMMENT ON COLUMN maker.new_cdp.id
     IS E'@omit';
 
+CREATE INDEX new_cdp_log_index
+    ON maker.new_cdp (log_id);
+
 ALTER TABLE public.checked_headers
     ADD COLUMN new_cdp INTEGER NOT NULL DEFAULT 0;
 
 -- +goose Down
+DROP INDEX maker.new_cdp_log_index;
 DROP TABLE maker.new_cdp;
 ALTER TABLE public.checked_headers
     DROP COLUMN new_cdp;

--- a/db/migrations/20190919141224_create_ilk_state_history_table_and_triggers.sql
+++ b/db/migrations/20190919141224_create_ilk_state_history_table_and_triggers.sql
@@ -41,6 +41,9 @@ LIMIT 1
 $$
     LANGUAGE sql;
 
+COMMENT ON FUNCTION ilk_rate_before_block
+    IS E'@omit';
+
 
 CREATE FUNCTION ilk_art_before_block(ilk_id INTEGER, header_id INTEGER) RETURNS NUMERIC AS
 $$
@@ -59,6 +62,9 @@ ORDER BY block_number DESC
 LIMIT 1
 $$
     LANGUAGE sql;
+
+COMMENT ON FUNCTION ilk_art_before_block
+    IS E'@omit';
 
 
 CREATE FUNCTION ilk_spot_before_block(ilk_id INTEGER, header_id INTEGER) RETURNS NUMERIC AS
@@ -79,6 +85,9 @@ LIMIT 1
 $$
     LANGUAGE sql;
 
+COMMENT ON FUNCTION ilk_spot_before_block
+    IS E'@omit';
+
 
 CREATE FUNCTION ilk_line_before_block(ilk_id INTEGER, header_id INTEGER) RETURNS NUMERIC AS
 $$
@@ -97,6 +106,9 @@ ORDER BY block_number DESC
 LIMIT 1
 $$
     LANGUAGE sql;
+
+COMMENT ON FUNCTION ilk_line_before_block
+    IS E'@omit';
 
 
 CREATE FUNCTION ilk_dust_before_block(ilk_id INTEGER, header_id INTEGER) RETURNS NUMERIC AS
@@ -117,6 +129,9 @@ LIMIT 1
 $$
     LANGUAGE sql;
 
+COMMENT ON FUNCTION ilk_dust_before_block
+    IS E'@omit';
+
 
 CREATE FUNCTION ilk_chop_before_block(ilk_id INTEGER, header_id INTEGER) RETURNS NUMERIC AS
 $$
@@ -135,6 +150,9 @@ ORDER BY block_number DESC
 LIMIT 1
 $$
     LANGUAGE sql;
+
+COMMENT ON FUNCTION ilk_chop_before_block
+    IS E'@omit';
 
 
 CREATE FUNCTION ilk_lump_before_block(ilk_id INTEGER, header_id INTEGER) RETURNS NUMERIC AS
@@ -155,6 +173,9 @@ LIMIT 1
 $$
     LANGUAGE sql;
 
+COMMENT ON FUNCTION ilk_lump_before_block
+    IS E'@omit';
+
 
 CREATE FUNCTION ilk_flip_before_block(ilk_id INTEGER, header_id INTEGER) RETURNS TEXT AS
 $$
@@ -173,6 +194,9 @@ ORDER BY block_number DESC
 LIMIT 1
 $$
     LANGUAGE sql;
+
+COMMENT ON FUNCTION ilk_flip_before_block
+    IS E'@omit';
 
 
 CREATE FUNCTION ilk_rho_before_block(ilk_id INTEGER, header_id INTEGER) RETURNS NUMERIC AS
@@ -194,6 +218,9 @@ LIMIT 1
 $$
     LANGUAGE sql;
 
+COMMENT ON FUNCTION ilk_rho_before_block
+    IS E'@omit';
+
 
 CREATE FUNCTION ilk_duty_before_block(ilk_id INTEGER, header_id INTEGER) RETURNS NUMERIC AS
 $$
@@ -212,6 +239,9 @@ ORDER BY block_number DESC
 LIMIT 1
 $$
     LANGUAGE sql;
+
+COMMENT ON FUNCTION ilk_duty_before_block
+    IS E'@omit';
 
 
 CREATE FUNCTION ilk_pip_before_block(ilk_id INTEGER, header_id INTEGER) RETURNS TEXT AS
@@ -232,6 +262,9 @@ LIMIT 1
 $$
     LANGUAGE sql;
 
+COMMENT ON FUNCTION ilk_pip_before_block
+    IS E'@omit';
+
 
 CREATE FUNCTION ilk_mat_before_block(ilk_id INTEGER, header_id INTEGER) RETURNS NUMERIC AS
 $$
@@ -251,6 +284,9 @@ LIMIT 1
 $$
     LANGUAGE sql;
 
+COMMENT ON FUNCTION ilk_mat_before_block
+    IS E'@omit';
+
 
 CREATE FUNCTION ilk_time_created(ilk_id INTEGER) RETURNS TIMESTAMP AS
 $$
@@ -260,6 +296,9 @@ FROM public.headers
 WHERE vat_init.ilk_id = ilk_time_created.ilk_id
 $$
     LANGUAGE sql;
+
+COMMENT ON FUNCTION ilk_time_created
+    IS E'@omit';
 
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.delete_redundant_ilk_state(ilk_id INTEGER, header_id INTEGER) RETURNS api.historical_ilk_state
@@ -311,6 +350,9 @@ $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
 
+COMMENT ON FUNCTION maker.delete_redundant_ilk_state
+    IS E'@omit';
+
 
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.insert_new_rate(new_diff maker.vat_ilk_rate) RETURNS maker.vat_ilk_rate
@@ -357,6 +399,9 @@ $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
 
+COMMENT ON FUNCTION maker.insert_new_rate
+    IS E'@omit';
+
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.update_rates_until_next_diff(start_at_diff maker.vat_ilk_rate, new_rate NUMERIC) RETURNS maker.vat_ilk_rate
 AS
@@ -388,6 +433,9 @@ END
 $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
+
+COMMENT ON FUNCTION maker.update_rates_until_next_diff
+    IS E'@omit';
 
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.update_ilk_rates() RETURNS TRIGGER
@@ -459,6 +507,9 @@ $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
 
+COMMENT ON FUNCTION maker.insert_new_art
+    IS E'@omit';
+
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.update_arts_until_next_diff(start_at_diff maker.vat_ilk_art, new_art NUMERIC) RETURNS maker.vat_ilk_art
 AS
@@ -490,6 +541,9 @@ END
 $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
+
+COMMENT ON FUNCTION maker.update_arts_until_next_diff
+    IS E'@omit';
 
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.update_ilk_arts() RETURNS TRIGGER
@@ -561,6 +615,9 @@ $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
 
+COMMENT ON FUNCTION maker.insert_new_spot
+    IS E'@omit';
+
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.update_spots_until_next_diff(start_at_diff maker.vat_ilk_spot, new_spot NUMERIC) RETURNS maker.vat_ilk_spot
 AS
@@ -592,6 +649,9 @@ END
 $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
+
+COMMENT ON FUNCTION maker.update_spots_until_next_diff
+    IS E'@omit';
 
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.update_ilk_spots() RETURNS TRIGGER
@@ -663,6 +723,9 @@ $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
 
+COMMENT ON FUNCTION maker.insert_new_line
+    IS E'@omit';
+
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.update_lines_until_next_diff(start_at_diff maker.vat_ilk_line, new_line NUMERIC) RETURNS maker.vat_ilk_line
 AS
@@ -694,6 +757,9 @@ END
 $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
+
+COMMENT ON FUNCTION maker.update_lines_until_next_diff
+    IS E'@omit';
 
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.update_ilk_lines() RETURNS TRIGGER
@@ -765,6 +831,9 @@ $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
 
+COMMENT ON FUNCTION maker.insert_new_dust
+    IS E'@omit';
+
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.update_dusts_until_next_diff(start_at_diff maker.vat_ilk_dust, new_dust NUMERIC) RETURNS maker.vat_ilk_dust
 AS
@@ -796,6 +865,9 @@ END
 $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
+
+COMMENT ON FUNCTION maker.update_dusts_until_next_diff
+    IS E'@omit';
 
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.update_ilk_dusts() RETURNS TRIGGER
@@ -867,6 +939,9 @@ $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
 
+COMMENT ON FUNCTION maker.insert_new_chop
+    IS E'@omit';
+
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.update_chops_until_next_diff(start_at_diff maker.cat_ilk_chop, new_chop NUMERIC) RETURNS maker.cat_ilk_chop
 AS
@@ -898,6 +973,9 @@ END
 $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
+
+COMMENT ON FUNCTION maker.update_chops_until_next_diff
+    IS E'@omit';
 
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.update_ilk_chops() RETURNS TRIGGER
@@ -969,6 +1047,9 @@ $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
 
+COMMENT ON FUNCTION maker.insert_new_lump
+    IS E'@omit';
+
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.update_lumps_until_next_diff(start_at_diff maker.cat_ilk_lump, new_lump NUMERIC) RETURNS maker.cat_ilk_lump
 AS
@@ -1000,6 +1081,9 @@ END
 $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
+
+COMMENT ON FUNCTION maker.update_lumps_until_next_diff
+    IS E'@omit';
 
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.update_ilk_lumps() RETURNS TRIGGER
@@ -1071,6 +1155,9 @@ $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
 
+COMMENT ON FUNCTION maker.insert_new_flip
+    IS E'@omit';
+
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.update_flips_until_next_diff(start_at_diff maker.cat_ilk_flip, new_flip TEXT) RETURNS maker.cat_ilk_flip
 AS
@@ -1102,6 +1189,9 @@ END
 $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
+
+COMMENT ON FUNCTION maker.update_flips_until_next_diff
+    IS E'@omit';
 
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.update_ilk_flips() RETURNS TRIGGER
@@ -1173,6 +1263,9 @@ $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
 
+COMMENT ON FUNCTION maker.insert_new_rho
+    IS E'@omit';
+
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.update_rhos_until_next_diff(start_at_diff maker.jug_ilk_rho, new_rho NUMERIC) RETURNS maker.jug_ilk_rho
 AS
@@ -1204,6 +1297,9 @@ END
 $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
+
+COMMENT ON FUNCTION maker.update_rhos_until_next_diff
+    IS E'@omit';
 
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.update_ilk_rhos() RETURNS TRIGGER
@@ -1275,6 +1371,9 @@ $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
 
+COMMENT ON FUNCTION maker.insert_new_duty
+    IS E'@omit';
+
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.update_duties_until_next_diff(start_at_diff maker.jug_ilk_duty, new_duty NUMERIC) RETURNS maker.jug_ilk_duty
 AS
@@ -1306,6 +1405,9 @@ END
 $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
+
+COMMENT ON FUNCTION maker.update_duties_until_next_diff
+    IS E'@omit';
 
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.update_ilk_duties() RETURNS TRIGGER
@@ -1377,6 +1479,9 @@ $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
 
+COMMENT ON FUNCTION maker.insert_new_pip
+    IS E'@omit';
+
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.update_pips_until_next_diff(start_at_diff maker.spot_ilk_pip, new_pip TEXT) RETURNS maker.spot_ilk_pip
 AS
@@ -1408,6 +1513,9 @@ END
 $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
+
+COMMENT ON FUNCTION maker.update_pips_until_next_diff
+    IS E'@omit';
 
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.update_ilk_pips() RETURNS TRIGGER
@@ -1479,6 +1587,9 @@ $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
 
+COMMENT ON FUNCTION maker.insert_new_mat
+    IS E'@omit';
+
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.update_mats_until_next_diff(start_at_diff maker.spot_ilk_mat, new_mat NUMERIC) RETURNS maker.spot_ilk_mat
 AS
@@ -1510,6 +1621,9 @@ END
 $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
+
+COMMENT ON FUNCTION maker.update_mats_until_next_diff
+    IS E'@omit';
 
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.update_ilk_mats() RETURNS TRIGGER
@@ -1562,6 +1676,9 @@ $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
 
+COMMENT ON FUNCTION maker.insert_new_time_created
+    IS E'@omit';
+
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.clear_time_created(old_event maker.vat_init) RETURNS maker.vat_init
 AS
@@ -1578,6 +1695,9 @@ $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
 
+COMMENT ON FUNCTION maker.clear_time_created
+    IS E'@omit';
+
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.update_time_created() RETURNS TRIGGER
 AS
@@ -1593,6 +1713,9 @@ END
 $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
+
+COMMENT ON FUNCTION maker.update_time_created
+    IS E'@omit';
 
 CREATE TRIGGER ilk_init
     AFTER INSERT OR UPDATE OR DELETE

--- a/db/migrations/20191118031513_create_log_value.sql
+++ b/db/migrations/20191118031513_create_log_value.sql
@@ -12,9 +12,12 @@ COMMENT ON COLUMN maker.log_value.id
 
 CREATE INDEX log_value_header_index
     ON maker.log_value (header_id);
+CREATE INDEX log_value_log_index
+    ON maker.log_value (log_id);
 
 
 -- +goose Down
+DROP INDEX maker.log_value_log_index;
 DROP INDEX maker.log_value_header_index;
 
 DROP TABLE maker.log_value;

--- a/db/migrations/20191125170230_create_pot_file.sql
+++ b/db/migrations/20191125170230_create_pot_file.sql
@@ -11,6 +11,8 @@ CREATE TABLE maker.pot_file_dsr
 
 CREATE INDEX pot_file_dsr_header_index
     ON maker.pot_file_dsr (header_id);
+CREATE INDEX pot_file_dsr_log_index
+    ON maker.pot_file_dsr (log_id);
 
 CREATE TABLE maker.pot_file_vow
 (
@@ -24,11 +26,15 @@ CREATE TABLE maker.pot_file_vow
 
 CREATE INDEX pot_file_vow_header_index
     ON maker.pot_file_vow (header_id);
+CREATE INDEX pot_file_vow_log_index
+    ON maker.pot_file_vow (log_id);
 
 
 -- +goose Down
 DROP INDEX maker.pot_file_dsr_header_index;
+DROP INDEX maker.pot_file_dsr_log_index;
 DROP INDEX maker.pot_file_vow_header_index;
+DROP INDEX maker.pot_file_vow_log_index;
 
 DROP TABLE maker.pot_file_dsr;
 DROP TABLE maker.pot_file_vow;

--- a/db/migrations/20191127095017_create_pot_cage.sql
+++ b/db/migrations/20191127095017_create_pot_cage.sql
@@ -9,9 +9,12 @@ CREATE TABLE maker.pot_cage
 
 CREATE INDEX pot_cage_header_index
     ON maker.pot_cage (header_id);
+CREATE INDEX pot_cage_log_index
+    ON maker.pot_cage (log_id);
 
 
 -- +goose Down
+DROP INDEX maker.pot_cage_log_index;
 DROP INDEX maker.pot_cage_header_index;
 
 DROP TABLE maker.pot_cage;

--- a/db/migrations/20191202091203_create_historical_urn_state_table_and_triggers.sql
+++ b/db/migrations/20191202091203_create_historical_urn_state_table_and_triggers.sql
@@ -28,6 +28,9 @@ LIMIT 1
 $$
     LANGUAGE sql;
 
+COMMENT ON FUNCTION urn_ink_before_block
+    IS E'@omit';
+
 
 CREATE FUNCTION urn_art_before_block(urn_id INTEGER, header_id INTEGER) RETURNS NUMERIC AS
 $$
@@ -45,6 +48,9 @@ LIMIT 1
 $$
     LANGUAGE sql;
 
+COMMENT ON FUNCTION urn_art_before_block
+    IS E'@omit';
+
 
 CREATE FUNCTION urn_time_created(urn_id INTEGER) RETURNS TIMESTAMP AS
 $$
@@ -54,6 +60,9 @@ FROM maker.vat_urn_ink
 WHERE vat_urn_ink.urn_id = urn_time_created.urn_id
 $$
     LANGUAGE sql;
+
+COMMENT ON FUNCTION urn_time_created
+    IS E'@omit';
 
 
 -- +goose StatementBegin
@@ -90,6 +99,9 @@ $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
 
+COMMENT ON FUNCTION maker.delete_obsolete_urn_state
+    IS E'@omit';
+
 
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.insert_urn_ink(new_diff maker.vat_urn_ink) RETURNS maker.vat_urn_ink
@@ -121,6 +133,9 @@ END
 $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
+
+COMMENT ON FUNCTION maker.insert_urn_ink
+    IS E'@omit';
 
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.update_urn_inks_until_next_diff(start_at_diff maker.vat_urn_ink, new_ink NUMERIC) RETURNS maker.vat_urn_ink
@@ -157,6 +172,9 @@ $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
 
+COMMENT ON FUNCTION maker.update_urn_inks_until_next_diff
+    IS E'@omit';
+
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.update_urn_created(urn_id INTEGER) RETURNS maker.vat_urn_ink
 AS
@@ -174,6 +192,9 @@ END
 $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
+
+COMMENT ON FUNCTION maker.update_urn_created
+    IS E'@omit';
 
 
 -- +goose StatementBegin
@@ -234,6 +255,9 @@ $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
 
+COMMENT ON FUNCTION maker.insert_urn_art
+    IS E'@omit';
+
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.update_urn_arts_until_next_diff(start_at_diff maker.vat_urn_art, new_art NUMERIC) RETURNS maker.vat_urn_art
 AS
@@ -268,6 +292,9 @@ END
 $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
+
+COMMENT ON FUNCTION maker.update_urn_arts_until_next_diff
+    IS E'@omit';
 
 
 -- +goose StatementBegin

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -2639,6 +2639,13 @@ $$;
 
 
 --
+-- Name: FUNCTION clear_time_created(old_event maker.vat_init); Type: COMMENT; Schema: maker; Owner: -
+--
+
+COMMENT ON FUNCTION maker.clear_time_created(old_event maker.vat_init) IS '@omit';
+
+
+--
 -- Name: delete_obsolete_urn_state(integer, integer); Type: FUNCTION; Schema: maker; Owner: -
 --
 
@@ -2671,6 +2678,13 @@ BEGIN
     RETURN NULL;
 END
 $$;
+
+
+--
+-- Name: FUNCTION delete_obsolete_urn_state(urn_id integer, header_id integer); Type: COMMENT; Schema: maker; Owner: -
+--
+
+COMMENT ON FUNCTION maker.delete_obsolete_urn_state(urn_id integer, header_id integer) IS '@omit';
 
 
 --
@@ -2723,6 +2737,13 @@ BEGIN
     RETURN NULL;
 END
 $$;
+
+
+--
+-- Name: FUNCTION delete_redundant_ilk_state(ilk_id integer, header_id integer); Type: COMMENT; Schema: maker; Owner: -
+--
+
+COMMENT ON FUNCTION maker.delete_redundant_ilk_state(ilk_id integer, header_id integer) IS '@omit';
 
 
 --
@@ -2979,6 +3000,13 @@ $$;
 
 
 --
+-- Name: FUNCTION insert_new_art(new_diff maker.vat_ilk_art); Type: COMMENT; Schema: maker; Owner: -
+--
+
+COMMENT ON FUNCTION maker.insert_new_art(new_diff maker.vat_ilk_art) IS '@omit';
+
+
+--
 -- Name: cat_ilk_chop; Type: TABLE; Schema: maker; Owner: -
 --
 
@@ -3036,6 +3064,13 @@ BEGIN
     RETURN new_diff;
 END
 $$;
+
+
+--
+-- Name: FUNCTION insert_new_chop(new_diff maker.cat_ilk_chop); Type: COMMENT; Schema: maker; Owner: -
+--
+
+COMMENT ON FUNCTION maker.insert_new_chop(new_diff maker.cat_ilk_chop) IS '@omit';
 
 
 --
@@ -3099,6 +3134,13 @@ $$;
 
 
 --
+-- Name: FUNCTION insert_new_dust(new_diff maker.vat_ilk_dust); Type: COMMENT; Schema: maker; Owner: -
+--
+
+COMMENT ON FUNCTION maker.insert_new_dust(new_diff maker.vat_ilk_dust) IS '@omit';
+
+
+--
 -- Name: jug_ilk_duty; Type: TABLE; Schema: maker; Owner: -
 --
 
@@ -3156,6 +3198,13 @@ BEGIN
     RETURN new_diff;
 END
 $$;
+
+
+--
+-- Name: FUNCTION insert_new_duty(new_diff maker.jug_ilk_duty); Type: COMMENT; Schema: maker; Owner: -
+--
+
+COMMENT ON FUNCTION maker.insert_new_duty(new_diff maker.jug_ilk_duty) IS '@omit';
 
 
 --
@@ -3219,6 +3268,13 @@ $$;
 
 
 --
+-- Name: FUNCTION insert_new_flip(new_diff maker.cat_ilk_flip); Type: COMMENT; Schema: maker; Owner: -
+--
+
+COMMENT ON FUNCTION maker.insert_new_flip(new_diff maker.cat_ilk_flip) IS '@omit';
+
+
+--
 -- Name: vat_ilk_line; Type: TABLE; Schema: maker; Owner: -
 --
 
@@ -3276,6 +3332,13 @@ BEGIN
     RETURN new_diff;
 END
 $$;
+
+
+--
+-- Name: FUNCTION insert_new_line(new_diff maker.vat_ilk_line); Type: COMMENT; Schema: maker; Owner: -
+--
+
+COMMENT ON FUNCTION maker.insert_new_line(new_diff maker.vat_ilk_line) IS '@omit';
 
 
 --
@@ -3339,6 +3402,13 @@ $$;
 
 
 --
+-- Name: FUNCTION insert_new_lump(new_diff maker.cat_ilk_lump); Type: COMMENT; Schema: maker; Owner: -
+--
+
+COMMENT ON FUNCTION maker.insert_new_lump(new_diff maker.cat_ilk_lump) IS '@omit';
+
+
+--
 -- Name: spot_ilk_mat; Type: TABLE; Schema: maker; Owner: -
 --
 
@@ -3396,6 +3466,13 @@ BEGIN
     RETURN new_diff;
 END
 $$;
+
+
+--
+-- Name: FUNCTION insert_new_mat(new_diff maker.spot_ilk_mat); Type: COMMENT; Schema: maker; Owner: -
+--
+
+COMMENT ON FUNCTION maker.insert_new_mat(new_diff maker.spot_ilk_mat) IS '@omit';
 
 
 --
@@ -3459,6 +3536,13 @@ $$;
 
 
 --
+-- Name: FUNCTION insert_new_pip(new_diff maker.spot_ilk_pip); Type: COMMENT; Schema: maker; Owner: -
+--
+
+COMMENT ON FUNCTION maker.insert_new_pip(new_diff maker.spot_ilk_pip) IS '@omit';
+
+
+--
 -- Name: vat_ilk_rate; Type: TABLE; Schema: maker; Owner: -
 --
 
@@ -3516,6 +3600,13 @@ BEGIN
     RETURN new_diff;
 END
 $$;
+
+
+--
+-- Name: FUNCTION insert_new_rate(new_diff maker.vat_ilk_rate); Type: COMMENT; Schema: maker; Owner: -
+--
+
+COMMENT ON FUNCTION maker.insert_new_rate(new_diff maker.vat_ilk_rate) IS '@omit';
 
 
 --
@@ -3579,6 +3670,13 @@ $$;
 
 
 --
+-- Name: FUNCTION insert_new_rho(new_diff maker.jug_ilk_rho); Type: COMMENT; Schema: maker; Owner: -
+--
+
+COMMENT ON FUNCTION maker.insert_new_rho(new_diff maker.jug_ilk_rho) IS '@omit';
+
+
+--
 -- Name: vat_ilk_spot; Type: TABLE; Schema: maker; Owner: -
 --
 
@@ -3639,6 +3737,13 @@ $$;
 
 
 --
+-- Name: FUNCTION insert_new_spot(new_diff maker.vat_ilk_spot); Type: COMMENT; Schema: maker; Owner: -
+--
+
+COMMENT ON FUNCTION maker.insert_new_spot(new_diff maker.vat_ilk_spot) IS '@omit';
+
+
+--
 -- Name: insert_new_time_created(maker.vat_init); Type: FUNCTION; Schema: maker; Owner: -
 --
 
@@ -3664,6 +3769,13 @@ BEGIN
     RETURN NULL;
 END
 $$;
+
+
+--
+-- Name: FUNCTION insert_new_time_created(new_event maker.vat_init); Type: COMMENT; Schema: maker; Owner: -
+--
+
+COMMENT ON FUNCTION maker.insert_new_time_created(new_event maker.vat_init) IS '@omit';
 
 
 --
@@ -4339,6 +4451,13 @@ $$;
 
 
 --
+-- Name: FUNCTION insert_urn_art(new_diff maker.vat_urn_art); Type: COMMENT; Schema: maker; Owner: -
+--
+
+COMMENT ON FUNCTION maker.insert_urn_art(new_diff maker.vat_urn_art) IS '@omit';
+
+
+--
 -- Name: vat_urn_ink; Type: TABLE; Schema: maker; Owner: -
 --
 
@@ -4385,6 +4504,13 @@ $$;
 
 
 --
+-- Name: FUNCTION insert_urn_ink(new_diff maker.vat_urn_ink); Type: COMMENT; Schema: maker; Owner: -
+--
+
+COMMENT ON FUNCTION maker.insert_urn_ink(new_diff maker.vat_urn_ink) IS '@omit';
+
+
+--
 -- Name: update_arts_until_next_diff(maker.vat_ilk_art, numeric); Type: FUNCTION; Schema: maker; Owner: -
 --
 
@@ -4416,6 +4542,13 @@ BEGIN
     RETURN NULL;
 END
 $$;
+
+
+--
+-- Name: FUNCTION update_arts_until_next_diff(start_at_diff maker.vat_ilk_art, new_art numeric); Type: COMMENT; Schema: maker; Owner: -
+--
+
+COMMENT ON FUNCTION maker.update_arts_until_next_diff(start_at_diff maker.vat_ilk_art, new_art numeric) IS '@omit';
 
 
 --
@@ -4453,6 +4586,13 @@ $$;
 
 
 --
+-- Name: FUNCTION update_chops_until_next_diff(start_at_diff maker.cat_ilk_chop, new_chop numeric); Type: COMMENT; Schema: maker; Owner: -
+--
+
+COMMENT ON FUNCTION maker.update_chops_until_next_diff(start_at_diff maker.cat_ilk_chop, new_chop numeric) IS '@omit';
+
+
+--
 -- Name: update_dusts_until_next_diff(maker.vat_ilk_dust, numeric); Type: FUNCTION; Schema: maker; Owner: -
 --
 
@@ -4484,6 +4624,13 @@ BEGIN
     RETURN NULL;
 END
 $$;
+
+
+--
+-- Name: FUNCTION update_dusts_until_next_diff(start_at_diff maker.vat_ilk_dust, new_dust numeric); Type: COMMENT; Schema: maker; Owner: -
+--
+
+COMMENT ON FUNCTION maker.update_dusts_until_next_diff(start_at_diff maker.vat_ilk_dust, new_dust numeric) IS '@omit';
 
 
 --
@@ -4521,6 +4668,13 @@ $$;
 
 
 --
+-- Name: FUNCTION update_duties_until_next_diff(start_at_diff maker.jug_ilk_duty, new_duty numeric); Type: COMMENT; Schema: maker; Owner: -
+--
+
+COMMENT ON FUNCTION maker.update_duties_until_next_diff(start_at_diff maker.jug_ilk_duty, new_duty numeric) IS '@omit';
+
+
+--
 -- Name: update_flips_until_next_diff(maker.cat_ilk_flip, text); Type: FUNCTION; Schema: maker; Owner: -
 --
 
@@ -4552,6 +4706,13 @@ BEGIN
     RETURN NULL;
 END
 $$;
+
+
+--
+-- Name: FUNCTION update_flips_until_next_diff(start_at_diff maker.cat_ilk_flip, new_flip text); Type: COMMENT; Schema: maker; Owner: -
+--
+
+COMMENT ON FUNCTION maker.update_flips_until_next_diff(start_at_diff maker.cat_ilk_flip, new_flip text) IS '@omit';
 
 
 --
@@ -4829,6 +4990,13 @@ $$;
 
 
 --
+-- Name: FUNCTION update_lines_until_next_diff(start_at_diff maker.vat_ilk_line, new_line numeric); Type: COMMENT; Schema: maker; Owner: -
+--
+
+COMMENT ON FUNCTION maker.update_lines_until_next_diff(start_at_diff maker.vat_ilk_line, new_line numeric) IS '@omit';
+
+
+--
 -- Name: update_lumps_until_next_diff(maker.cat_ilk_lump, numeric); Type: FUNCTION; Schema: maker; Owner: -
 --
 
@@ -4860,6 +5028,13 @@ BEGIN
     RETURN NULL;
 END
 $$;
+
+
+--
+-- Name: FUNCTION update_lumps_until_next_diff(start_at_diff maker.cat_ilk_lump, new_lump numeric); Type: COMMENT; Schema: maker; Owner: -
+--
+
+COMMENT ON FUNCTION maker.update_lumps_until_next_diff(start_at_diff maker.cat_ilk_lump, new_lump numeric) IS '@omit';
 
 
 --
@@ -4897,6 +5072,13 @@ $$;
 
 
 --
+-- Name: FUNCTION update_mats_until_next_diff(start_at_diff maker.spot_ilk_mat, new_mat numeric); Type: COMMENT; Schema: maker; Owner: -
+--
+
+COMMENT ON FUNCTION maker.update_mats_until_next_diff(start_at_diff maker.spot_ilk_mat, new_mat numeric) IS '@omit';
+
+
+--
 -- Name: update_pips_until_next_diff(maker.spot_ilk_pip, text); Type: FUNCTION; Schema: maker; Owner: -
 --
 
@@ -4928,6 +5110,13 @@ BEGIN
     RETURN NULL;
 END
 $$;
+
+
+--
+-- Name: FUNCTION update_pips_until_next_diff(start_at_diff maker.spot_ilk_pip, new_pip text); Type: COMMENT; Schema: maker; Owner: -
+--
+
+COMMENT ON FUNCTION maker.update_pips_until_next_diff(start_at_diff maker.spot_ilk_pip, new_pip text) IS '@omit';
 
 
 --
@@ -4965,6 +5154,13 @@ $$;
 
 
 --
+-- Name: FUNCTION update_rates_until_next_diff(start_at_diff maker.vat_ilk_rate, new_rate numeric); Type: COMMENT; Schema: maker; Owner: -
+--
+
+COMMENT ON FUNCTION maker.update_rates_until_next_diff(start_at_diff maker.vat_ilk_rate, new_rate numeric) IS '@omit';
+
+
+--
 -- Name: update_rhos_until_next_diff(maker.jug_ilk_rho, numeric); Type: FUNCTION; Schema: maker; Owner: -
 --
 
@@ -4996,6 +5192,13 @@ BEGIN
     RETURN NULL;
 END
 $$;
+
+
+--
+-- Name: FUNCTION update_rhos_until_next_diff(start_at_diff maker.jug_ilk_rho, new_rho numeric); Type: COMMENT; Schema: maker; Owner: -
+--
+
+COMMENT ON FUNCTION maker.update_rhos_until_next_diff(start_at_diff maker.jug_ilk_rho, new_rho numeric) IS '@omit';
 
 
 --
@@ -5033,6 +5236,13 @@ $$;
 
 
 --
+-- Name: FUNCTION update_spots_until_next_diff(start_at_diff maker.vat_ilk_spot, new_spot numeric); Type: COMMENT; Schema: maker; Owner: -
+--
+
+COMMENT ON FUNCTION maker.update_spots_until_next_diff(start_at_diff maker.vat_ilk_spot, new_spot numeric) IS '@omit';
+
+
+--
 -- Name: update_time_created(); Type: FUNCTION; Schema: maker; Owner: -
 --
 
@@ -5048,6 +5258,13 @@ BEGIN
     RETURN NULL;
 END
 $$;
+
+
+--
+-- Name: FUNCTION update_time_created(); Type: COMMENT; Schema: maker; Owner: -
+--
+
+COMMENT ON FUNCTION maker.update_time_created() IS '@omit';
 
 
 --
@@ -5108,6 +5325,13 @@ $$;
 
 
 --
+-- Name: FUNCTION update_urn_arts_until_next_diff(start_at_diff maker.vat_urn_art, new_art numeric); Type: COMMENT; Schema: maker; Owner: -
+--
+
+COMMENT ON FUNCTION maker.update_urn_arts_until_next_diff(start_at_diff maker.vat_urn_art, new_art numeric) IS '@omit';
+
+
+--
 -- Name: update_urn_created(integer); Type: FUNCTION; Schema: maker; Owner: -
 --
 
@@ -5125,6 +5349,13 @@ BEGIN
     RETURN NULL;
 END
 $$;
+
+
+--
+-- Name: FUNCTION update_urn_created(urn_id integer); Type: COMMENT; Schema: maker; Owner: -
+--
+
+COMMENT ON FUNCTION maker.update_urn_created(urn_id integer) IS '@omit';
 
 
 --
@@ -5187,6 +5418,13 @@ $$;
 
 
 --
+-- Name: FUNCTION update_urn_inks_until_next_diff(start_at_diff maker.vat_urn_ink, new_ink numeric); Type: COMMENT; Schema: maker; Owner: -
+--
+
+COMMENT ON FUNCTION maker.update_urn_inks_until_next_diff(start_at_diff maker.vat_urn_ink, new_ink numeric) IS '@omit';
+
+
+--
 -- Name: get_latest_flap_bid_bid(numeric); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -5200,6 +5438,13 @@ WHERE bid IS NOT NULL
 ORDER BY block_number DESC
 LIMIT 1
 $$;
+
+
+--
+-- Name: FUNCTION get_latest_flap_bid_bid(bid_id numeric); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.get_latest_flap_bid_bid(bid_id numeric) IS '@omit';
 
 
 --
@@ -5219,6 +5464,13 @@ $$;
 
 
 --
+-- Name: FUNCTION get_latest_flap_bid_end(bid_id numeric); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.get_latest_flap_bid_end(bid_id numeric) IS '@omit';
+
+
+--
 -- Name: get_latest_flap_bid_guy(numeric); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -5232,6 +5484,13 @@ WHERE guy IS NOT NULL
 ORDER BY block_number DESC
 LIMIT 1
 $$;
+
+
+--
+-- Name: FUNCTION get_latest_flap_bid_guy(bid_id numeric); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.get_latest_flap_bid_guy(bid_id numeric) IS '@omit';
 
 
 --
@@ -5251,6 +5510,13 @@ $$;
 
 
 --
+-- Name: FUNCTION get_latest_flap_bid_lot(bid_id numeric); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.get_latest_flap_bid_lot(bid_id numeric) IS '@omit';
+
+
+--
 -- Name: get_latest_flap_bid_tic(numeric); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -5264,6 +5530,13 @@ WHERE tic IS NOT NULL
 ORDER BY block_number DESC
 LIMIT 1
 $$;
+
+
+--
+-- Name: FUNCTION get_latest_flap_bid_tic(bid_id numeric); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.get_latest_flap_bid_tic(bid_id numeric) IS '@omit';
 
 
 --
@@ -5283,6 +5556,13 @@ $$;
 
 
 --
+-- Name: FUNCTION get_latest_flip_bid_bid(bid_id numeric); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.get_latest_flip_bid_bid(bid_id numeric) IS '@omit';
+
+
+--
 -- Name: get_latest_flip_bid_end(numeric); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -5296,6 +5576,13 @@ WHERE "end" IS NOT NULL
 ORDER BY block_number DESC
 LIMIT 1
 $$;
+
+
+--
+-- Name: FUNCTION get_latest_flip_bid_end(bid_id numeric); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.get_latest_flip_bid_end(bid_id numeric) IS '@omit';
 
 
 --
@@ -5315,6 +5602,13 @@ $$;
 
 
 --
+-- Name: FUNCTION get_latest_flip_bid_gal(bid_id numeric); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.get_latest_flip_bid_gal(bid_id numeric) IS '@omit';
+
+
+--
 -- Name: get_latest_flip_bid_guy(numeric); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -5328,6 +5622,13 @@ WHERE guy IS NOT NULL
 ORDER BY block_number DESC
 LIMIT 1
 $$;
+
+
+--
+-- Name: FUNCTION get_latest_flip_bid_guy(bid_id numeric); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.get_latest_flip_bid_guy(bid_id numeric) IS '@omit';
 
 
 --
@@ -5347,6 +5648,13 @@ $$;
 
 
 --
+-- Name: FUNCTION get_latest_flip_bid_lot(bid_id numeric); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.get_latest_flip_bid_lot(bid_id numeric) IS '@omit';
+
+
+--
 -- Name: get_latest_flip_bid_tab(numeric); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -5360,6 +5668,13 @@ WHERE tab IS NOT NULL
 ORDER BY block_number DESC
 LIMIT 1
 $$;
+
+
+--
+-- Name: FUNCTION get_latest_flip_bid_tab(bid_id numeric); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.get_latest_flip_bid_tab(bid_id numeric) IS '@omit';
 
 
 --
@@ -5379,6 +5694,13 @@ $$;
 
 
 --
+-- Name: FUNCTION get_latest_flip_bid_tic(bid_id numeric); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.get_latest_flip_bid_tic(bid_id numeric) IS '@omit';
+
+
+--
 -- Name: get_latest_flop_bid_bid(numeric); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -5392,6 +5714,13 @@ WHERE bid IS NOT NULL
 ORDER BY block_number DESC
 LIMIT 1
 $$;
+
+
+--
+-- Name: FUNCTION get_latest_flop_bid_bid(bid_id numeric); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.get_latest_flop_bid_bid(bid_id numeric) IS '@omit';
 
 
 --
@@ -5411,6 +5740,13 @@ $$;
 
 
 --
+-- Name: FUNCTION get_latest_flop_bid_end(bid_id numeric); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.get_latest_flop_bid_end(bid_id numeric) IS '@omit';
+
+
+--
 -- Name: get_latest_flop_bid_guy(numeric); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -5424,6 +5760,13 @@ WHERE guy IS NOT NULL
 ORDER BY block_number DESC
 LIMIT 1
 $$;
+
+
+--
+-- Name: FUNCTION get_latest_flop_bid_guy(bid_id numeric); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.get_latest_flop_bid_guy(bid_id numeric) IS '@omit';
 
 
 --
@@ -5443,6 +5786,13 @@ $$;
 
 
 --
+-- Name: FUNCTION get_latest_flop_bid_lot(bid_id numeric); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.get_latest_flop_bid_lot(bid_id numeric) IS '@omit';
+
+
+--
 -- Name: get_latest_flop_bid_tic(numeric); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -5456,6 +5806,13 @@ WHERE tic IS NOT NULL
 ORDER BY block_number DESC
 LIMIT 1
 $$;
+
+
+--
+-- Name: FUNCTION get_latest_flop_bid_tic(bid_id numeric); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.get_latest_flop_bid_tic(bid_id numeric) IS '@omit';
 
 
 --
@@ -5500,6 +5857,13 @@ $$;
 
 
 --
+-- Name: FUNCTION ilk_art_before_block(ilk_id integer, header_id integer); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.ilk_art_before_block(ilk_id integer, header_id integer) IS '@omit';
+
+
+--
 -- Name: ilk_chop_before_block(integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -5520,6 +5884,13 @@ WHERE cat_ilk_chop.ilk_id = ilk_chop_before_block.ilk_id
 ORDER BY block_number DESC
 LIMIT 1
 $$;
+
+
+--
+-- Name: FUNCTION ilk_chop_before_block(ilk_id integer, header_id integer); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.ilk_chop_before_block(ilk_id integer, header_id integer) IS '@omit';
 
 
 --
@@ -5546,6 +5917,13 @@ $$;
 
 
 --
+-- Name: FUNCTION ilk_dust_before_block(ilk_id integer, header_id integer); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.ilk_dust_before_block(ilk_id integer, header_id integer) IS '@omit';
+
+
+--
 -- Name: ilk_duty_before_block(integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -5566,6 +5944,13 @@ WHERE jug_ilk_duty.ilk_id = ilk_duty_before_block.ilk_id
 ORDER BY block_number DESC
 LIMIT 1
 $$;
+
+
+--
+-- Name: FUNCTION ilk_duty_before_block(ilk_id integer, header_id integer); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.ilk_duty_before_block(ilk_id integer, header_id integer) IS '@omit';
 
 
 --
@@ -5592,6 +5977,13 @@ $$;
 
 
 --
+-- Name: FUNCTION ilk_flip_before_block(ilk_id integer, header_id integer); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.ilk_flip_before_block(ilk_id integer, header_id integer) IS '@omit';
+
+
+--
 -- Name: ilk_line_before_block(integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -5612,6 +6004,13 @@ WHERE vat_ilk_line.ilk_id = ilk_line_before_block.ilk_id
 ORDER BY block_number DESC
 LIMIT 1
 $$;
+
+
+--
+-- Name: FUNCTION ilk_line_before_block(ilk_id integer, header_id integer); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.ilk_line_before_block(ilk_id integer, header_id integer) IS '@omit';
 
 
 --
@@ -5638,6 +6037,13 @@ $$;
 
 
 --
+-- Name: FUNCTION ilk_lump_before_block(ilk_id integer, header_id integer); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.ilk_lump_before_block(ilk_id integer, header_id integer) IS '@omit';
+
+
+--
 -- Name: ilk_mat_before_block(integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -5658,6 +6064,13 @@ WHERE spot_ilk_mat.ilk_id = ilk_mat_before_block.ilk_id
 ORDER BY block_number DESC
 LIMIT 1
 $$;
+
+
+--
+-- Name: FUNCTION ilk_mat_before_block(ilk_id integer, header_id integer); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.ilk_mat_before_block(ilk_id integer, header_id integer) IS '@omit';
 
 
 --
@@ -5684,6 +6097,13 @@ $$;
 
 
 --
+-- Name: FUNCTION ilk_pip_before_block(ilk_id integer, header_id integer); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.ilk_pip_before_block(ilk_id integer, header_id integer) IS '@omit';
+
+
+--
 -- Name: ilk_rate_before_block(integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -5704,6 +6124,13 @@ WHERE vat_ilk_rate.ilk_id = ilk_rate_before_block.ilk_id
 ORDER BY block_number DESC
 LIMIT 1
 $$;
+
+
+--
+-- Name: FUNCTION ilk_rate_before_block(ilk_id integer, header_id integer); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.ilk_rate_before_block(ilk_id integer, header_id integer) IS '@omit';
 
 
 --
@@ -5731,6 +6158,13 @@ $$;
 
 
 --
+-- Name: FUNCTION ilk_rho_before_block(ilk_id integer, header_id integer); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.ilk_rho_before_block(ilk_id integer, header_id integer) IS '@omit';
+
+
+--
 -- Name: ilk_spot_before_block(integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -5754,6 +6188,13 @@ $$;
 
 
 --
+-- Name: FUNCTION ilk_spot_before_block(ilk_id integer, header_id integer); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.ilk_spot_before_block(ilk_id integer, header_id integer) IS '@omit';
+
+
+--
 -- Name: ilk_time_created(integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -5765,6 +6206,13 @@ FROM public.headers
          LEFT JOIN maker.vat_init ON vat_init.header_id = headers.id
 WHERE vat_init.ilk_id = ilk_time_created.ilk_id
 $$;
+
+
+--
+-- Name: FUNCTION ilk_time_created(ilk_id integer); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.ilk_time_created(ilk_id integer) IS '@omit';
 
 
 --
@@ -5789,6 +6237,13 @@ $$;
 
 
 --
+-- Name: FUNCTION urn_art_before_block(urn_id integer, header_id integer); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.urn_art_before_block(urn_id integer, header_id integer) IS '@omit';
+
+
+--
 -- Name: urn_ink_before_block(integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -5810,6 +6265,13 @@ $$;
 
 
 --
+-- Name: FUNCTION urn_ink_before_block(urn_id integer, header_id integer); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.urn_ink_before_block(urn_id integer, header_id integer) IS '@omit';
+
+
+--
 -- Name: urn_time_created(integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -5821,6 +6283,13 @@ FROM maker.vat_urn_ink
          LEFT JOIN public.headers ON vat_urn_ink.header_id = headers.id
 WHERE vat_urn_ink.urn_id = urn_time_created.urn_id
 $$;
+
+
+--
+-- Name: FUNCTION urn_time_created(urn_id integer); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.urn_time_created(urn_id integer) IS '@omit';
 
 
 --
@@ -14379,6 +14848,13 @@ CREATE INDEX bite_header_index ON maker.bite USING btree (header_id);
 
 
 --
+-- Name: bite_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX bite_log_index ON maker.bite USING btree (log_id);
+
+
+--
 -- Name: bite_urn_index; Type: INDEX; Schema: maker; Owner: -
 --
 
@@ -14400,6 +14876,13 @@ CREATE INDEX cat_file_chop_lump_ilk_index ON maker.cat_file_chop_lump USING btre
 
 
 --
+-- Name: cat_file_chop_lump_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX cat_file_chop_lump_log_index ON maker.cat_file_chop_lump USING btree (log_id);
+
+
+--
 -- Name: cat_file_flip_header_index; Type: INDEX; Schema: maker; Owner: -
 --
 
@@ -14414,10 +14897,24 @@ CREATE INDEX cat_file_flip_ilk_index ON maker.cat_file_flip USING btree (ilk_id)
 
 
 --
+-- Name: cat_file_flip_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX cat_file_flip_log_index ON maker.cat_file_flip USING btree (log_id);
+
+
+--
 -- Name: cat_file_vow_header_index; Type: INDEX; Schema: maker; Owner: -
 --
 
 CREATE INDEX cat_file_vow_header_index ON maker.cat_file_vow USING btree (header_id);
+
+
+--
+-- Name: cat_file_vow_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX cat_file_vow_log_index ON maker.cat_file_vow USING btree (log_id);
 
 
 --
@@ -14463,17 +14960,52 @@ CREATE INDEX cat_ilk_lump_ilk_index ON maker.cat_ilk_lump USING btree (ilk_id);
 
 
 --
--- Name: cdp_manager_cdpi_cdpi_index; Type: INDEX; Schema: maker; Owner: -
+-- Name: cat_live_header_id_index; Type: INDEX; Schema: maker; Owner: -
 --
 
-CREATE INDEX cdp_manager_cdpi_cdpi_index ON maker.cdp_manager_cdpi USING btree (cdpi);
+CREATE INDEX cat_live_header_id_index ON maker.cat_live USING btree (header_id);
 
 
 --
--- Name: cdp_manager_ilks_cdpi_index; Type: INDEX; Schema: maker; Owner: -
+-- Name: cat_vat_header_id_index; Type: INDEX; Schema: maker; Owner: -
 --
 
-CREATE INDEX cdp_manager_ilks_cdpi_index ON maker.cdp_manager_ilks USING btree (cdpi);
+CREATE INDEX cat_vat_header_id_index ON maker.cat_vat USING btree (header_id);
+
+
+--
+-- Name: cat_vow_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX cat_vow_header_id_index ON maker.cat_vow USING btree (header_id);
+
+
+--
+-- Name: cdp_manager_cdpi_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX cdp_manager_cdpi_header_id_index ON maker.cdp_manager_cdpi USING btree (header_id);
+
+
+--
+-- Name: cdp_manager_count_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX cdp_manager_count_header_id_index ON maker.cdp_manager_count USING btree (header_id);
+
+
+--
+-- Name: cdp_manager_first_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX cdp_manager_first_header_id_index ON maker.cdp_manager_first USING btree (header_id);
+
+
+--
+-- Name: cdp_manager_ilks_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX cdp_manager_ilks_header_id_index ON maker.cdp_manager_ilks USING btree (header_id);
 
 
 --
@@ -14484,10 +15016,31 @@ CREATE INDEX cdp_manager_ilks_ilk_id_index ON maker.cdp_manager_ilks USING btree
 
 
 --
--- Name: cdp_manager_owns_cdpi_index; Type: INDEX; Schema: maker; Owner: -
+-- Name: cdp_manager_last_header_id_index; Type: INDEX; Schema: maker; Owner: -
 --
 
-CREATE INDEX cdp_manager_owns_cdpi_index ON maker.cdp_manager_owns USING btree (cdpi);
+CREATE INDEX cdp_manager_last_header_id_index ON maker.cdp_manager_last USING btree (header_id);
+
+
+--
+-- Name: cdp_manager_list_next_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX cdp_manager_list_next_header_id_index ON maker.cdp_manager_list_next USING btree (header_id);
+
+
+--
+-- Name: cdp_manager_list_prev_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX cdp_manager_list_prev_header_id_index ON maker.cdp_manager_list_prev USING btree (header_id);
+
+
+--
+-- Name: cdp_manager_owns_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX cdp_manager_owns_header_id_index ON maker.cdp_manager_owns USING btree (header_id);
 
 
 --
@@ -14498,10 +15051,10 @@ CREATE INDEX cdp_manager_owns_owner_index ON maker.cdp_manager_owns USING btree 
 
 
 --
--- Name: cdp_manager_urns_cdpi_index; Type: INDEX; Schema: maker; Owner: -
+-- Name: cdp_manager_urns_header_id_index; Type: INDEX; Schema: maker; Owner: -
 --
 
-CREATE INDEX cdp_manager_urns_cdpi_index ON maker.cdp_manager_urns USING btree (cdpi);
+CREATE INDEX cdp_manager_urns_header_id_index ON maker.cdp_manager_urns USING btree (header_id);
 
 
 --
@@ -14512,10 +15065,17 @@ CREATE INDEX cdp_manager_urns_urn_index ON maker.cdp_manager_urns USING btree (u
 
 
 --
--- Name: deal_address_id_index; Type: INDEX; Schema: maker; Owner: -
+-- Name: cdp_manager_vat_header_id_index; Type: INDEX; Schema: maker; Owner: -
 --
 
-CREATE INDEX deal_address_id_index ON maker.deal USING btree (address_id);
+CREATE INDEX cdp_manager_vat_header_id_index ON maker.cdp_manager_vat USING btree (header_id);
+
+
+--
+-- Name: deal_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX deal_address_index ON maker.deal USING btree (address_id);
 
 
 --
@@ -14533,6 +15093,20 @@ CREATE INDEX deal_header_index ON maker.deal USING btree (header_id);
 
 
 --
+-- Name: deal_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX deal_log_index ON maker.deal USING btree (log_id);
+
+
+--
+-- Name: dent_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX dent_address_index ON maker.dent USING btree (address_id);
+
+
+--
 -- Name: dent_header_index; Type: INDEX; Schema: maker; Owner: -
 --
 
@@ -14540,10 +15114,38 @@ CREATE INDEX dent_header_index ON maker.dent USING btree (header_id);
 
 
 --
--- Name: flap_bid_bid_address_id_index; Type: INDEX; Schema: maker; Owner: -
+-- Name: dent_log_index; Type: INDEX; Schema: maker; Owner: -
 --
 
-CREATE INDEX flap_bid_bid_address_id_index ON maker.flap_bid_bid USING btree (address_id);
+CREATE INDEX dent_log_index ON maker.dent USING btree (log_id);
+
+
+--
+-- Name: flap_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flap_address_index ON maker.flap USING btree (address_id);
+
+
+--
+-- Name: flap_beg_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flap_beg_address_index ON maker.flap_beg USING btree (address_id);
+
+
+--
+-- Name: flap_beg_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flap_beg_header_id_index ON maker.flap_beg USING btree (header_id);
+
+
+--
+-- Name: flap_bid_bid_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flap_bid_bid_address_index ON maker.flap_bid_bid USING btree (address_id);
 
 
 --
@@ -14554,10 +15156,17 @@ CREATE INDEX flap_bid_bid_bid_id_index ON maker.flap_bid_bid USING btree (bid_id
 
 
 --
--- Name: flap_bid_end_bid_address_id_index; Type: INDEX; Schema: maker; Owner: -
+-- Name: flap_bid_bid_header_id_index; Type: INDEX; Schema: maker; Owner: -
 --
 
-CREATE INDEX flap_bid_end_bid_address_id_index ON maker.flap_bid_end USING btree (address_id);
+CREATE INDEX flap_bid_bid_header_id_index ON maker.flap_bid_bid USING btree (header_id);
+
+
+--
+-- Name: flap_bid_end_bid_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flap_bid_end_bid_address_index ON maker.flap_bid_end USING btree (address_id);
 
 
 --
@@ -14568,10 +15177,17 @@ CREATE INDEX flap_bid_end_bid_id_index ON maker.flap_bid_end USING btree (bid_id
 
 
 --
--- Name: flap_bid_guy_bid_address_id_index; Type: INDEX; Schema: maker; Owner: -
+-- Name: flap_bid_end_header_id_index; Type: INDEX; Schema: maker; Owner: -
 --
 
-CREATE INDEX flap_bid_guy_bid_address_id_index ON maker.flap_bid_guy USING btree (address_id);
+CREATE INDEX flap_bid_end_header_id_index ON maker.flap_bid_end USING btree (header_id);
+
+
+--
+-- Name: flap_bid_guy_bid_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flap_bid_guy_bid_address_index ON maker.flap_bid_guy USING btree (address_id);
 
 
 --
@@ -14582,10 +15198,17 @@ CREATE INDEX flap_bid_guy_bid_id_index ON maker.flap_bid_guy USING btree (bid_id
 
 
 --
--- Name: flap_bid_lot_bid_address_id_index; Type: INDEX; Schema: maker; Owner: -
+-- Name: flap_bid_guy_header_id_index; Type: INDEX; Schema: maker; Owner: -
 --
 
-CREATE INDEX flap_bid_lot_bid_address_id_index ON maker.flap_bid_lot USING btree (address_id);
+CREATE INDEX flap_bid_guy_header_id_index ON maker.flap_bid_guy USING btree (header_id);
+
+
+--
+-- Name: flap_bid_lot_bid_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flap_bid_lot_bid_address_index ON maker.flap_bid_lot USING btree (address_id);
 
 
 --
@@ -14596,10 +15219,17 @@ CREATE INDEX flap_bid_lot_bid_id_index ON maker.flap_bid_lot USING btree (bid_id
 
 
 --
--- Name: flap_bid_tic_bid_address_id_index; Type: INDEX; Schema: maker; Owner: -
+-- Name: flap_bid_lot_header_id_index; Type: INDEX; Schema: maker; Owner: -
 --
 
-CREATE INDEX flap_bid_tic_bid_address_id_index ON maker.flap_bid_tic USING btree (address_id);
+CREATE INDEX flap_bid_lot_header_id_index ON maker.flap_bid_lot USING btree (header_id);
+
+
+--
+-- Name: flap_bid_tic_bid_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flap_bid_tic_bid_address_index ON maker.flap_bid_tic USING btree (address_id);
 
 
 --
@@ -14610,6 +15240,34 @@ CREATE INDEX flap_bid_tic_bid_id_index ON maker.flap_bid_tic USING btree (bid_id
 
 
 --
+-- Name: flap_bid_tic_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flap_bid_tic_header_id_index ON maker.flap_bid_tic USING btree (header_id);
+
+
+--
+-- Name: flap_gem_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flap_gem_address_index ON maker.flap_gem USING btree (address_id);
+
+
+--
+-- Name: flap_gem_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flap_gem_header_id_index ON maker.flap_gem USING btree (header_id);
+
+
+--
+-- Name: flap_kick_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flap_kick_address_index ON maker.flap_kick USING btree (address_id);
+
+
+--
 -- Name: flap_kick_header_index; Type: INDEX; Schema: maker; Owner: -
 --
 
@@ -14617,24 +15275,108 @@ CREATE INDEX flap_kick_header_index ON maker.flap_kick USING btree (header_id);
 
 
 --
--- Name: flap_kicks_address_id_index; Type: INDEX; Schema: maker; Owner: -
+-- Name: flap_kick_log_index; Type: INDEX; Schema: maker; Owner: -
 --
 
-CREATE INDEX flap_kicks_address_id_index ON maker.flap_kicks USING btree (address_id);
-
-
---
--- Name: flap_kicks_kicks_index; Type: INDEX; Schema: maker; Owner: -
---
-
-CREATE INDEX flap_kicks_kicks_index ON maker.flap_kicks USING btree (kicks);
+CREATE INDEX flap_kick_log_index ON maker.flap_kick USING btree (log_id);
 
 
 --
--- Name: flip_bid_bid_address_id_index; Type: INDEX; Schema: maker; Owner: -
+-- Name: flap_kicks_address_index; Type: INDEX; Schema: maker; Owner: -
 --
 
-CREATE INDEX flip_bid_bid_address_id_index ON maker.flip_bid_bid USING btree (address_id);
+CREATE INDEX flap_kicks_address_index ON maker.flap_kicks USING btree (address_id);
+
+
+--
+-- Name: flap_kicks_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flap_kicks_header_id_index ON maker.flap_kicks USING btree (header_id);
+
+
+--
+-- Name: flap_live_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flap_live_address_index ON maker.flap_live USING btree (address_id);
+
+
+--
+-- Name: flap_live_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flap_live_header_id_index ON maker.flap_live USING btree (header_id);
+
+
+--
+-- Name: flap_tau_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flap_tau_address_index ON maker.flap_tau USING btree (address_id);
+
+
+--
+-- Name: flap_tau_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flap_tau_header_id_index ON maker.flap_tau USING btree (header_id);
+
+
+--
+-- Name: flap_ttl_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flap_ttl_address_index ON maker.flap_ttl USING btree (address_id);
+
+
+--
+-- Name: flap_ttl_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flap_ttl_header_id_index ON maker.flap_ttl USING btree (header_id);
+
+
+--
+-- Name: flap_vat_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flap_vat_address_index ON maker.flap_vat USING btree (address_id);
+
+
+--
+-- Name: flap_vat_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flap_vat_header_id_index ON maker.flap_vat USING btree (header_id);
+
+
+--
+-- Name: flip_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flip_address_index ON maker.flip USING btree (address_id);
+
+
+--
+-- Name: flip_beg_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flip_beg_address_index ON maker.flip_beg USING btree (address_id);
+
+
+--
+-- Name: flip_beg_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flip_beg_header_id_index ON maker.flip_beg USING btree (header_id);
+
+
+--
+-- Name: flip_bid_bid_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flip_bid_bid_address_index ON maker.flip_bid_bid USING btree (address_id);
 
 
 --
@@ -14645,10 +15387,17 @@ CREATE INDEX flip_bid_bid_bid_id_index ON maker.flip_bid_bid USING btree (bid_id
 
 
 --
--- Name: flip_bid_end_address_id_index; Type: INDEX; Schema: maker; Owner: -
+-- Name: flip_bid_bid_header_id_index; Type: INDEX; Schema: maker; Owner: -
 --
 
-CREATE INDEX flip_bid_end_address_id_index ON maker.flip_bid_end USING btree (address_id);
+CREATE INDEX flip_bid_bid_header_id_index ON maker.flip_bid_bid USING btree (header_id);
+
+
+--
+-- Name: flip_bid_end_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flip_bid_end_address_index ON maker.flip_bid_end USING btree (address_id);
 
 
 --
@@ -14659,10 +15408,17 @@ CREATE INDEX flip_bid_end_bid_id_index ON maker.flip_bid_end USING btree (bid_id
 
 
 --
--- Name: flip_bid_gal_address_id_index; Type: INDEX; Schema: maker; Owner: -
+-- Name: flip_bid_end_header_id_index; Type: INDEX; Schema: maker; Owner: -
 --
 
-CREATE INDEX flip_bid_gal_address_id_index ON maker.flip_bid_gal USING btree (address_id);
+CREATE INDEX flip_bid_end_header_id_index ON maker.flip_bid_end USING btree (header_id);
+
+
+--
+-- Name: flip_bid_gal_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flip_bid_gal_address_index ON maker.flip_bid_gal USING btree (address_id);
 
 
 --
@@ -14673,10 +15429,17 @@ CREATE INDEX flip_bid_gal_bid_id_index ON maker.flip_bid_gal USING btree (bid_id
 
 
 --
--- Name: flip_bid_guy_address_id_index; Type: INDEX; Schema: maker; Owner: -
+-- Name: flip_bid_gal_header_id_index; Type: INDEX; Schema: maker; Owner: -
 --
 
-CREATE INDEX flip_bid_guy_address_id_index ON maker.flip_bid_guy USING btree (address_id);
+CREATE INDEX flip_bid_gal_header_id_index ON maker.flip_bid_gal USING btree (header_id);
+
+
+--
+-- Name: flip_bid_guy_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flip_bid_guy_address_index ON maker.flip_bid_guy USING btree (address_id);
 
 
 --
@@ -14687,10 +15450,17 @@ CREATE INDEX flip_bid_guy_bid_id_index ON maker.flip_bid_guy USING btree (bid_id
 
 
 --
--- Name: flip_bid_lot_address_id_index; Type: INDEX; Schema: maker; Owner: -
+-- Name: flip_bid_guy_header_id_index; Type: INDEX; Schema: maker; Owner: -
 --
 
-CREATE INDEX flip_bid_lot_address_id_index ON maker.flip_bid_lot USING btree (address_id);
+CREATE INDEX flip_bid_guy_header_id_index ON maker.flip_bid_guy USING btree (header_id);
+
+
+--
+-- Name: flip_bid_lot_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flip_bid_lot_address_index ON maker.flip_bid_lot USING btree (address_id);
 
 
 --
@@ -14701,10 +15471,17 @@ CREATE INDEX flip_bid_lot_bid_id_index ON maker.flip_bid_lot USING btree (bid_id
 
 
 --
--- Name: flip_bid_tab_address_id_index; Type: INDEX; Schema: maker; Owner: -
+-- Name: flip_bid_lot_header_id_index; Type: INDEX; Schema: maker; Owner: -
 --
 
-CREATE INDEX flip_bid_tab_address_id_index ON maker.flip_bid_tab USING btree (address_id);
+CREATE INDEX flip_bid_lot_header_id_index ON maker.flip_bid_lot USING btree (header_id);
+
+
+--
+-- Name: flip_bid_tab_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flip_bid_tab_address_index ON maker.flip_bid_tab USING btree (address_id);
 
 
 --
@@ -14715,10 +15492,17 @@ CREATE INDEX flip_bid_tab_bid_id_index ON maker.flip_bid_tab USING btree (bid_id
 
 
 --
--- Name: flip_bid_tic_address_id_index; Type: INDEX; Schema: maker; Owner: -
+-- Name: flip_bid_tab_header_id_index; Type: INDEX; Schema: maker; Owner: -
 --
 
-CREATE INDEX flip_bid_tic_address_id_index ON maker.flip_bid_tic USING btree (address_id);
+CREATE INDEX flip_bid_tab_header_id_index ON maker.flip_bid_tab USING btree (header_id);
+
+
+--
+-- Name: flip_bid_tic_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flip_bid_tic_address_index ON maker.flip_bid_tic USING btree (address_id);
 
 
 --
@@ -14729,10 +15513,17 @@ CREATE INDEX flip_bid_tic_bid_id_index ON maker.flip_bid_tic USING btree (bid_id
 
 
 --
--- Name: flip_bid_usr_address_id_index; Type: INDEX; Schema: maker; Owner: -
+-- Name: flip_bid_tic_header_id_index; Type: INDEX; Schema: maker; Owner: -
 --
 
-CREATE INDEX flip_bid_usr_address_id_index ON maker.flip_bid_usr USING btree (address_id);
+CREATE INDEX flip_bid_tic_header_id_index ON maker.flip_bid_tic USING btree (header_id);
+
+
+--
+-- Name: flip_bid_usr_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flip_bid_usr_address_index ON maker.flip_bid_usr USING btree (address_id);
 
 
 --
@@ -14743,6 +15534,27 @@ CREATE INDEX flip_bid_usr_bid_id_index ON maker.flip_bid_usr USING btree (bid_id
 
 
 --
+-- Name: flip_bid_usr_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flip_bid_usr_header_id_index ON maker.flip_bid_usr USING btree (header_id);
+
+
+--
+-- Name: flip_ilk_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flip_ilk_address_index ON maker.flip_ilk USING btree (address_id);
+
+
+--
+-- Name: flip_ilk_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flip_ilk_header_id_index ON maker.flip_ilk USING btree (header_id);
+
+
+--
 -- Name: flip_ilk_ilk_id_index; Type: INDEX; Schema: maker; Owner: -
 --
 
@@ -14750,10 +15562,10 @@ CREATE INDEX flip_ilk_ilk_id_index ON maker.flip_ilk USING btree (ilk_id);
 
 
 --
--- Name: flip_kick_address_id_index; Type: INDEX; Schema: maker; Owner: -
+-- Name: flip_kick_address_index; Type: INDEX; Schema: maker; Owner: -
 --
 
-CREATE INDEX flip_kick_address_id_index ON maker.flip_kick USING btree (address_id);
+CREATE INDEX flip_kick_address_index ON maker.flip_kick USING btree (address_id);
 
 
 --
@@ -14771,24 +15583,94 @@ CREATE INDEX flip_kick_header_index ON maker.flip_kick USING btree (header_id);
 
 
 --
--- Name: flip_kicks_address_id_index; Type: INDEX; Schema: maker; Owner: -
+-- Name: flip_kick_log_index; Type: INDEX; Schema: maker; Owner: -
 --
 
-CREATE INDEX flip_kicks_address_id_index ON maker.flip_kicks USING btree (address_id);
-
-
---
--- Name: flip_kicks_kicks_index; Type: INDEX; Schema: maker; Owner: -
---
-
-CREATE INDEX flip_kicks_kicks_index ON maker.flip_kicks USING btree (kicks);
+CREATE INDEX flip_kick_log_index ON maker.flip_kick USING btree (log_id);
 
 
 --
--- Name: flop_bid_bid_address_id_index; Type: INDEX; Schema: maker; Owner: -
+-- Name: flip_kicks_address_index; Type: INDEX; Schema: maker; Owner: -
 --
 
-CREATE INDEX flop_bid_bid_address_id_index ON maker.flop_bid_bid USING btree (address_id);
+CREATE INDEX flip_kicks_address_index ON maker.flip_kicks USING btree (address_id);
+
+
+--
+-- Name: flip_kicks_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flip_kicks_header_id_index ON maker.flip_kicks USING btree (header_id);
+
+
+--
+-- Name: flip_tau_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flip_tau_address_index ON maker.flip_tau USING btree (address_id);
+
+
+--
+-- Name: flip_tau_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flip_tau_header_id_index ON maker.flip_tau USING btree (header_id);
+
+
+--
+-- Name: flip_ttl_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flip_ttl_address_index ON maker.flip_ttl USING btree (address_id);
+
+
+--
+-- Name: flip_ttl_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flip_ttl_header_id_index ON maker.flip_ttl USING btree (header_id);
+
+
+--
+-- Name: flip_vat_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flip_vat_address_index ON maker.flip_vat USING btree (address_id);
+
+
+--
+-- Name: flip_vat_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flip_vat_header_id_index ON maker.flip_vat USING btree (header_id);
+
+
+--
+-- Name: flop_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flop_address_index ON maker.flop USING btree (address_id);
+
+
+--
+-- Name: flop_beg_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flop_beg_address_index ON maker.flop_beg USING btree (address_id);
+
+
+--
+-- Name: flop_beg_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flop_beg_header_id_index ON maker.flop_beg USING btree (header_id);
+
+
+--
+-- Name: flop_bid_bid_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flop_bid_bid_address_index ON maker.flop_bid_bid USING btree (address_id);
 
 
 --
@@ -14799,10 +15681,17 @@ CREATE INDEX flop_bid_bid_bid_id_index ON maker.flop_bid_bid USING btree (bid_id
 
 
 --
--- Name: flop_bid_end_bid_address_id_index; Type: INDEX; Schema: maker; Owner: -
+-- Name: flop_bid_bid_header_id_index; Type: INDEX; Schema: maker; Owner: -
 --
 
-CREATE INDEX flop_bid_end_bid_address_id_index ON maker.flop_bid_end USING btree (address_id);
+CREATE INDEX flop_bid_bid_header_id_index ON maker.flop_bid_bid USING btree (header_id);
+
+
+--
+-- Name: flop_bid_end_bid_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flop_bid_end_bid_address_index ON maker.flop_bid_end USING btree (address_id);
 
 
 --
@@ -14813,10 +15702,17 @@ CREATE INDEX flop_bid_end_bid_id_index ON maker.flop_bid_end USING btree (bid_id
 
 
 --
--- Name: flop_bid_guy_bid_address_id_index; Type: INDEX; Schema: maker; Owner: -
+-- Name: flop_bid_end_header_id_index; Type: INDEX; Schema: maker; Owner: -
 --
 
-CREATE INDEX flop_bid_guy_bid_address_id_index ON maker.flop_bid_guy USING btree (address_id);
+CREATE INDEX flop_bid_end_header_id_index ON maker.flop_bid_end USING btree (header_id);
+
+
+--
+-- Name: flop_bid_guy_bid_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flop_bid_guy_bid_address_index ON maker.flop_bid_guy USING btree (address_id);
 
 
 --
@@ -14827,10 +15723,17 @@ CREATE INDEX flop_bid_guy_bid_id_index ON maker.flop_bid_guy USING btree (bid_id
 
 
 --
--- Name: flop_bid_lot_bid_address_id_index; Type: INDEX; Schema: maker; Owner: -
+-- Name: flop_bid_guy_header_id_index; Type: INDEX; Schema: maker; Owner: -
 --
 
-CREATE INDEX flop_bid_lot_bid_address_id_index ON maker.flop_bid_lot USING btree (address_id);
+CREATE INDEX flop_bid_guy_header_id_index ON maker.flop_bid_guy USING btree (header_id);
+
+
+--
+-- Name: flop_bid_lot_bid_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flop_bid_lot_bid_address_index ON maker.flop_bid_lot USING btree (address_id);
 
 
 --
@@ -14841,10 +15744,17 @@ CREATE INDEX flop_bid_lot_bid_id_index ON maker.flop_bid_lot USING btree (bid_id
 
 
 --
--- Name: flop_bid_tic_bid_address_id_index; Type: INDEX; Schema: maker; Owner: -
+-- Name: flop_bid_lot_header_id_index; Type: INDEX; Schema: maker; Owner: -
 --
 
-CREATE INDEX flop_bid_tic_bid_address_id_index ON maker.flop_bid_tic USING btree (address_id);
+CREATE INDEX flop_bid_lot_header_id_index ON maker.flop_bid_lot USING btree (header_id);
+
+
+--
+-- Name: flop_bid_tic_bid_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flop_bid_tic_bid_address_index ON maker.flop_bid_tic USING btree (address_id);
 
 
 --
@@ -14855,6 +15765,34 @@ CREATE INDEX flop_bid_tic_bid_id_index ON maker.flop_bid_tic USING btree (bid_id
 
 
 --
+-- Name: flop_bid_tic_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flop_bid_tic_header_id_index ON maker.flop_bid_tic USING btree (header_id);
+
+
+--
+-- Name: flop_gem_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flop_gem_address_index ON maker.flop_gem USING btree (address_id);
+
+
+--
+-- Name: flop_gem_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flop_gem_header_id_index ON maker.flop_gem USING btree (header_id);
+
+
+--
+-- Name: flop_kick_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flop_kick_address_index ON maker.flop_kick USING btree (address_id);
+
+
+--
 -- Name: flop_kick_header_index; Type: INDEX; Schema: maker; Owner: -
 --
 
@@ -14862,17 +15800,101 @@ CREATE INDEX flop_kick_header_index ON maker.flop_kick USING btree (header_id);
 
 
 --
--- Name: flop_kicks_address_id_index; Type: INDEX; Schema: maker; Owner: -
+-- Name: flop_kick_log_index; Type: INDEX; Schema: maker; Owner: -
 --
 
-CREATE INDEX flop_kicks_address_id_index ON maker.flop_kicks USING btree (address_id);
+CREATE INDEX flop_kick_log_index ON maker.flop_kick USING btree (log_id);
 
 
 --
--- Name: flop_kicks_kicks_index; Type: INDEX; Schema: maker; Owner: -
+-- Name: flop_kicks_address_index; Type: INDEX; Schema: maker; Owner: -
 --
 
-CREATE INDEX flop_kicks_kicks_index ON maker.flop_kicks USING btree (kicks);
+CREATE INDEX flop_kicks_address_index ON maker.flop_kicks USING btree (address_id);
+
+
+--
+-- Name: flop_kicks_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flop_kicks_header_id_index ON maker.flop_kicks USING btree (header_id);
+
+
+--
+-- Name: flop_live_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flop_live_address_index ON maker.flop_live USING btree (address_id);
+
+
+--
+-- Name: flop_live_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flop_live_header_id_index ON maker.flop_live USING btree (header_id);
+
+
+--
+-- Name: flop_pad_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flop_pad_address_index ON maker.flop_pad USING btree (address_id);
+
+
+--
+-- Name: flop_pad_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flop_pad_header_id_index ON maker.flop_pad USING btree (header_id);
+
+
+--
+-- Name: flop_tau_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flop_tau_address_index ON maker.flop_tau USING btree (address_id);
+
+
+--
+-- Name: flop_tau_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flop_tau_header_id_index ON maker.flop_tau USING btree (header_id);
+
+
+--
+-- Name: flop_ttl_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flop_ttl_address_index ON maker.flop_ttl USING btree (address_id);
+
+
+--
+-- Name: flop_ttl_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flop_ttl_header_id_index ON maker.flop_ttl USING btree (header_id);
+
+
+--
+-- Name: flop_vat_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flop_vat_address_index ON maker.flop_vat USING btree (address_id);
+
+
+--
+-- Name: flop_vat_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flop_vat_header_id_index ON maker.flop_vat USING btree (header_id);
+
+
+--
+-- Name: jug_base_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX jug_base_header_id_index ON maker.jug_base USING btree (header_id);
 
 
 --
@@ -14890,10 +15912,24 @@ CREATE INDEX jug_drip_ilk_index ON maker.jug_drip USING btree (ilk_id);
 
 
 --
+-- Name: jug_drip_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX jug_drip_log_index ON maker.jug_drip USING btree (log_id);
+
+
+--
 -- Name: jug_file_base_header_index; Type: INDEX; Schema: maker; Owner: -
 --
 
 CREATE INDEX jug_file_base_header_index ON maker.jug_file_base USING btree (header_id);
+
+
+--
+-- Name: jug_file_base_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX jug_file_base_log_index ON maker.jug_file_base USING btree (log_id);
 
 
 --
@@ -14911,10 +15947,24 @@ CREATE INDEX jug_file_ilk_ilk_index ON maker.jug_file_ilk USING btree (ilk_id);
 
 
 --
+-- Name: jug_file_ilk_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX jug_file_ilk_log_index ON maker.jug_file_ilk USING btree (log_id);
+
+
+--
 -- Name: jug_file_vow_header_index; Type: INDEX; Schema: maker; Owner: -
 --
 
 CREATE INDEX jug_file_vow_header_index ON maker.jug_file_vow USING btree (header_id);
+
+
+--
+-- Name: jug_file_vow_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX jug_file_vow_log_index ON maker.jug_file_vow USING btree (log_id);
 
 
 --
@@ -14960,10 +16010,45 @@ CREATE INDEX jug_init_ilk_index ON maker.jug_init USING btree (ilk_id);
 
 
 --
+-- Name: jug_init_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX jug_init_log_index ON maker.jug_init USING btree (log_id);
+
+
+--
+-- Name: jug_vat_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX jug_vat_header_id_index ON maker.jug_vat USING btree (header_id);
+
+
+--
+-- Name: jug_vow_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX jug_vow_header_id_index ON maker.jug_vow USING btree (header_id);
+
+
+--
 -- Name: log_value_header_index; Type: INDEX; Schema: maker; Owner: -
 --
 
 CREATE INDEX log_value_header_index ON maker.log_value USING btree (header_id);
+
+
+--
+-- Name: log_value_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX log_value_log_index ON maker.log_value USING btree (log_id);
+
+
+--
+-- Name: new_cdp_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX new_cdp_log_index ON maker.new_cdp USING btree (log_id);
 
 
 --
@@ -14974,6 +16059,13 @@ CREATE INDEX pot_cage_header_index ON maker.pot_cage USING btree (header_id);
 
 
 --
+-- Name: pot_cage_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX pot_cage_log_index ON maker.pot_cage USING btree (log_id);
+
+
+--
 -- Name: pot_file_dsr_header_index; Type: INDEX; Schema: maker; Owner: -
 --
 
@@ -14981,10 +16073,24 @@ CREATE INDEX pot_file_dsr_header_index ON maker.pot_file_dsr USING btree (header
 
 
 --
+-- Name: pot_file_dsr_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX pot_file_dsr_log_index ON maker.pot_file_dsr USING btree (log_id);
+
+
+--
 -- Name: pot_file_vow_header_index; Type: INDEX; Schema: maker; Owner: -
 --
 
 CREATE INDEX pot_file_vow_header_index ON maker.pot_file_vow USING btree (header_id);
+
+
+--
+-- Name: pot_file_vow_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX pot_file_vow_log_index ON maker.pot_file_vow USING btree (log_id);
 
 
 --
@@ -15002,6 +16108,13 @@ CREATE INDEX spot_file_mat_ilk_index ON maker.spot_file_mat USING btree (ilk_id)
 
 
 --
+-- Name: spot_file_mat_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX spot_file_mat_log_index ON maker.spot_file_mat USING btree (log_id);
+
+
+--
 -- Name: spot_file_pip_header_index; Type: INDEX; Schema: maker; Owner: -
 --
 
@@ -15013,6 +16126,13 @@ CREATE INDEX spot_file_pip_header_index ON maker.spot_file_pip USING btree (head
 --
 
 CREATE INDEX spot_file_pip_ilk_index ON maker.spot_file_pip USING btree (ilk_id);
+
+
+--
+-- Name: spot_file_pip_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX spot_file_pip_log_index ON maker.spot_file_pip USING btree (log_id);
 
 
 --
@@ -15044,6 +16164,13 @@ CREATE INDEX spot_ilk_pip_ilk_index ON maker.spot_ilk_pip USING btree (ilk_id);
 
 
 --
+-- Name: spot_par_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX spot_par_header_id_index ON maker.spot_par USING btree (header_id);
+
+
+--
 -- Name: spot_poke_header_index; Type: INDEX; Schema: maker; Owner: -
 --
 
@@ -15058,10 +16185,45 @@ CREATE INDEX spot_poke_ilk_index ON maker.spot_poke USING btree (ilk_id);
 
 
 --
+-- Name: spot_poke_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX spot_poke_log_index ON maker.spot_poke USING btree (log_id);
+
+
+--
+-- Name: spot_vat_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX spot_vat_header_id_index ON maker.spot_vat USING btree (header_id);
+
+
+--
+-- Name: tend_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX tend_address_index ON maker.tend USING btree (address_id);
+
+
+--
 -- Name: tend_header_index; Type: INDEX; Schema: maker; Owner: -
 --
 
 CREATE INDEX tend_header_index ON maker.tend USING btree (header_id);
+
+
+--
+-- Name: tend_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX tend_log_index ON maker.tend USING btree (log_id);
+
+
+--
+-- Name: tick_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX tick_address_index ON maker.tick USING btree (address_id);
 
 
 --
@@ -15079,6 +16241,13 @@ CREATE INDEX tick_header_index ON maker.tick USING btree (header_id);
 
 
 --
+-- Name: tick_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX tick_log_index ON maker.tick USING btree (log_id);
+
+
+--
 -- Name: urn_ilk_index; Type: INDEX; Schema: maker; Owner: -
 --
 
@@ -15086,10 +16255,31 @@ CREATE INDEX urn_ilk_index ON maker.urns USING btree (ilk_id);
 
 
 --
+-- Name: vat_dai_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vat_dai_header_id_index ON maker.vat_dai USING btree (header_id);
+
+
+--
+-- Name: vat_debt_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vat_debt_header_id_index ON maker.vat_debt USING btree (header_id);
+
+
+--
 -- Name: vat_file_debt_ceiling_header_index; Type: INDEX; Schema: maker; Owner: -
 --
 
 CREATE INDEX vat_file_debt_ceiling_header_index ON maker.vat_file_debt_ceiling USING btree (header_id);
+
+
+--
+-- Name: vat_file_debt_ceiling_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vat_file_debt_ceiling_log_index ON maker.vat_file_debt_ceiling USING btree (log_id);
 
 
 --
@@ -15107,6 +16297,13 @@ CREATE INDEX vat_file_ilk_ilk_index ON maker.vat_file_ilk USING btree (ilk_id);
 
 
 --
+-- Name: vat_file_ilk_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vat_file_ilk_log_index ON maker.vat_file_ilk USING btree (log_id);
+
+
+--
 -- Name: vat_flux_header_index; Type: INDEX; Schema: maker; Owner: -
 --
 
@@ -15118,6 +16315,13 @@ CREATE INDEX vat_flux_header_index ON maker.vat_flux USING btree (header_id);
 --
 
 CREATE INDEX vat_flux_ilk_index ON maker.vat_flux USING btree (ilk_id);
+
+
+--
+-- Name: vat_flux_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vat_flux_log_index ON maker.vat_flux USING btree (log_id);
 
 
 --
@@ -15135,6 +16339,13 @@ CREATE INDEX vat_fold_ilk_index ON maker.vat_fold USING btree (ilk_id);
 
 
 --
+-- Name: vat_fold_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vat_fold_log_index ON maker.vat_fold USING btree (log_id);
+
+
+--
 -- Name: vat_fork_header_index; Type: INDEX; Schema: maker; Owner: -
 --
 
@@ -15149,6 +16360,13 @@ CREATE INDEX vat_fork_ilk_index ON maker.vat_fork USING btree (ilk_id);
 
 
 --
+-- Name: vat_fork_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vat_fork_log_index ON maker.vat_fork USING btree (log_id);
+
+
+--
 -- Name: vat_frob_header_index; Type: INDEX; Schema: maker; Owner: -
 --
 
@@ -15156,10 +16374,24 @@ CREATE INDEX vat_frob_header_index ON maker.vat_frob USING btree (header_id);
 
 
 --
+-- Name: vat_frob_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vat_frob_log_index ON maker.vat_frob USING btree (log_id);
+
+
+--
 -- Name: vat_frob_urn_index; Type: INDEX; Schema: maker; Owner: -
 --
 
 CREATE INDEX vat_frob_urn_index ON maker.vat_frob USING btree (urn_id);
+
+
+--
+-- Name: vat_gem_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vat_gem_header_id_index ON maker.vat_gem USING btree (header_id);
 
 
 --
@@ -15177,6 +16409,13 @@ CREATE INDEX vat_grab_header_index ON maker.vat_grab USING btree (header_id);
 
 
 --
+-- Name: vat_grab_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vat_grab_log_index ON maker.vat_grab USING btree (log_id);
+
+
+--
 -- Name: vat_grab_urn_index; Type: INDEX; Schema: maker; Owner: -
 --
 
@@ -15188,6 +16427,13 @@ CREATE INDEX vat_grab_urn_index ON maker.vat_grab USING btree (urn_id);
 --
 
 CREATE INDEX vat_heal_header_index ON maker.vat_heal USING btree (header_id);
+
+
+--
+-- Name: vat_heal_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vat_heal_log_index ON maker.vat_heal USING btree (log_id);
 
 
 --
@@ -15275,10 +16521,45 @@ CREATE INDEX vat_init_ilk_index ON maker.vat_init USING btree (ilk_id);
 
 
 --
+-- Name: vat_init_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vat_init_log_index ON maker.vat_init USING btree (log_id);
+
+
+--
+-- Name: vat_line_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vat_line_header_id_index ON maker.vat_line USING btree (header_id);
+
+
+--
+-- Name: vat_live_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vat_live_header_id_index ON maker.vat_live USING btree (header_id);
+
+
+--
 -- Name: vat_move_header_index; Type: INDEX; Schema: maker; Owner: -
 --
 
 CREATE INDEX vat_move_header_index ON maker.vat_move USING btree (header_id);
+
+
+--
+-- Name: vat_move_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vat_move_log_index ON maker.vat_move USING btree (log_id);
+
+
+--
+-- Name: vat_sin_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vat_sin_header_id_index ON maker.vat_sin USING btree (header_id);
 
 
 --
@@ -15296,10 +16577,24 @@ CREATE INDEX vat_slip_ilk_index ON maker.vat_slip USING btree (ilk_id);
 
 
 --
+-- Name: vat_slip_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vat_slip_log_index ON maker.vat_slip USING btree (log_id);
+
+
+--
 -- Name: vat_suck_header_index; Type: INDEX; Schema: maker; Owner: -
 --
 
 CREATE INDEX vat_suck_header_index ON maker.vat_suck USING btree (header_id);
+
+
+--
+-- Name: vat_suck_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vat_suck_log_index ON maker.vat_suck USING btree (log_id);
 
 
 --
@@ -15331,6 +16626,34 @@ CREATE INDEX vat_urn_ink_urn_index ON maker.vat_urn_ink USING btree (urn_id);
 
 
 --
+-- Name: vat_vice_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vat_vice_header_id_index ON maker.vat_vice USING btree (header_id);
+
+
+--
+-- Name: vow_ash_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vow_ash_header_id_index ON maker.vow_ash USING btree (header_id);
+
+
+--
+-- Name: vow_bump_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vow_bump_header_id_index ON maker.vow_bump USING btree (header_id);
+
+
+--
+-- Name: vow_dump_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vow_dump_header_id_index ON maker.vow_dump USING btree (header_id);
+
+
+--
 -- Name: vow_fess_header_index; Type: INDEX; Schema: maker; Owner: -
 --
 
@@ -15338,10 +16661,31 @@ CREATE INDEX vow_fess_header_index ON maker.vow_fess USING btree (header_id);
 
 
 --
+-- Name: vow_fess_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vow_fess_log_index ON maker.vow_fess USING btree (log_id);
+
+
+--
 -- Name: vow_file_header_index; Type: INDEX; Schema: maker; Owner: -
 --
 
 CREATE INDEX vow_file_header_index ON maker.vow_file USING btree (header_id);
+
+
+--
+-- Name: vow_file_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vow_file_log_index ON maker.vow_file USING btree (log_id);
+
+
+--
+-- Name: vow_flapper_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vow_flapper_header_id_index ON maker.vow_flapper USING btree (header_id);
 
 
 --
@@ -15359,10 +16703,73 @@ CREATE INDEX vow_flog_header_index ON maker.vow_flog USING btree (header_id);
 
 
 --
+-- Name: vow_flog_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vow_flog_log_index ON maker.vow_flog USING btree (log_id);
+
+
+--
+-- Name: vow_flopper_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vow_flopper_header_id_index ON maker.vow_flopper USING btree (header_id);
+
+
+--
+-- Name: vow_hump_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vow_hump_header_id_index ON maker.vow_hump USING btree (header_id);
+
+
+--
+-- Name: vow_sin_integer_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vow_sin_integer_header_id_index ON maker.vow_sin_integer USING btree (header_id);
+
+
+--
 -- Name: vow_sin_mapping_era_index; Type: INDEX; Schema: maker; Owner: -
 --
 
 CREATE INDEX vow_sin_mapping_era_index ON maker.vow_sin_mapping USING btree (era);
+
+
+--
+-- Name: vow_sin_mapping_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vow_sin_mapping_header_id_index ON maker.vow_sin_mapping USING btree (header_id);
+
+
+--
+-- Name: vow_sump_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vow_sump_header_id_index ON maker.vow_sump USING btree (header_id);
+
+
+--
+-- Name: vow_vat_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vow_vat_header_id_index ON maker.vow_vat USING btree (header_id);
+
+
+--
+-- Name: vow_wait_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vow_wait_header_id_index ON maker.vow_wait USING btree (header_id);
+
+
+--
+-- Name: yank_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX yank_address_index ON maker.yank USING btree (address_id);
 
 
 --
@@ -15380,6 +16787,13 @@ CREATE INDEX yank_header_index ON maker.yank USING btree (header_id);
 
 
 --
+-- Name: yank_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX yank_log_index ON maker.yank USING btree (log_id);
+
+
+--
 -- Name: block_id_index; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -15387,10 +16801,73 @@ CREATE INDEX block_id_index ON public.full_sync_transactions USING btree (block_
 
 
 --
+-- Name: full_sync_logs_receipt; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX full_sync_logs_receipt ON public.full_sync_logs USING btree (receipt_id);
+
+
+--
+-- Name: full_sync_receipts_block; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX full_sync_receipts_block ON public.full_sync_receipts USING btree (block_id);
+
+
+--
+-- Name: full_sync_receipts_contract_address; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX full_sync_receipts_contract_address ON public.full_sync_receipts USING btree (contract_address_id);
+
+
+--
+-- Name: header_sync_logs_address; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX header_sync_logs_address ON public.header_sync_logs USING btree (address);
+
+
+--
+-- Name: header_sync_logs_transaction; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX header_sync_logs_transaction ON public.header_sync_logs USING btree (tx_hash);
+
+
+--
+-- Name: header_sync_receipts_contract_address; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX header_sync_receipts_contract_address ON public.header_sync_receipts USING btree (contract_address_id);
+
+
+--
+-- Name: header_sync_receipts_transaction; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX header_sync_receipts_transaction ON public.header_sync_receipts USING btree (transaction_id);
+
+
+--
+-- Name: header_sync_transactions_header; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX header_sync_transactions_header ON public.header_sync_transactions USING btree (header_id);
+
+
+--
 -- Name: headers_block_number; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX headers_block_number ON public.headers USING btree (block_number);
+
+
+--
+-- Name: headers_eth_node; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX headers_eth_node ON public.headers USING btree (eth_node_id);
 
 
 --
@@ -15419,6 +16896,13 @@ CREATE INDEX tx_from_index ON public.full_sync_transactions USING btree (tx_from
 --
 
 CREATE INDEX tx_to_index ON public.full_sync_transactions USING btree (tx_to);
+
+
+--
+-- Name: uncles_eth_node; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX uncles_eth_node ON public.uncles USING btree (eth_node_id);
 
 
 --


### PR DESCRIPTION
Add the indexes that postgraphile complains about lacking when run with the `--no-ignore-indexes` flag

Also I noticed that when running postgraphile with the `api` and `maker` schemas, a bunch of convenience methods being used by our trigger tables are exposed, so I went ahead and added `omit` tags to those. It might make more sense to exclude them a different way (maybe a different schema?), but I figured this might work as a first pass. 