### PR TITLE
Allow for passing in a VDB version to Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,12 @@ ENV GO111MODULE on
 WORKDIR /go/src/github.com/makerdao/vdb-mcd-transformers
 ADD . .
 
+ARG VDB_VERSION=staging
+
 WORKDIR /go/src/github.com/makerdao
 RUN git clone https://github.com/makerdao/vulcanizedb.git
 WORKDIR /go/src/github.com/makerdao/vulcanizedb
-RUN git checkout v0.0.10
+RUN git checkout $VDB_VERSION
 RUN go build
 
 # build mcd with local vdb


### PR DESCRIPTION
Allowing to pass in a VDB version, and defaults to `staging`. Realized I needed this for https://github.com/makerdao/vdb-mcd-transformers/pull/61 😅 