### PR TITLE
Return error when foreign key insert fails

### DIFF
--- a/transformers/events/flap_kick/converter.go
+++ b/transformers/events/flap_kick/converter.go
@@ -67,7 +67,7 @@ func (converter Converter) ToModels(abi string, logs []core.HeaderSyncLog, db *p
 		}
 		addressId, addressErr := shared.GetOrCreateAddress(flapKickEntity.ContractAddress.Hex(), db)
 		if addressErr != nil {
-			_ = shared.ErrCouldNotCreateFK(addressErr)
+			return nil, shared.ErrCouldNotCreateFK(addressErr)
 		}
 
 		model := event.InsertionModel{

--- a/transformers/events/flip_kick/converter.go
+++ b/transformers/events/flip_kick/converter.go
@@ -67,7 +67,7 @@ func (c Converter) ToModels(abi string, logs []core.HeaderSyncLog, db *postgres.
 		}
 		addressId, addressErr := shared.GetOrCreateAddress(flipKickEntity.ContractAddress.Hex(), db)
 		if addressErr != nil {
-			_ = shared.ErrCouldNotCreateFK(addressErr)
+			return nil, shared.ErrCouldNotCreateFK(addressErr)
 		}
 
 		model := event.InsertionModel{

--- a/transformers/events/flop_kick/converter.go
+++ b/transformers/events/flop_kick/converter.go
@@ -65,7 +65,7 @@ func (c Converter) ToModels(abi string, logs []core.HeaderSyncLog, db *postgres.
 	for _, flopKickEntity := range entities {
 		addressId, addressErr := shared.GetOrCreateAddress(flopKickEntity.ContractAddress.Hex(), db)
 		if addressErr != nil {
-			_ = shared.ErrCouldNotCreateFK(addressErr)
+			return nil, shared.ErrCouldNotCreateFK(addressErr)
 		}
 
 		model := event.InsertionModel{

--- a/transformers/events/jug_init/converter.go
+++ b/transformers/events/jug_init/converter.go
@@ -37,7 +37,7 @@ func (Converter) ToModels(_ string, logs []core.HeaderSyncLog, db *postgres.DB) 
 		ilk := log.Log.Topics[2].Hex()
 		ilkID, ilkErr := shared.GetOrCreateIlk(ilk, db)
 		if ilkErr != nil {
-			_ = shared.ErrCouldNotCreateFK(ilkErr)
+			return nil, shared.ErrCouldNotCreateFK(ilkErr)
 		}
 
 		model := event.InsertionModel{

--- a/transformers/events/vat_move/converter.go
+++ b/transformers/events/vat_move/converter.go
@@ -32,7 +32,7 @@ func (Converter) ToModels(_ string, logs []core.HeaderSyncLog, _ *postgres.DB) (
 	for _, log := range logs {
 		err := shared.VerifyLog(log.Log, shared.FourTopicsRequired, shared.LogDataNotRequired)
 		if err != nil {
-			return []event.InsertionModel{}, err
+			return nil, err
 		}
 
 		src := common.BytesToAddress(log.Log.Topics[1].Bytes()).String()


### PR DESCRIPTION
Thanks @m0ar for noticing this issue!

Ideally I'd love to have tests to hedge against regressions here, but I was having trouble coming up for an effective strategy for doing so. Normally I'd mock the namespace that inserts an `ilk` or `address`, but those aren't behind an interface right now (maybe worth considering?). Some things I tried:
- passing null values for the relevant topic - seems to happily insert a zero-valued field (problem?)
- passing a null db - results on a panic on the call to `db.Get` (maybe we need a null check on the db in converters that use it?)

Would welcome ideas!