### PR TITLE
(VDB-1075) deny event transformer

### DIFF
--- a/db/migrations/20191223233720_create_deny.sql
+++ b/db/migrations/20191223233720_create_deny.sql
@@ -1,0 +1,28 @@
+-- +goose Up
+CREATE TABLE maker.deny
+(
+    id         SERIAL PRIMARY KEY,
+    header_id  INTEGER NOT NULL REFERENCES headers (id) ON DELETE CASCADE,
+    log_id     BIGINT  NOT NULL REFERENCES header_sync_logs (id) ON DELETE CASCADE,
+    address_id INTEGER NOT NULL REFERENCES addresses (id) ON DELETE CASCADE,
+    usr        INTEGER NOT NULL REFERENCES addresses (id) ON DELETE CASCADE,
+    UNIQUE (header_id, log_id)
+);
+
+CREATE INDEX deny_header_index
+    ON maker.deny (header_id);
+CREATE INDEX deny_log_index
+    ON maker.deny (log_id);
+CREATE INDEX deny_address_index
+    ON maker.deny (address_id);
+CREATE INDEX deny_usr_index
+    ON maker.deny (usr);
+
+
+-- +goose Down
+DROP INDEX maker.deny_usr_index;
+DROP INDEX maker.deny_address_index;
+DROP INDEX maker.deny_log_index;
+DROP INDEX maker.deny_header_index;
+
+DROP TABLE maker.deny;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -7017,6 +7017,39 @@ ALTER SEQUENCE maker.dent_id_seq OWNED BY maker.dent.id;
 
 
 --
+-- Name: deny; Type: TABLE; Schema: maker; Owner: -
+--
+
+CREATE TABLE maker.deny (
+    id integer NOT NULL,
+    header_id integer NOT NULL,
+    log_id bigint NOT NULL,
+    address_id integer NOT NULL,
+    usr integer NOT NULL
+);
+
+
+--
+-- Name: deny_id_seq; Type: SEQUENCE; Schema: maker; Owner: -
+--
+
+CREATE SEQUENCE maker.deny_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: deny_id_seq; Type: SEQUENCE OWNED BY; Schema: maker; Owner: -
+--
+
+ALTER SEQUENCE maker.deny_id_seq OWNED BY maker.deny.id;
+
+
+--
 -- Name: flap; Type: TABLE; Schema: maker; Owner: -
 --
 
@@ -11960,6 +11993,13 @@ ALTER TABLE ONLY maker.dent ALTER COLUMN id SET DEFAULT nextval('maker.dent_id_s
 
 
 --
+-- Name: deny id; Type: DEFAULT; Schema: maker; Owner: -
+--
+
+ALTER TABLE ONLY maker.deny ALTER COLUMN id SET DEFAULT nextval('maker.deny_id_seq'::regclass);
+
+
+--
 -- Name: flap id; Type: DEFAULT; Schema: maker; Owner: -
 --
 
@@ -13349,6 +13389,22 @@ ALTER TABLE ONLY maker.dent
 
 ALTER TABLE ONLY maker.dent
     ADD CONSTRAINT dent_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: deny deny_header_id_log_id_key; Type: CONSTRAINT; Schema: maker; Owner: -
+--
+
+ALTER TABLE ONLY maker.deny
+    ADD CONSTRAINT deny_header_id_log_id_key UNIQUE (header_id, log_id);
+
+
+--
+-- Name: deny deny_pkey; Type: CONSTRAINT; Schema: maker; Owner: -
+--
+
+ALTER TABLE ONLY maker.deny
+    ADD CONSTRAINT deny_pkey PRIMARY KEY (id);
 
 
 --
@@ -15893,6 +15949,34 @@ CREATE INDEX dent_header_index ON maker.dent USING btree (header_id);
 --
 
 CREATE INDEX dent_log_index ON maker.dent USING btree (log_id);
+
+
+--
+-- Name: deny_address_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX deny_address_index ON maker.deny USING btree (address_id);
+
+
+--
+-- Name: deny_header_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX deny_header_index ON maker.deny USING btree (header_id);
+
+
+--
+-- Name: deny_log_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX deny_log_index ON maker.deny USING btree (log_id);
+
+
+--
+-- Name: deny_usr_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX deny_usr_index ON maker.deny USING btree (usr);
 
 
 --
@@ -18550,6 +18634,38 @@ ALTER TABLE ONLY maker.dent
 
 ALTER TABLE ONLY maker.dent
     ADD CONSTRAINT dent_log_id_fkey FOREIGN KEY (log_id) REFERENCES public.header_sync_logs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: deny deny_address_id_fkey; Type: FK CONSTRAINT; Schema: maker; Owner: -
+--
+
+ALTER TABLE ONLY maker.deny
+    ADD CONSTRAINT deny_address_id_fkey FOREIGN KEY (address_id) REFERENCES public.addresses(id) ON DELETE CASCADE;
+
+
+--
+-- Name: deny deny_header_id_fkey; Type: FK CONSTRAINT; Schema: maker; Owner: -
+--
+
+ALTER TABLE ONLY maker.deny
+    ADD CONSTRAINT deny_header_id_fkey FOREIGN KEY (header_id) REFERENCES public.headers(id) ON DELETE CASCADE;
+
+
+--
+-- Name: deny deny_log_id_fkey; Type: FK CONSTRAINT; Schema: maker; Owner: -
+--
+
+ALTER TABLE ONLY maker.deny
+    ADD CONSTRAINT deny_log_id_fkey FOREIGN KEY (log_id) REFERENCES public.header_sync_logs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: deny deny_usr_fkey; Type: FK CONSTRAINT; Schema: maker; Owner: -
+--
+
+ALTER TABLE ONLY maker.deny
+    ADD CONSTRAINT deny_usr_fkey FOREIGN KEY (usr) REFERENCES public.addresses(id) ON DELETE CASCADE;
 
 
 --

--- a/environments/docker.toml
+++ b/environments/docker.toml
@@ -21,6 +21,7 @@
         "cat_file_vow",
         "deal",
         "dent",
+        "deny",
         "flap_kick",
         "flip_kick",
         "flop_kick",
@@ -43,6 +44,7 @@
         "spot_poke",
         "tend",
         "tick",
+        "vat_deny",
         "vat_file_debt_ceiling",
         "vat_file_ilk",
         "vat_flux",
@@ -174,6 +176,14 @@
         repository = "github.com/makerdao/vdb-mcd-transformers"
         migrations = "db/migrations"
         contracts = ["MCD_FLIP_ETH_A", "MCD_FLIP_BAT_A", "MCD_FLIP_SAI", "MCD_FLOP"]
+        rank = "0"
+    [exporter.deny]
+        path = "transformers/events/deny/initializer"
+        type = "eth_event"
+        repository = "github.com/makerdao/vdb-mcd-transformers"
+        migrations = "db/migrations"
+        contracts = ["MCD_CAT", "MCD_FLAP", "MCD_FLIP_ETH_A", "MCD_FLIP_BAT_A", "MCD_FLIP_SAI", "MCD_FLOP", "MCD_JUG",
+                     "MCD_POT", "MCD_SPOT", "MCD_VOW"]
         rank = "0"
     [exporter.flap_kick]
         path = "transformers/events/flap_kick/initializer"
@@ -328,6 +338,13 @@
         repository = "github.com/makerdao/vdb-mcd-transformers"
         migrations = "db/migrations"
         contracts = ["MCD_FLIP_ETH_A", "MCD_FLIP_BAT_A", "MCD_FLIP_SAI", "MCD_FLAP", "MCD_FLOP"]
+        rank = "0"
+    [exporter.vat_deny]
+        path = "transformers/events/deny/vat_initializer"
+        type = "eth_event"
+        repository = "github.com/makerdao/vdb-mcd-transformers"
+        migrations = "db/migrations"
+        contracts = ["MCD_VAT"]
         rank = "0"
     [exporter.vat_file_debt_ceiling]
         path = "transformers/events/vat_file/debt_ceiling/initializer"

--- a/environments/mcdTransformers.toml
+++ b/environments/mcdTransformers.toml
@@ -34,6 +34,7 @@
         "cat_file_vow",
         "deal",
         "dent",
+        "deny",
         "flap_kick",
         "flip_kick",
         "flop_kick",
@@ -56,6 +57,7 @@
         "spot_poke",
         "tend",
         "tick",
+        "vat_deny",
         "vat_file_debt_ceiling",
         "vat_file_ilk",
         "vat_flux",
@@ -187,6 +189,14 @@
         repository = "github.com/makerdao/vdb-mcd-transformers"
         migrations = "db/migrations"
         contracts = ["MCD_FLIP_ETH_A", "MCD_FLIP_BAT_A", "MCD_FLIP_SAI", "MCD_FLOP"]
+        rank = "0"
+    [exporter.deny]
+        path = "transformers/events/deny/initializer"
+        type = "eth_event"
+        repository = "github.com/makerdao/vdb-mcd-transformers"
+        migrations = "db/migrations"
+        contracts = ["MCD_CAT", "MCD_FLAP", "MCD_FLIP_ETH_A", "MCD_FLIP_BAT_A", "MCD_FLIP_SAI", "MCD_FLOP", "MCD_JUG",
+                     "MCD_POT", "MCD_SPOT", "MCD_VOW"]
         rank = "0"
     [exporter.flap_kick]
         path = "transformers/events/flap_kick/initializer"
@@ -341,6 +351,13 @@
         repository = "github.com/makerdao/vdb-mcd-transformers"
         migrations = "db/migrations"
         contracts = ["MCD_FLIP_ETH_A", "MCD_FLIP_BAT_A", "MCD_FLIP_SAI", "MCD_FLAP", "MCD_FLOP"]
+        rank = "0"
+    [exporter.vat_deny]
+        path = "transformers/events/deny/vat_initializer"
+        type = "eth_event"
+        repository = "github.com/makerdao/vdb-mcd-transformers"
+        migrations = "db/migrations"
+        contracts = ["MCD_VAT"]
         rank = "0"
     [exporter.vat_file_debt_ceiling]
         path = "transformers/events/vat_file/debt_ceiling/initializer"

--- a/environments/testing.toml
+++ b/environments/testing.toml
@@ -34,6 +34,7 @@
         "cat_file_vow",
         "deal",
         "dent",
+        "deny",
         "flap_kick",
         "flip_kick",
         "flop_kick",
@@ -56,6 +57,7 @@
         "spot_poke",
         "tend",
         "tick",
+        "vat_deny",
         "vat_file_debt_ceiling",
         "vat_file_ilk",
         "vat_flux",
@@ -187,6 +189,14 @@
         repository = "github.com/makerdao/vdb-mcd-transformers"
         migrations = "db/migrations"
         contracts = [ "MCD_FLIP_ETH_A", "MCD_FLIP_BAT_A", "MCD_FLIP_SAI", "MCD_FLOP" ]
+        rank = "0"
+    [exporter.deny]
+        path = "transformers/events/deny/initializer"
+        type = "eth_event"
+        repository = "github.com/makerdao/vdb-mcd-transformers"
+        migrations = "db/migrations"
+        contracts = ["MCD_CAT", "MCD_FLAP", "MCD_FLIP_ETH_A", "MCD_FLIP_BAT_A", "MCD_FLIP_SAI", "MCD_FLOP", "MCD_JUG",
+                     "MCD_POT", "MCD_SPOT", "MCD_VOW"]
         rank = "0"
     [exporter.flap_kick]
         path = "transformers/events/flap_kick/initializer"
@@ -341,6 +351,13 @@
         repository = "github.com/makerdao/vdb-mcd-transformers"
         migrations = "db/migrations"
         contracts = [ "MCD_FLIP_ETH_A", "MCD_FLIP_BAT_A", "MCD_FLIP_SAI", "MCD_FLAP", "MCD_FLOP" ]
+        rank = "0"
+    [exporter.vat_deny]
+        path = "transformers/events/deny/vat_initializer"
+        type = "eth_event"
+        repository = "github.com/makerdao/vdb-mcd-transformers"
+        migrations = "db/migrations"
+        contracts = ["MCD_VAT"]
         rank = "0"
     [exporter.vat_file_debt_ceiling]
         path = "transformers/events/vat_file/debt_ceiling/initializer"

--- a/transformers/events/deny/converter.go
+++ b/transformers/events/deny/converter.go
@@ -1,0 +1,53 @@
+package deny
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
+	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
+	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/pkg/core"
+	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
+)
+
+type Converter struct {
+	LogNoteArgumentOffset int
+}
+
+func (c Converter) ToModels(_ string, logs []core.HeaderSyncLog, db *postgres.DB) ([]event.InsertionModel, error) {
+	numTopicsRequired := shared.ThreeTopicsRequired + c.LogNoteArgumentOffset
+	usrTopicIndex := 2 + c.LogNoteArgumentOffset
+	var models []event.InsertionModel
+	for _, log := range logs {
+		validationErr := shared.VerifyLog(log.Log, numTopicsRequired, shared.LogDataNotRequired)
+		if validationErr != nil {
+			return nil, validationErr
+		}
+
+		contractAddress := log.Log.Address.String()
+		contractAddressID, contractAddressErr := shared.GetOrCreateAddress(contractAddress, db)
+		if contractAddressErr != nil {
+			return nil, shared.ErrCouldNotCreateFK(contractAddressErr)
+		}
+
+		usrAddress := common.HexToAddress(log.Log.Topics[usrTopicIndex].Hex()).Hex()
+		usrAddressID, usrAddressErr := shared.GetOrCreateAddress(usrAddress, db)
+		if usrAddressErr != nil {
+			return nil, shared.ErrCouldNotCreateFK(usrAddressErr)
+		}
+
+		model := event.InsertionModel{
+			SchemaName:     constants.MakerSchema,
+			TableName:      constants.DenyTable,
+			OrderedColumns: []event.ColumnName{event.HeaderFK, event.LogFK, event.AddressFK, constants.UsrColumn},
+			ColumnValues: event.ColumnValues{
+				event.HeaderFK:      log.HeaderID,
+				event.LogFK:         log.ID,
+				event.AddressFK:     contractAddressID,
+				constants.UsrColumn: usrAddressID,
+			},
+		}
+		models = append(models, model)
+	}
+
+	return models, nil
+}

--- a/transformers/events/deny/converter_test.go
+++ b/transformers/events/deny/converter_test.go
@@ -1,0 +1,77 @@
+package deny_test
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/makerdao/vdb-mcd-transformers/test_config"
+	"github.com/makerdao/vdb-mcd-transformers/transformers/events/deny"
+	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
+	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
+	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
+	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/pkg/core"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Deny Converter", func() {
+	var db = test_config.NewTestDB(test_config.NewTestNode())
+
+	BeforeEach(func() {
+		test_config.CleanTestDB(db)
+	})
+
+	It("converts normal deny logs to models", func() {
+		converter := deny.Converter{}
+		models, err := converter.ToModels(constants.CatABI(), []core.HeaderSyncLog{test_data.DenyHeaderSyncLog}, db)
+		Expect(err).NotTo(HaveOccurred())
+
+		var contractAddressID int64
+		contractAddressErr := db.Get(&contractAddressID, `SELECT id FROM addresses WHERE address = $1`,
+			test_data.DenyHeaderSyncLog.Log.Address.String())
+		Expect(contractAddressErr).NotTo(HaveOccurred())
+
+		var usrAddressID int64
+		usrAddressErr := db.Get(&usrAddressID, `SELECT id FROM addresses WHERE address = $1`,
+			common.HexToAddress(test_data.DenyHeaderSyncLog.Log.Topics[2].Hex()).Hex())
+		Expect(usrAddressErr).NotTo(HaveOccurred())
+
+		expectedModel := test_data.DenyModel()
+		expectedModel.ColumnValues[event.AddressFK] = contractAddressID
+		expectedModel.ColumnValues[constants.UsrColumn] = usrAddressID
+
+		Expect(models).To(Equal([]event.InsertionModel{expectedModel}))
+	})
+
+	It("converts Vat deny logs to models", func() {
+		converter := deny.Converter{LogNoteArgumentOffset: -1}
+		models, err := converter.ToModels(constants.VatABI(), []core.HeaderSyncLog{test_data.VatDenyHeaderSyncLog}, db)
+		Expect(err).NotTo(HaveOccurred())
+
+		var contractAddressID int64
+		contractAddressErr := db.Get(&contractAddressID, `SELECT id FROM addresses WHERE address = $1`,
+			test_data.VatDenyHeaderSyncLog.Log.Address.String())
+		Expect(contractAddressErr).NotTo(HaveOccurred())
+
+		var usrAddressID int64
+		usrAddressErr := db.Get(&usrAddressID, `SELECT id FROM addresses WHERE address = $1`,
+			common.HexToAddress(test_data.VatDenyHeaderSyncLog.Log.Topics[1].Hex()).Hex())
+		Expect(usrAddressErr).NotTo(HaveOccurred())
+
+		expectedModel := test_data.VatDenyModel()
+		expectedModel.ColumnValues[event.AddressFK] = contractAddressID
+		expectedModel.ColumnValues[constants.UsrColumn] = usrAddressID
+
+		Expect(models).To(Equal([]event.InsertionModel{expectedModel}))
+	})
+
+	It("returns an error if the expected amount of topics aren't in the log", func() {
+		converter := deny.Converter{}
+		invalidLog := test_data.DenyHeaderSyncLog
+		invalidLog.Log.Topics = []common.Hash{}
+
+		_, err := converter.ToModels(constants.CatABI(), []core.HeaderSyncLog{invalidLog}, db)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(shared.ErrLogMissingTopics(3, 0)))
+	})
+})

--- a/transformers/events/deny/deny_suite_test.go
+++ b/transformers/events/deny/deny_suite_test.go
@@ -1,0 +1,13 @@
+package deny_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestDeny(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Deny Suite")
+}

--- a/transformers/events/deny/initializer/initializer.go
+++ b/transformers/events/deny/initializer/initializer.go
@@ -1,0 +1,14 @@
+package initializer
+
+import (
+	"github.com/makerdao/vdb-mcd-transformers/transformers/events/deny"
+	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
+	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
+	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/transformer"
+)
+
+var EventTransformerInitializer transformer.EventTransformerInitializer = event.Transformer{
+	Config:    shared.GetEventTransformerConfig(constants.DenyTable, constants.DenySignature()),
+	Converter: deny.Converter{},
+}.NewTransformer

--- a/transformers/events/deny/vat_initializer/initializer.go
+++ b/transformers/events/deny/vat_initializer/initializer.go
@@ -1,0 +1,14 @@
+package vat_initializer
+
+import (
+	"github.com/makerdao/vdb-mcd-transformers/transformers/events/deny"
+	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
+	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
+	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/transformer"
+)
+
+var EventTransformerInitializer transformer.EventTransformerInitializer = event.Transformer{
+	Config:    shared.GetEventTransformerConfig(constants.DenyTable, constants.DenySignature()),
+	Converter: deny.Converter{LogNoteArgumentOffset: -1},
+}.NewTransformer

--- a/transformers/integration_tests/deny_test.go
+++ b/transformers/integration_tests/deny_test.go
@@ -1,0 +1,119 @@
+package integration_tests
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/makerdao/vdb-mcd-transformers/test_config"
+	"github.com/makerdao/vdb-mcd-transformers/transformers/events/deny"
+	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
+	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
+	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
+	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/transformer"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Deny transformer", func() {
+	const (
+		defaultOffset int = 0
+		vatOffset     int = -1
+	)
+
+	Context("Cat deny events", func() {
+		usrAddress := "0x13141b8a5e4a82ebc6b636849dd6a515185d6236"
+		denyIntegrationTest(int64(14764643), test_data.CatAddress(), usrAddress, defaultOffset)
+	})
+
+	Context("Flap deny events", func() {
+		usrAddress := "0x13141b8a5e4a82ebc6b636849dd6a515185d6236"
+		denyIntegrationTest(int64(14764643), test_data.FlapAddress(), usrAddress, defaultOffset)
+	})
+
+	Context("Flip deny events", func() {
+		usrAddress := "0x13141b8a5e4a82ebc6b636849dd6a515185d6236"
+		denyIntegrationTest(int64(14764652), test_data.EthFlipAddress(), usrAddress, defaultOffset)
+	})
+
+	Context("Flop deny events", func() {
+		usrAddress := "0x13141b8a5e4a82ebc6b636849dd6a515185d6236"
+		denyIntegrationTest(int64(14764643), test_data.FlopAddress(), usrAddress, defaultOffset)
+	})
+
+	Context("Jug deny events", func() {
+		usrAddress := "0x13141b8a5e4a82ebc6b636849dd6a515185d6236"
+		denyIntegrationTest(int64(14764643), test_data.JugAddress(), usrAddress, defaultOffset)
+	})
+
+	Context("Pot deny events", func() {
+		usrAddress := "0x13141b8a5e4a82ebc6b636849dd6a515185d6236"
+		denyIntegrationTest(int64(14764643), test_data.PotAddress(), usrAddress, defaultOffset)
+	})
+
+	Context("Spot deny events", func() {
+		usrAddress := "0x13141b8a5e4a82ebc6b636849dd6a515185d6236"
+		denyIntegrationTest(int64(14764643), test_data.SpotAddress(), usrAddress, defaultOffset)
+	})
+
+	Context("Vat deny events", func() {
+		usrAddress := "0x13141b8a5e4a82ebc6b636849dd6a515185d6236"
+		denyIntegrationTest(int64(14764643), test_data.VowAddress(), usrAddress, vatOffset)
+	})
+
+	Context("Vow deny events", func() {
+		usrAddress := "0x13141b8a5e4a82ebc6b636849dd6a515185d6236"
+		denyIntegrationTest(int64(14764643), test_data.VowAddress(), usrAddress, defaultOffset)
+	})
+})
+
+func denyIntegrationTest(blockNumber int64, contractAddressHex, usrAddressHex string, logNoteArgumentOffset int) {
+	It("persists event", func() {
+		test_config.CleanTestDB(db)
+		logFetcher := fetcher.NewLogFetcher(blockChain)
+		denyConfig := transformer.EventTransformerConfig{
+			TransformerName: constants.DenyTable,
+			Topic:           constants.DenySignature(),
+		}
+		initializer := event.Transformer{
+			Config:    denyConfig,
+			Converter: deny.Converter{LogNoteArgumentOffset: logNoteArgumentOffset},
+		}
+
+		header, headerErr := persistHeader(db, blockNumber, blockChain)
+		Expect(headerErr).NotTo(HaveOccurred())
+
+		initializer.Config.ContractAddresses = []string{contractAddressHex}
+		initializer.Config.StartingBlockNumber = blockNumber
+		initializer.Config.EndingBlockNumber = blockNumber
+
+		address := common.HexToAddress(contractAddressHex)
+		topics := []common.Hash{common.HexToHash(denyConfig.Topic)}
+
+		logs, logsErr := logFetcher.FetchLogs([]common.Address{address}, topics, header)
+		Expect(logsErr).NotTo(HaveOccurred())
+
+		headerSyncLogs := test_data.CreateLogs(header.Id, logs, db)
+
+		denyTransformer := initializer.NewTransformer(db)
+		transformErr := denyTransformer.Execute(headerSyncLogs)
+		Expect(transformErr).NotTo(HaveOccurred())
+
+		var dbResult []denyModel
+		err := db.Select(&dbResult, `SELECT address_id, usr FROM maker.deny`)
+		Expect(err).NotTo(HaveOccurred())
+
+		contractAddressID, contractAddressErr := shared.GetOrCreateAddress(contractAddressHex, db)
+		Expect(contractAddressErr).NotTo(HaveOccurred())
+		usrAddressID, usrAddressErr := shared.GetOrCreateAddress(usrAddressHex, db)
+		Expect(usrAddressErr).NotTo(HaveOccurred())
+
+		Expect(len(dbResult)).To(Equal(1))
+		Expect(dbResult[0].AddressId).To(Equal(contractAddressID))
+		Expect(dbResult[0].Usr).To(Equal(usrAddressID))
+	})
+}
+
+type denyModel struct {
+	Usr       int64 `db:"usr"`
+	AddressId int64 `db:"address_id"`
+}

--- a/transformers/shared/constants/method.go
+++ b/transformers/shared/constants/method.go
@@ -47,6 +47,7 @@ func catFileVowMethod() string {
 }
 func dealMethod() string     { return getSolidityFunctionSignature(FlipABI(), "deal") }
 func dentMethod() string     { return getSolidityFunctionSignature(FlipABI(), "dent") }
+func denyMethod() string     { return getSolidityFunctionSignature(CatABI(), "deny") }
 func flapKickMethod() string { return getSolidityFunctionSignature(FlapABI(), "Kick") }
 func flipKickMethod() string { return getSolidityFunctionSignature(FlipABI(), "Kick") }
 func flopKickMethod() string { return getSolidityFunctionSignature(FlopABI(), "Kick") }

--- a/transformers/shared/constants/signature.go
+++ b/transformers/shared/constants/signature.go
@@ -22,6 +22,7 @@ func CatFileFlipSignature() string        { return getLogNoteTopicZero(catFileFl
 func CatFileVowSignature() string         { return getLogNoteTopicZero(catFileVowMethod()) }
 func DealSignature() string               { return getLogNoteTopicZero(dealMethod()) }
 func DentSignature() string               { return getLogNoteTopicZero(dentMethod()) }
+func DenySignature() string               { return getLogNoteTopicZero(denyMethod()) }
 func FlapKickSignature() string           { return getEventTopicZero(flapKickMethod()) }
 func FlipKickSignature() string           { return getEventTopicZero(flipKickMethod()) }
 func FlopKickSignature() string           { return getEventTopicZero(flopKickMethod()) }

--- a/transformers/shared/constants/signature_test.go
+++ b/transformers/shared/constants/signature_test.go
@@ -46,6 +46,10 @@ var _ = Describe("Signature constants", func() {
 		Expect(DentSignature()).To(Equal("0x5ff3a38200000000000000000000000000000000000000000000000000000000"))
 	})
 
+	It("generates deny signature", func() {
+		Expect(DenySignature()).To(Equal("0x9c52a7f100000000000000000000000000000000000000000000000000000000"))
+	})
+
 	It("generates flap kick signature", func() {
 		Expect(FlapKickSignature()).To(Equal("0xe6dde59cbc017becba89714a037778d234a84ce7f0a137487142a007e580d609"))
 	})

--- a/transformers/shared/constants/table.go
+++ b/transformers/shared/constants/table.go
@@ -30,6 +30,7 @@ const (
 	CatFileVowTable         = "cat_file_vow"
 	DealTable               = "deal"
 	DentTable               = "dent"
+	DenyTable               = "deny"
 	FlapKickTable           = "flap_kick"
 	FlipKickTable           = "flip_kick"
 	FlopKickTable           = "flop_kick"

--- a/transformers/test_data/deny.go
+++ b/transformers/test_data/deny.go
@@ -1,0 +1,82 @@
+package test_data
+
+import (
+	"math/rand"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
+	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/pkg/core"
+	"github.com/makerdao/vulcanizedb/pkg/fakes"
+)
+
+var rawDenyLog = types.Log{
+	Address: common.HexToAddress(CatAddress()),
+	Topics: []common.Hash{
+		common.HexToHash(constants.DenySignature()),
+		common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"),
+		common.HexToHash("0x00000000000000000000000013141b8a5e4a82ebc6b636849dd6a515185d6236"),
+		common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"),
+	},
+	Data:        hexutil.MustDecode("0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000e09c52a7f100000000000000000000000013141b8a5e4a82ebc6b636849dd6a515185d62360000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"),
+	BlockNumber: 10,
+	TxHash:      common.HexToHash("0xe8f39fbb7fea3621f543868f19b1114e305aff6a063a30d32835ff1012526f91"),
+	TxIndex:     7,
+	BlockHash:   fakes.FakeHash,
+	Index:       8,
+	Removed:     false,
+}
+
+var DenyHeaderSyncLog = core.HeaderSyncLog{
+	ID:          int64(rand.Int31()),
+	HeaderID:    int64(rand.Int31()),
+	Log:         rawDenyLog,
+	Transformed: false,
+}
+
+func DenyModel() event.InsertionModel { return CopyModel(denyModel) }
+
+var denyModel = event.InsertionModel{
+	SchemaName:     constants.MakerSchema,
+	TableName:      constants.DenyTable,
+	OrderedColumns: []event.ColumnName{event.HeaderFK, event.LogFK, event.AddressFK, constants.UsrColumn},
+	ColumnValues:   event.ColumnValues{event.HeaderFK: DenyHeaderSyncLog.HeaderID, event.LogFK: DenyHeaderSyncLog.ID},
+}
+
+var rawVatDenyLog = types.Log{
+	Address: common.HexToAddress(VatAddress()),
+	Topics: []common.Hash{
+		common.HexToHash(constants.DenySignature()),
+		common.HexToHash("0x00000000000000000000000013141b8a5e4a82ebc6b636849dd6a515185d6236"),
+		common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"),
+		common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"),
+	},
+	Data:        hexutil.MustDecode("0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000e09c52a7f100000000000000000000000013141b8a5e4a82ebc6b636849dd6a515185d62360000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"),
+	BlockNumber: 10,
+	TxHash:      common.HexToHash("0xe8f39fbb7fea3621f543868f19b1114e305aff6a063a30d32835ff1012526f91"),
+	TxIndex:     7,
+	BlockHash:   fakes.FakeHash,
+	Index:       8,
+	Removed:     false,
+}
+
+var VatDenyHeaderSyncLog = core.HeaderSyncLog{
+	ID:          int64(rand.Int31()),
+	HeaderID:    int64(rand.Int31()),
+	Log:         rawVatDenyLog,
+	Transformed: false,
+}
+
+func VatDenyModel() event.InsertionModel { return CopyModel(vatDenyModel) }
+
+var vatDenyModel = event.InsertionModel{
+	SchemaName:     constants.MakerSchema,
+	TableName:      constants.DenyTable,
+	OrderedColumns: []event.ColumnName{event.HeaderFK, event.LogFK, event.AddressFK, constants.UsrColumn},
+	ColumnValues: event.ColumnValues{
+		event.HeaderFK: VatDenyHeaderSyncLog.HeaderID,
+		event.LogFK:    VatDenyHeaderSyncLog.ID,
+	},
+}


### PR DESCRIPTION
This PR attempts to use the same transformer across all contracts' `deny` events, despite `Vat`'s `LogNote` events being shaped slightly differently. 