### PR TITLE
(VDB-1133) Add auction reorg-safety triggers

### DIFF
--- a/db/migrations/20190711091453_create_flip_table.sql
+++ b/db/migrations/20190711091453_create_flip_table.sql
@@ -14,7 +14,7 @@ CREATE TABLE maker.flip
     tab          NUMERIC   DEFAULT NULL,
     created      TIMESTAMP DEFAULT NULL,
     updated      TIMESTAMP NOT NULL,
-    PRIMARY KEY (block_number, bid_id, address_id)
+    PRIMARY KEY (address_id, bid_id, block_number)
 );
 
 CREATE INDEX flip_address_index
@@ -164,8 +164,51 @@ $$
 COMMENT ON FUNCTION flip_bid_time_created
     IS E'@omit';
 
-
 -- +goose StatementBegin
+CREATE OR REPLACE FUNCTION maker.delete_obsolete_flip(bid_id NUMERIC, address_id INTEGER, header_id INTEGER) RETURNS VOID AS
+$$
+DECLARE
+    flip_block      BIGINT     := (
+        SELECT block_number
+        FROM public.headers
+        WHERE id = header_id);
+    flip_state      maker.flip := (
+        SELECT (flip.address_id, block_number, flip.bid_id, guy, tic, "end", lot, bid, usr, gal, tab, created, updated)
+        FROM maker.flip
+        WHERE flip.bid_id = delete_obsolete_flip.bid_id
+          AND flip.address_id = delete_obsolete_flip.address_id
+          AND flip.block_number = flip_block);
+    prev_flip_state maker.flip := (
+        SELECT (flip.address_id, block_number, flip.bid_id, guy, tic, "end", lot, bid, usr, gal, tab, created, updated)
+        FROM maker.flip
+        WHERE flip.bid_id = delete_obsolete_flip.bid_id
+          AND flip.address_id = delete_obsolete_flip.address_id
+          AND flip.block_number < flip_block
+        ORDER BY flip.block_number DESC
+        LIMIT 1);
+BEGIN
+    DELETE
+    FROM maker.flip
+    WHERE flip.bid_id = delete_obsolete_flip.bid_id
+      AND flip.address_id = delete_obsolete_flip.address_id
+      AND flip.block_number = flip_block
+      AND (flip_state.guy IS NULL OR flip_state.guy = prev_flip_state.guy)
+      AND (flip_state.tic IS NULL OR flip_state.tic = prev_flip_state.tic)
+      AND (flip_state."end" IS NULL OR flip_state."end" = prev_flip_state."end")
+      AND (flip_state.lot IS NULL OR flip_state.lot = prev_flip_state.lot)
+      AND (flip_state.bid IS NULL OR flip_state.bid = prev_flip_state.bid)
+      AND (flip_state.usr IS NULL OR flip_state.usr = prev_flip_state.usr)
+      AND (flip_state.gal IS NULL OR flip_state.gal = prev_flip_state.gal)
+      AND (flip_state.tab IS NULL OR flip_state.tab = prev_flip_state.tab);
+END
+$$
+    LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+COMMENT ON FUNCTION maker.delete_obsolete_flip
+    IS E'@omit';
+
+
 CREATE OR REPLACE FUNCTION maker.insert_new_flip_guy(new_diff maker.flip_bid_guy) RETURNS VOID AS
 $$
 WITH diff_block AS (
@@ -188,32 +231,31 @@ VALUES (new_diff.bid_id,
         flip_bid_tab_before_block(new_diff.bid_id, new_diff.address_id, new_diff.header_id),
         (SELECT api.epoch_to_datetime(block_timestamp) FROM diff_block),
         flip_bid_time_created(new_diff.address_id, new_diff.bid_id))
-ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET guy = new_diff.guy;
+ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET guy = new_diff.guy
 $$
     LANGUAGE sql;
--- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.update_flip_guys_until_next_diff(new_diff maker.flip_bid_guy) RETURNS VOID
+CREATE OR REPLACE FUNCTION maker.update_flip_guys_until_next_diff(start_at_diff maker.flip_bid_guy, new_guy TEXT) RETURNS VOID
 AS
 $$
 DECLARE
     diff_block_number   BIGINT := (
         SELECT block_number
         FROM public.headers
-        WHERE id = new_diff.header_id);
+        WHERE id = start_at_diff.header_id);
     next_guy_diff_block BIGINT := (
         SELECT MIN(block_number)
         FROM maker.flip_bid_guy
                  LEFT JOIN public.headers ON flip_bid_guy.header_id = headers.id
-        WHERE flip_bid_guy.bid_id = new_diff.bid_id
-          AND flip_bid_guy.address_id = new_diff.address_id
+        WHERE flip_bid_guy.bid_id = start_at_diff.bid_id
+          AND flip_bid_guy.address_id = start_at_diff.address_id
           AND block_number > diff_block_number);
 BEGIN
     UPDATE maker.flip
-    SET guy = new_diff.guy
-    WHERE flip.bid_id = new_diff.bid_id
-      AND flip.address_id = new_diff.address_id
+    SET guy = new_guy
+    WHERE flip.bid_id = start_at_diff.bid_id
+      AND flip.address_id = start_at_diff.address_id
       AND flip.block_number >= diff_block_number
       AND (next_guy_diff_block IS NULL
         OR flip.block_number < next_guy_diff_block);
@@ -230,8 +272,15 @@ CREATE OR REPLACE FUNCTION maker.update_flip_guys() RETURNS TRIGGER
 AS
 $$
 BEGIN
-    PERFORM maker.insert_new_flip_guy(NEW);
-    PERFORM maker.update_flip_guys_until_next_diff(NEW);
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_new_flip_guy(NEW);
+        PERFORM maker.update_flip_guys_until_next_diff(NEW, NEW.guy);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.update_flip_guys_until_next_diff(
+                OLD,
+                flip_bid_guy_before_block(OLD.bid_id, OLD.address_id, OLD.header_id));
+        PERFORM maker.delete_obsolete_flip(OLD.bid_id, OLD.address_id, OLD.header_id);
+    END IF;
     RETURN NULL;
 END
 $$
@@ -239,12 +288,11 @@ $$
 -- +goose StatementEnd
 
 CREATE TRIGGER flip_guy
-    AFTER INSERT OR UPDATE
+    AFTER INSERT OR UPDATE OR DELETE
     ON maker.flip_bid_guy
     FOR EACH ROW
 EXECUTE PROCEDURE maker.update_flip_guys();
 
--- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.insert_new_flip_tic(new_diff maker.flip_bid_tic) RETURNS VOID AS
 $$
 WITH diff_block AS (
@@ -267,32 +315,31 @@ VALUES (new_diff.bid_id,
         flip_bid_tab_before_block(new_diff.bid_id, new_diff.address_id, new_diff.header_id),
         (SELECT api.epoch_to_datetime(block_timestamp) FROM diff_block),
         flip_bid_time_created(new_diff.address_id, new_diff.bid_id))
-ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET tic = new_diff.tic;
+ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET tic = new_diff.tic
 $$
     LANGUAGE sql;
--- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.update_flip_tics_until_next_diff(new_diff maker.flip_bid_tic) RETURNS VOID
+CREATE OR REPLACE FUNCTION maker.update_flip_tics_until_next_diff(start_at_diff maker.flip_bid_tic, new_tic NUMERIC) RETURNS VOID
 AS
 $$
 DECLARE
     diff_block_number   BIGINT := (
         SELECT block_number
         FROM public.headers
-        WHERE id = new_diff.header_id);
+        WHERE id = start_at_diff.header_id);
     next_tic_diff_block BIGINT := (
         SELECT MIN(block_number)
         FROM maker.flip_bid_tic
                  LEFT JOIN public.headers ON flip_bid_tic.header_id = headers.id
-        WHERE flip_bid_tic.bid_id = new_diff.bid_id
-          AND flip_bid_tic.address_id = new_diff.address_id
+        WHERE flip_bid_tic.bid_id = start_at_diff.bid_id
+          AND flip_bid_tic.address_id = start_at_diff.address_id
           AND block_number > diff_block_number);
 BEGIN
     UPDATE maker.flip
-    SET tic = new_diff.tic
-    WHERE flip.bid_id = new_diff.bid_id
-      AND flip.address_id = new_diff.address_id
+    SET tic = new_tic
+    WHERE flip.bid_id = start_at_diff.bid_id
+      AND flip.address_id = start_at_diff.address_id
       AND flip.block_number >= diff_block_number
       AND (next_tic_diff_block IS NULL
         OR flip.block_number < next_tic_diff_block);
@@ -309,8 +356,15 @@ CREATE OR REPLACE FUNCTION maker.update_flip_tics() RETURNS TRIGGER
 AS
 $$
 BEGIN
-    PERFORM maker.insert_new_flip_tic(NEW);
-    PERFORM maker.update_flip_tics_until_next_diff(NEW);
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_new_flip_tic(NEW);
+        PERFORM maker.update_flip_tics_until_next_diff(NEW, NEW.tic);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.update_flip_tics_until_next_diff(
+                OLD,
+                flip_bid_tic_before_block(OLD.bid_id, OLD.address_id, OLD.header_id));
+        PERFORM maker.delete_obsolete_flip(OLD.bid_id, OLD.address_id, OLD.header_id);
+    END IF;
     RETURN NULL;
 END
 $$
@@ -318,12 +372,11 @@ $$
 -- +goose StatementEnd
 
 CREATE TRIGGER flip_tic
-    AFTER INSERT OR UPDATE
+    AFTER INSERT OR UPDATE OR DELETE
     ON maker.flip_bid_tic
     FOR EACH ROW
 EXECUTE PROCEDURE maker.update_flip_tics();
 
--- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.insert_new_flip_end(new_diff maker.flip_bid_end) RETURNS VOID AS
 $$
 WITH diff_block AS (
@@ -346,32 +399,31 @@ VALUES (new_diff.bid_id,
         flip_bid_tab_before_block(new_diff.bid_id, new_diff.address_id, new_diff.header_id),
         (SELECT api.epoch_to_datetime(block_timestamp) FROM diff_block),
         flip_bid_time_created(new_diff.address_id, new_diff.bid_id))
-ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET "end" = new_diff."end";
+ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET "end" = new_diff."end"
 $$
     LANGUAGE sql;
--- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.update_flip_ends_until_next_diff(new_diff maker.flip_bid_end) RETURNS VOID
+CREATE OR REPLACE FUNCTION maker.update_flip_ends_until_next_diff(start_at_diff maker.flip_bid_end, new_end NUMERIC) RETURNS VOID
 AS
 $$
 DECLARE
     diff_block_number   BIGINT := (
         SELECT block_number
         FROM public.headers
-        WHERE id = new_diff.header_id);
+        WHERE id = start_at_diff.header_id);
     next_end_diff_block BIGINT := (
         SELECT MIN(block_number)
         FROM maker.flip_bid_end
                  LEFT JOIN public.headers ON flip_bid_end.header_id = headers.id
-        WHERE flip_bid_end.bid_id = new_diff.bid_id
-          AND flip_bid_end.address_id = new_diff.address_id
+        WHERE flip_bid_end.bid_id = start_at_diff.bid_id
+          AND flip_bid_end.address_id = start_at_diff.address_id
           AND block_number > diff_block_number);
 BEGIN
     UPDATE maker.flip
-    SET "end" = new_diff."end"
-    WHERE flip.bid_id = new_diff.bid_id
-      AND flip.address_id = new_diff.address_id
+    SET "end" = new_end
+    WHERE flip.bid_id = start_at_diff.bid_id
+      AND flip.address_id = start_at_diff.address_id
       AND flip.block_number >= diff_block_number
       AND (next_end_diff_block IS NULL
         OR flip.block_number < next_end_diff_block);
@@ -388,8 +440,15 @@ CREATE OR REPLACE FUNCTION maker.update_flip_ends() RETURNS TRIGGER
 AS
 $$
 BEGIN
-    PERFORM maker.insert_new_flip_end(NEW);
-    PERFORM maker.update_flip_ends_until_next_diff(NEW);
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_new_flip_end(NEW);
+        PERFORM maker.update_flip_ends_until_next_diff(NEW, NEW."end");
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.update_flip_ends_until_next_diff(
+                OLD,
+                flip_bid_end_before_block(OLD.bid_id, OLD.address_id, OLD.header_id));
+        PERFORM maker.delete_obsolete_flip(OLD.bid_id, OLD.address_id, OLD.header_id);
+    END IF;
     RETURN NULL;
 END
 $$
@@ -397,12 +456,11 @@ $$
 -- +goose StatementEnd
 
 CREATE TRIGGER flip_end
-    AFTER INSERT OR UPDATE
+    AFTER INSERT OR UPDATE OR DELETE
     ON maker.flip_bid_end
     FOR EACH ROW
 EXECUTE PROCEDURE maker.update_flip_ends();
 
--- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.insert_new_flip_lot(new_diff maker.flip_bid_lot) RETURNS VOID AS
 $$
 WITH diff_block AS (
@@ -425,32 +483,31 @@ VALUES (new_diff.bid_id,
         flip_bid_tab_before_block(new_diff.bid_id, new_diff.address_id, new_diff.header_id),
         (SELECT api.epoch_to_datetime(block_timestamp) FROM diff_block),
         flip_bid_time_created(new_diff.address_id, new_diff.bid_id))
-ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET lot = new_diff.lot;
+ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET lot = new_diff.lot
 $$
     LANGUAGE sql;
--- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.update_flip_lots_until_next_diff(new_diff maker.flip_bid_lot) RETURNS VOID
+CREATE OR REPLACE FUNCTION maker.update_flip_lots_until_next_diff(start_at_diff maker.flip_bid_lot, new_lot NUMERIC) RETURNS VOID
 AS
 $$
 DECLARE
     diff_block_number   BIGINT := (
         SELECT block_number
         FROM public.headers
-        WHERE id = new_diff.header_id);
+        WHERE id = start_at_diff.header_id);
     next_lot_diff_block BIGINT := (
         SELECT MIN(block_number)
         FROM maker.flip_bid_lot
                  LEFT JOIN public.headers ON flip_bid_lot.header_id = headers.id
-        WHERE flip_bid_lot.bid_id = new_diff.bid_id
-          AND flip_bid_lot.address_id = new_diff.address_id
+        WHERE flip_bid_lot.bid_id = start_at_diff.bid_id
+          AND flip_bid_lot.address_id = start_at_diff.address_id
           AND block_number > diff_block_number);
 BEGIN
     UPDATE maker.flip
-    SET lot = new_diff.lot
-    WHERE flip.bid_id = new_diff.bid_id
-      AND flip.address_id = new_diff.address_id
+    SET lot = new_lot
+    WHERE flip.bid_id = start_at_diff.bid_id
+      AND flip.address_id = start_at_diff.address_id
       AND flip.block_number >= diff_block_number
       AND (next_lot_diff_block IS NULL
         OR flip.block_number < next_lot_diff_block);
@@ -467,8 +524,15 @@ CREATE OR REPLACE FUNCTION maker.update_flip_lots() RETURNS TRIGGER
 AS
 $$
 BEGIN
-    PERFORM maker.insert_new_flip_lot(NEW);
-    PERFORM maker.update_flip_lots_until_next_diff(NEW);
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_new_flip_lot(NEW);
+        PERFORM maker.update_flip_lots_until_next_diff(NEW, NEW.lot);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.update_flip_lots_until_next_diff(
+                OLD,
+                flip_bid_lot_before_block(OLD.bid_id, OLD.address_id, OLD.header_id));
+        PERFORM maker.delete_obsolete_flip(OLD.bid_id, OLD.address_id, OLD.header_id);
+    END IF;
     RETURN NULL;
 END
 $$
@@ -476,12 +540,11 @@ $$
 -- +goose StatementEnd
 
 CREATE TRIGGER flip_lot
-    AFTER INSERT OR UPDATE
+    AFTER INSERT OR UPDATE OR DELETE
     ON maker.flip_bid_lot
     FOR EACH ROW
 EXECUTE PROCEDURE maker.update_flip_lots();
 
--- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.insert_new_flip_bid(new_diff maker.flip_bid_bid) RETURNS VOID AS
 $$
 WITH diff_block AS (
@@ -504,32 +567,31 @@ VALUES (new_diff.bid_id,
         flip_bid_tab_before_block(new_diff.bid_id, new_diff.address_id, new_diff.header_id),
         (SELECT api.epoch_to_datetime(block_timestamp) FROM diff_block),
         flip_bid_time_created(new_diff.address_id, new_diff.bid_id))
-ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET bid = new_diff.bid;
+ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET bid = new_diff.bid
 $$
     LANGUAGE sql;
--- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.update_flip_bids_until_next_diff(new_diff maker.flip_bid_bid) RETURNS VOID
+CREATE OR REPLACE FUNCTION maker.update_flip_bids_until_next_diff(start_at_diff maker.flip_bid_bid, new_bid NUMERIC) RETURNS VOID
 AS
 $$
 DECLARE
     diff_block_number   BIGINT := (
         SELECT block_number
         FROM public.headers
-        WHERE id = new_diff.header_id);
+        WHERE id = start_at_diff.header_id);
     next_bid_diff_block BIGINT := (
         SELECT MIN(block_number)
         FROM maker.flip_bid_bid
                  LEFT JOIN public.headers ON flip_bid_bid.header_id = headers.id
-        WHERE flip_bid_bid.bid_id = new_diff.bid_id
-          AND flip_bid_bid.address_id = new_diff.address_id
+        WHERE flip_bid_bid.bid_id = start_at_diff.bid_id
+          AND flip_bid_bid.address_id = start_at_diff.address_id
           AND block_number > diff_block_number);
 BEGIN
     UPDATE maker.flip
-    SET bid = new_diff.bid
-    WHERE flip.bid_id = new_diff.bid_id
-      AND flip.address_id = new_diff.address_id
+    SET bid = new_bid
+    WHERE flip.bid_id = start_at_diff.bid_id
+      AND flip.address_id = start_at_diff.address_id
       AND flip.block_number >= diff_block_number
       AND (next_bid_diff_block IS NULL
         OR flip.block_number < next_bid_diff_block);
@@ -546,8 +608,15 @@ CREATE OR REPLACE FUNCTION maker.update_flip_bids() RETURNS TRIGGER
 AS
 $$
 BEGIN
-    PERFORM maker.insert_new_flip_bid(NEW);
-    PERFORM maker.update_flip_bids_until_next_diff(NEW);
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_new_flip_bid(NEW);
+        PERFORM maker.update_flip_bids_until_next_diff(NEW, NEW.bid);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.update_flip_bids_until_next_diff(
+                OLD,
+                flip_bid_bid_before_block(OLD.bid_id, OLD.address_id, OLD.header_id));
+        PERFORM maker.delete_obsolete_flip(OLD.bid_id, OLD.address_id, OLD.header_id);
+    END IF;
     RETURN NULL;
 END
 $$
@@ -555,12 +624,11 @@ $$
 -- +goose StatementEnd
 
 CREATE TRIGGER flip_bid
-    AFTER INSERT OR UPDATE
+    AFTER INSERT OR UPDATE OR DELETE
     ON maker.flip_bid_bid
     FOR EACH ROW
 EXECUTE PROCEDURE maker.update_flip_bids();
 
--- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.insert_new_flip_usr(new_diff maker.flip_bid_usr) RETURNS VOID AS
 $$
 WITH diff_block AS (
@@ -583,32 +651,31 @@ VALUES (new_diff.bid_id,
         flip_bid_tab_before_block(new_diff.bid_id, new_diff.address_id, new_diff.header_id),
         (SELECT api.epoch_to_datetime(block_timestamp) FROM diff_block),
         flip_bid_time_created(new_diff.address_id, new_diff.bid_id))
-ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET usr = new_diff.usr;
+ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET usr = new_diff.usr
 $$
     LANGUAGE sql;
--- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.update_flip_usrs_until_next_diff(new_diff maker.flip_bid_usr) RETURNS VOID
+CREATE OR REPLACE FUNCTION maker.update_flip_usrs_until_next_diff(stat_at_diff maker.flip_bid_usr, new_usr TEXT) RETURNS VOID
 AS
 $$
 DECLARE
     diff_block_number   BIGINT := (
         SELECT block_number
         FROM public.headers
-        WHERE id = new_diff.header_id);
+        WHERE id = stat_at_diff.header_id);
     next_usr_diff_block BIGINT := (
         SELECT MIN(block_number)
         FROM maker.flip_bid_usr
                  LEFT JOIN public.headers ON flip_bid_usr.header_id = headers.id
-        WHERE flip_bid_usr.bid_id = new_diff.bid_id
-          AND flip_bid_usr.address_id = new_diff.address_id
+        WHERE flip_bid_usr.bid_id = stat_at_diff.bid_id
+          AND flip_bid_usr.address_id = stat_at_diff.address_id
           AND block_number > diff_block_number);
 BEGIN
     UPDATE maker.flip
-    SET usr = new_diff.usr
-    WHERE flip.bid_id = new_diff.bid_id
-      AND flip.address_id = new_diff.address_id
+    SET usr = new_usr
+    WHERE flip.bid_id = stat_at_diff.bid_id
+      AND flip.address_id = stat_at_diff.address_id
       AND flip.block_number >= diff_block_number
       AND (next_usr_diff_block IS NULL
         OR flip.block_number < next_usr_diff_block);
@@ -625,8 +692,15 @@ CREATE OR REPLACE FUNCTION maker.update_flip_usrs() RETURNS TRIGGER
 AS
 $$
 BEGIN
-    PERFORM maker.insert_new_flip_usr(NEW);
-    PERFORM maker.update_flip_usrs_until_next_diff(NEW);
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_new_flip_usr(NEW);
+        PERFORM maker.update_flip_usrs_until_next_diff(NEW, NEW.usr);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.update_flip_usrs_until_next_diff(
+                OLD,
+                flip_bid_usr_before_block(OLD.bid_id, OLD.address_id, OLD.header_id));
+        PERFORM maker.delete_obsolete_flip(OLD.bid_id, OLD.address_id, OLD.header_id);
+    END IF;
     RETURN NULL;
 END
 $$
@@ -634,12 +708,11 @@ $$
 -- +goose StatementEnd
 
 CREATE TRIGGER flip_usr
-    AFTER INSERT OR UPDATE
+    AFTER INSERT OR UPDATE OR DELETE
     ON maker.flip_bid_usr
     FOR EACH ROW
 EXECUTE PROCEDURE maker.update_flip_usrs();
 
--- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.insert_new_flip_gal(new_diff maker.flip_bid_gal) RETURNS VOID AS
 $$
 WITH diff_block AS (
@@ -662,32 +735,31 @@ VALUES (new_diff.bid_id,
         flip_bid_tab_before_block(new_diff.bid_id, new_diff.address_id, new_diff.header_id),
         (SELECT api.epoch_to_datetime(block_timestamp) FROM diff_block),
         flip_bid_time_created(new_diff.address_id, new_diff.bid_id))
-ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET gal = new_diff.gal;
+ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET gal = new_diff.gal
 $$
     LANGUAGE sql;
--- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.update_flip_gals_until_next_diff(new_diff maker.flip_bid_gal) RETURNS VOID
+CREATE OR REPLACE FUNCTION maker.update_flip_gals_until_next_diff(start_at_diff maker.flip_bid_gal, new_gal TEXT) RETURNS VOID
 AS
 $$
 DECLARE
     diff_block_number   BIGINT := (
         SELECT block_number
         FROM public.headers
-        WHERE id = new_diff.header_id);
+        WHERE id = start_at_diff.header_id);
     next_gal_diff_block BIGINT := (
         SELECT MIN(block_number)
         FROM maker.flip_bid_gal
                  LEFT JOIN public.headers ON flip_bid_gal.header_id = headers.id
-        WHERE flip_bid_gal.bid_id = new_diff.bid_id
-          AND flip_bid_gal.address_id = new_diff.address_id
+        WHERE flip_bid_gal.bid_id = start_at_diff.bid_id
+          AND flip_bid_gal.address_id = start_at_diff.address_id
           AND block_number > diff_block_number);
 BEGIN
     UPDATE maker.flip
-    SET gal = new_diff.gal
-    WHERE flip.bid_id = new_diff.bid_id
-      AND flip.address_id = new_diff.address_id
+    SET gal = new_gal
+    WHERE flip.bid_id = start_at_diff.bid_id
+      AND flip.address_id = start_at_diff.address_id
       AND flip.block_number >= diff_block_number
       AND (next_gal_diff_block IS NULL
         OR flip.block_number < next_gal_diff_block);
@@ -704,8 +776,15 @@ CREATE OR REPLACE FUNCTION maker.update_flip_gals() RETURNS TRIGGER
 AS
 $$
 BEGIN
-    PERFORM maker.insert_new_flip_gal(NEW);
-    PERFORM maker.update_flip_gals_until_next_diff(NEW);
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_new_flip_gal(NEW);
+        PERFORM maker.update_flip_gals_until_next_diff(NEW, NEW.gal);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.update_flip_gals_until_next_diff(
+                OLD,
+                flip_bid_gal_before_block(OLD.bid_id, OLD.address_id, OLD.header_id));
+        PERFORM maker.delete_obsolete_flip(OLD.bid_id, OLD.address_id, OLD.header_id);
+    END IF;
     RETURN NULL;
 END
 $$
@@ -713,12 +792,11 @@ $$
 -- +goose StatementEnd
 
 CREATE TRIGGER flip_gal
-    AFTER INSERT OR UPDATE
+    AFTER INSERT OR UPDATE OR DELETE
     ON maker.flip_bid_gal
     FOR EACH ROW
 EXECUTE PROCEDURE maker.update_flip_gals();
 
--- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.insert_new_flip_tab(new_diff maker.flip_bid_tab) RETURNS VOID AS
 $$
 WITH diff_block AS (
@@ -741,32 +819,31 @@ VALUES (new_diff.bid_id,
         new_diff.tab,
         (SELECT api.epoch_to_datetime(block_timestamp) FROM diff_block),
         flip_bid_time_created(new_diff.address_id, new_diff.bid_id))
-ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET tab = new_diff.tab;
+ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET tab = new_diff.tab
 $$
     LANGUAGE sql;
--- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.update_flip_tabs_until_next_diff(new_diff maker.flip_bid_tab) RETURNS VOID
+CREATE OR REPLACE FUNCTION maker.update_flip_tabs_until_next_diff(start_at_diff maker.flip_bid_tab, new_tab NUMERIC) RETURNS VOID
 AS
 $$
 DECLARE
     diff_block_number   BIGINT := (
         SELECT block_number
         FROM public.headers
-        WHERE id = new_diff.header_id);
+        WHERE id = start_at_diff.header_id);
     next_tab_diff_block BIGINT := (
         SELECT MIN(block_number)
         FROM maker.flip_bid_tab
                  LEFT JOIN public.headers ON flip_bid_tab.header_id = headers.id
-        WHERE flip_bid_tab.bid_id = new_diff.bid_id
-          AND flip_bid_tab.address_id = new_diff.address_id
+        WHERE flip_bid_tab.bid_id = start_at_diff.bid_id
+          AND flip_bid_tab.address_id = start_at_diff.address_id
           AND block_number > diff_block_number);
 BEGIN
     UPDATE maker.flip
-    SET tab = new_diff.tab
-    WHERE flip.bid_id = new_diff.bid_id
-      AND flip.address_id = new_diff.address_id
+    SET tab = new_tab
+    WHERE flip.bid_id = start_at_diff.bid_id
+      AND flip.address_id = start_at_diff.address_id
       AND flip.block_number >= diff_block_number
       AND (next_tab_diff_block IS NULL
         OR flip.block_number < next_tab_diff_block);
@@ -783,8 +860,15 @@ CREATE OR REPLACE FUNCTION maker.update_flip_tabs() RETURNS TRIGGER
 AS
 $$
 BEGIN
-    PERFORM maker.insert_new_flip_tab(NEW);
-    PERFORM maker.update_flip_tabs_until_next_diff(NEW);
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_new_flip_tab(NEW);
+        PERFORM maker.update_flip_tabs_until_next_diff(NEW, NEW.tab);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.update_flip_tabs_until_next_diff(
+                OLD,
+                flip_bid_tab_before_block(OLD.bid_id, OLD.address_id, OLD.header_id));
+        PERFORM maker.delete_obsolete_flip(OLD.bid_id, OLD.address_id, OLD.header_id);
+    END IF;
     RETURN NULL;
 END
 $$
@@ -792,37 +876,64 @@ $$
 -- +goose StatementEnd
 
 CREATE TRIGGER flip_tab
-    AFTER INSERT OR UPDATE
+    AFTER INSERT OR UPDATE OR DELETE
     ON maker.flip_bid_tab
     FOR EACH ROW
 EXECUTE PROCEDURE maker.update_flip_tabs();
 
--- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.flip_created() RETURNS TRIGGER
+CREATE OR REPLACE FUNCTION maker.insert_flip_created(new_event maker.flip_kick) RETURNS VOID
 AS
 $$
-DECLARE
-    diff_timestamp TIMESTAMP := (
-        SELECT api.epoch_to_datetime(block_timestamp)
-        FROM public.headers
-        WHERE headers.id = NEW.header_id);
+UPDATE maker.flip
+SET created = api.epoch_to_datetime(headers.block_timestamp)
+FROM public.headers
+WHERE headers.id = new_event.header_id
+  AND flip.address_id = new_event.address_id
+  AND flip.bid_id = new_event.bid_id
+  AND flip.created IS NULL
+$$
+    LANGUAGE sql;
+
+COMMENT ON FUNCTION maker.insert_flip_created
+    IS E'@omit';
+
+CREATE OR REPLACE FUNCTION maker.clear_flip_created(old_event maker.flip_kick) RETURNS VOID
+AS
+$$
+UPDATE maker.flip
+SET created = flip_bid_time_created(old_event.address_id, old_event.bid_id)
+WHERE flip.address_id = old_event.address_id
+  AND flip.bid_id = old_event.bid_id
+$$
+    LANGUAGE sql;
+
+COMMENT ON FUNCTION maker.clear_flip_created
+    IS E'@omit';
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION maker.update_flip_created() RETURNS TRIGGER
+AS
+$$
 BEGIN
-    UPDATE maker.flip
-    SET created = diff_timestamp
-    WHERE flip.address_id = NEW.address_id
-      AND flip.bid_id = NEW.bid_id
-      AND flip.created IS NULL;
+    IF (TG_OP = 'INSERT') THEN
+        PERFORM maker.insert_flip_created(NEW);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.clear_flip_created(OLD);
+    END IF;
     RETURN NULL;
 END
 $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
 
+COMMENT ON FUNCTION maker.update_flip_created
+    IS E'@omit';
+
 CREATE TRIGGER flip_created_trigger
-    AFTER INSERT
+    AFTER INSERT OR DELETE
     ON maker.flip_kick
     FOR EACH ROW
-EXECUTE PROCEDURE maker.flip_created();
+EXECUTE PROCEDURE maker.update_flip_created();
 
 
 -- +goose Down
@@ -844,14 +955,16 @@ DROP FUNCTION maker.insert_new_flip_bid(maker.flip_bid_bid);
 DROP FUNCTION maker.insert_new_flip_usr(maker.flip_bid_usr);
 DROP FUNCTION maker.insert_new_flip_gal(maker.flip_bid_gal);
 DROP FUNCTION maker.insert_new_flip_tab(maker.flip_bid_tab);
-DROP FUNCTION maker.update_flip_guys_until_next_diff(maker.flip_bid_guy);
-DROP FUNCTION maker.update_flip_tics_until_next_diff(maker.flip_bid_tic);
-DROP FUNCTION maker.update_flip_ends_until_next_diff(maker.flip_bid_end);
-DROP FUNCTION maker.update_flip_lots_until_next_diff(maker.flip_bid_lot);
-DROP FUNCTION maker.update_flip_bids_until_next_diff(maker.flip_bid_bid);
-DROP FUNCTION maker.update_flip_usrs_until_next_diff(maker.flip_bid_usr);
-DROP FUNCTION maker.update_flip_gals_until_next_diff(maker.flip_bid_gal);
-DROP FUNCTION maker.update_flip_tabs_until_next_diff(maker.flip_bid_tab);
+DROP FUNCTION maker.insert_flip_created(maker.flip_kick);
+DROP FUNCTION maker.update_flip_guys_until_next_diff(maker.flip_bid_guy, TEXT);
+DROP FUNCTION maker.update_flip_tics_until_next_diff(maker.flip_bid_tic, NUMERIC);
+DROP FUNCTION maker.update_flip_ends_until_next_diff(maker.flip_bid_end, NUMERIC);
+DROP FUNCTION maker.update_flip_lots_until_next_diff(maker.flip_bid_lot, NUMERIC);
+DROP FUNCTION maker.update_flip_bids_until_next_diff(maker.flip_bid_bid, NUMERIC);
+DROP FUNCTION maker.update_flip_usrs_until_next_diff(maker.flip_bid_usr, TEXT);
+DROP FUNCTION maker.update_flip_gals_until_next_diff(maker.flip_bid_gal, TEXT);
+DROP FUNCTION maker.update_flip_tabs_until_next_diff(maker.flip_bid_tab, NUMERIC);
+DROP FUNCTION maker.clear_flip_created(maker.flip_kick);
 DROP FUNCTION maker.update_flip_guys();
 DROP FUNCTION maker.update_flip_tics();
 DROP FUNCTION maker.update_flip_ends();
@@ -860,7 +973,8 @@ DROP FUNCTION maker.update_flip_bids();
 DROP FUNCTION maker.update_flip_usrs();
 DROP FUNCTION maker.update_flip_gals();
 DROP FUNCTION maker.update_flip_tabs();
-DROP FUNCTION maker.flip_created();
+DROP FUNCTION maker.update_flip_created();
+DROP FUNCTION maker.delete_obsolete_flip(NUMERIC, INTEGER, INTEGER);
 DROP FUNCTION flip_bid_guy_before_block(NUMERIC, INTEGER, INTEGER);
 DROP FUNCTION flip_bid_tic_before_block(NUMERIC, INTEGER, INTEGER);
 DROP FUNCTION flip_bid_end_before_block(NUMERIC, INTEGER, INTEGER);

--- a/db/migrations/20190720000000_create_flop_table_and_triggers.sql
+++ b/db/migrations/20190720000000_create_flop_table_and_triggers.sql
@@ -11,14 +11,14 @@ CREATE TABLE maker.flop
     bid          NUMERIC   DEFAULT NULL,
     created      TIMESTAMP DEFAULT NULL,
     updated      TIMESTAMP NOT NULL,
-    PRIMARY KEY (block_number, bid_id, address_id)
+    PRIMARY KEY (address_id, bid_id, block_number)
 );
+
+COMMENT ON TABLE maker.flop
+    IS E'@name historicalFlapState';
 
 CREATE INDEX flop_address_index
     ON maker.flop (address_id);
-
-COMMENT ON TABLE maker.flop
-    IS E'@name historicalFlopState';
 
 CREATE FUNCTION flop_bid_guy_before_block(bid_id NUMERIC, address_id INTEGER, header_id INTEGER) RETURNS TEXT AS
 $$
@@ -113,8 +113,48 @@ $$
 COMMENT ON FUNCTION flop_bid_time_created
     IS E'@omit';
 
-
 -- +goose StatementBegin
+CREATE OR REPLACE FUNCTION maker.delete_obsolete_flop(bid_id NUMERIC, address_id INTEGER, header_id INTEGER) RETURNS VOID AS
+$$
+DECLARE
+    flop_block      BIGINT     := (
+        SELECT block_number
+        FROM public.headers
+        WHERE id = header_id);
+    flop_state      maker.flop := (
+        SELECT (flop.address_id, block_number, flop.bid_id, guy, tic, "end", lot, bid, created, updated)
+        FROM maker.flop
+        WHERE flop.bid_id = delete_obsolete_flop.bid_id
+          AND flop.address_id = delete_obsolete_flop.address_id
+          AND flop.block_number = flop_block);
+    prev_flop_state maker.flop := (
+        SELECT (flop.address_id, block_number, flop.bid_id, guy, tic, "end", lot, bid, created, updated)
+        FROM maker.flop
+        WHERE flop.bid_id = delete_obsolete_flop.bid_id
+          AND flop.address_id = delete_obsolete_flop.address_id
+          AND flop.block_number < flop_block
+        ORDER BY flop.block_number DESC
+        LIMIT 1);
+BEGIN
+    DELETE
+    FROM maker.flop
+    WHERE flop.bid_id = delete_obsolete_flop.bid_id
+      AND flop.address_id = delete_obsolete_flop.address_id
+      AND flop.block_number = flop_block
+      AND (flop_state.guy IS NULL OR flop_state.guy = prev_flop_state.guy)
+      AND (flop_state.tic IS NULL OR flop_state.tic = prev_flop_state.tic)
+      AND (flop_state."end" IS NULL OR flop_state."end" = prev_flop_state."end")
+      AND (flop_state.lot IS NULL OR flop_state.lot = prev_flop_state.lot)
+      AND (flop_state.bid IS NULL OR flop_state.bid = prev_flop_state.bid);
+END
+$$
+    LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+COMMENT ON FUNCTION maker.delete_obsolete_flop
+    IS E'@omit';
+
+
 CREATE OR REPLACE FUNCTION maker.insert_new_flop_guy(new_diff maker.flop_bid_guy) RETURNS VOID AS
 $$
 WITH diff_block AS (
@@ -134,32 +174,31 @@ VALUES (new_diff.bid_id,
         flop_bid_bid_before_block(new_diff.bid_id, new_diff.address_id, new_diff.header_id),
         (SELECT api.epoch_to_datetime(block_timestamp) FROM diff_block),
         flop_bid_time_created(new_diff.address_id, new_diff.bid_id))
-ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET guy = new_diff.guy;
+ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET guy = new_diff.guy
 $$
     LANGUAGE sql;
--- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.update_flop_guys_until_next_diff(new_diff maker.flop_bid_guy) RETURNS VOID
+CREATE OR REPLACE FUNCTION maker.update_flop_guys_until_next_diff(start_at_diff maker.flop_bid_guy, new_guy TEXT) RETURNS VOID
 AS
 $$
 DECLARE
     diff_block_number   BIGINT := (
         SELECT block_number
         FROM public.headers
-        WHERE id = new_diff.header_id);
+        WHERE id = start_at_diff.header_id);
     next_guy_diff_block BIGINT := (
         SELECT MIN(block_number)
         FROM maker.flop_bid_guy
                  LEFT JOIN public.headers ON flop_bid_guy.header_id = headers.id
-        WHERE flop_bid_guy.bid_id = new_diff.bid_id
-          AND flop_bid_guy.address_id = new_diff.address_id
+        WHERE flop_bid_guy.bid_id = start_at_diff.bid_id
+          AND flop_bid_guy.address_id = start_at_diff.address_id
           AND block_number > diff_block_number);
 BEGIN
     UPDATE maker.flop
-    SET guy = new_diff.guy
-    WHERE flop.bid_id = new_diff.bid_id
-      AND flop.address_id = new_diff.address_id
+    SET guy = new_guy
+    WHERE flop.bid_id = start_at_diff.bid_id
+      AND flop.address_id = start_at_diff.address_id
       AND flop.block_number >= diff_block_number
       AND (next_guy_diff_block IS NULL
         OR flop.block_number < next_guy_diff_block);
@@ -167,6 +206,7 @@ END
 $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
+
 
 COMMENT ON FUNCTION maker.update_flop_guys_until_next_diff
     IS E'@omit';
@@ -176,8 +216,15 @@ CREATE OR REPLACE FUNCTION maker.update_flop_guys() RETURNS TRIGGER
 AS
 $$
 BEGIN
-    PERFORM maker.insert_new_flop_guy(NEW);
-    PERFORM maker.update_flop_guys_until_next_diff(NEW);
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_new_flop_guy(NEW);
+        PERFORM maker.update_flop_guys_until_next_diff(NEW, NEW.guy);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.update_flop_guys_until_next_diff(
+                OLD,
+                flop_bid_guy_before_block(OLD.bid_id, OLD.address_id, OLD.header_id));
+        PERFORM maker.delete_obsolete_flop(OLD.bid_id, OLD.address_id, OLD.header_id);
+    END IF;
     RETURN NULL;
 END
 $$
@@ -185,12 +232,11 @@ $$
 -- +goose StatementEnd
 
 CREATE TRIGGER flop_guy
-    AFTER INSERT OR UPDATE
+    AFTER INSERT OR UPDATE OR DELETE
     ON maker.flop_bid_guy
     FOR EACH ROW
 EXECUTE PROCEDURE maker.update_flop_guys();
 
--- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.insert_new_flop_tic(new_diff maker.flop_bid_tic) RETURNS VOID AS
 $$
 WITH diff_block AS (
@@ -210,32 +256,31 @@ VALUES (new_diff.bid_id,
         flop_bid_bid_before_block(new_diff.bid_id, new_diff.address_id, new_diff.header_id),
         (SELECT api.epoch_to_datetime(block_timestamp) FROM diff_block),
         flop_bid_time_created(new_diff.address_id, new_diff.bid_id))
-ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET tic = new_diff.tic;
+ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET tic = new_diff.tic
 $$
     LANGUAGE sql;
--- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.update_flop_tics_until_next_diff(new_diff maker.flop_bid_tic) RETURNS VOID
+CREATE OR REPLACE FUNCTION maker.update_flop_tics_until_next_diff(start_at_diff maker.flop_bid_tic, new_tic NUMERIC) RETURNS VOID
 AS
 $$
 DECLARE
     diff_block_number   BIGINT := (
         SELECT block_number
         FROM public.headers
-        WHERE id = new_diff.header_id);
+        WHERE id = start_at_diff.header_id);
     next_tic_diff_block BIGINT := (
         SELECT MIN(block_number)
         FROM maker.flop_bid_tic
                  LEFT JOIN public.headers ON flop_bid_tic.header_id = headers.id
-        WHERE flop_bid_tic.bid_id = new_diff.bid_id
-          AND flop_bid_tic.address_id = new_diff.address_id
+        WHERE flop_bid_tic.bid_id = start_at_diff.bid_id
+          AND flop_bid_tic.address_id = start_at_diff.address_id
           AND block_number > diff_block_number);
 BEGIN
     UPDATE maker.flop
-    SET tic = new_diff.tic
-    WHERE flop.bid_id = new_diff.bid_id
-      AND flop.address_id = new_diff.address_id
+    SET tic = new_tic
+    WHERE flop.bid_id = start_at_diff.bid_id
+      AND flop.address_id = start_at_diff.address_id
       AND flop.block_number >= diff_block_number
       AND (next_tic_diff_block IS NULL
         OR flop.block_number < next_tic_diff_block);
@@ -252,8 +297,15 @@ CREATE OR REPLACE FUNCTION maker.update_flop_tics() RETURNS TRIGGER
 AS
 $$
 BEGIN
-    PERFORM maker.insert_new_flop_tic(NEW);
-    PERFORM maker.update_flop_tics_until_next_diff(NEW);
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_new_flop_tic(NEW);
+        PERFORM maker.update_flop_tics_until_next_diff(NEW, NEW.tic);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.update_flop_tics_until_next_diff(
+                OLD,
+                flop_bid_tic_before_block(OLD.bid_id, OLD.address_id, OLD.header_id));
+        PERFORM maker.delete_obsolete_flop(OLD.bid_id, OLD.address_id, OLD.header_id);
+    END IF;
     RETURN NULL;
 END
 $$
@@ -261,12 +313,11 @@ $$
 -- +goose StatementEnd
 
 CREATE TRIGGER flop_tic
-    AFTER INSERT OR UPDATE
+    AFTER INSERT OR UPDATE OR DELETE
     ON maker.flop_bid_tic
     FOR EACH ROW
 EXECUTE PROCEDURE maker.update_flop_tics();
 
--- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.insert_new_flop_end(new_diff maker.flop_bid_end) RETURNS VOID AS
 $$
 WITH diff_block AS (
@@ -286,32 +337,31 @@ VALUES (new_diff.bid_id,
         flop_bid_bid_before_block(new_diff.bid_id, new_diff.address_id, new_diff.header_id),
         (SELECT api.epoch_to_datetime(block_timestamp) FROM diff_block),
         flop_bid_time_created(new_diff.address_id, new_diff.bid_id))
-ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET "end" = new_diff."end";
+ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET "end" = new_diff."end"
 $$
     LANGUAGE sql;
--- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.update_flop_ends_until_next_diff(new_diff maker.flop_bid_end) RETURNS VOID
+CREATE OR REPLACE FUNCTION maker.update_flop_ends_until_next_diff(start_at_diff maker.flop_bid_end, new_end NUMERIC) RETURNS VOID
 AS
 $$
 DECLARE
     diff_block_number   BIGINT := (
         SELECT block_number
         FROM public.headers
-        WHERE id = new_diff.header_id);
+        WHERE id = start_at_diff.header_id);
     next_end_diff_block BIGINT := (
         SELECT MIN(block_number)
         FROM maker.flop_bid_end
                  LEFT JOIN public.headers ON flop_bid_end.header_id = headers.id
-        WHERE flop_bid_end.bid_id = new_diff.bid_id
-          AND flop_bid_end.address_id = new_diff.address_id
+        WHERE flop_bid_end.bid_id = start_at_diff.bid_id
+          AND flop_bid_end.address_id = start_at_diff.address_id
           AND block_number > diff_block_number);
 BEGIN
     UPDATE maker.flop
-    SET "end" = new_diff."end"
-    WHERE flop.bid_id = new_diff.bid_id
-      AND flop.address_id = new_diff.address_id
+    SET "end" = new_end
+    WHERE flop.bid_id = start_at_diff.bid_id
+      AND flop.address_id = start_at_diff.address_id
       AND flop.block_number >= diff_block_number
       AND (next_end_diff_block IS NULL
         OR flop.block_number < next_end_diff_block);
@@ -328,8 +378,15 @@ CREATE OR REPLACE FUNCTION maker.update_flop_ends() RETURNS TRIGGER
 AS
 $$
 BEGIN
-    PERFORM maker.insert_new_flop_end(NEW);
-    PERFORM maker.update_flop_ends_until_next_diff(NEW);
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_new_flop_end(NEW);
+        PERFORM maker.update_flop_ends_until_next_diff(NEW, NEW."end");
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.update_flop_ends_until_next_diff(
+                OLD,
+                flop_bid_end_before_block(OLD.bid_id, OLD.address_id, OLD.header_id));
+        PERFORM maker.delete_obsolete_flop(OLD.bid_id, OLD.address_id, OLD.header_id);
+    END IF;
     RETURN NULL;
 END
 $$
@@ -337,12 +394,11 @@ $$
 -- +goose StatementEnd
 
 CREATE TRIGGER flop_end
-    AFTER INSERT OR UPDATE
+    AFTER INSERT OR UPDATE OR DELETE
     ON maker.flop_bid_end
     FOR EACH ROW
 EXECUTE PROCEDURE maker.update_flop_ends();
 
--- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.insert_new_flop_lot(new_diff maker.flop_bid_lot) RETURNS VOID AS
 $$
 WITH diff_block AS (
@@ -362,32 +418,31 @@ VALUES (new_diff.bid_id,
         flop_bid_bid_before_block(new_diff.bid_id, new_diff.address_id, new_diff.header_id),
         (SELECT api.epoch_to_datetime(block_timestamp) FROM diff_block),
         flop_bid_time_created(new_diff.address_id, new_diff.bid_id))
-ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET lot = new_diff.lot;
+ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET lot = new_diff.lot
 $$
     LANGUAGE sql;
--- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.update_flop_lots_until_next_diff(new_diff maker.flop_bid_lot) RETURNS VOID
+CREATE OR REPLACE FUNCTION maker.update_flop_lots_until_next_diff(start_at_diff maker.flop_bid_lot, new_lot NUMERIC) RETURNS VOID
 AS
 $$
 DECLARE
     diff_block_number   BIGINT := (
         SELECT block_number
         FROM public.headers
-        WHERE id = new_diff.header_id);
+        WHERE id = start_at_diff.header_id);
     next_lot_diff_block BIGINT := (
         SELECT MIN(block_number)
         FROM maker.flop_bid_lot
                  LEFT JOIN public.headers ON flop_bid_lot.header_id = headers.id
-        WHERE flop_bid_lot.bid_id = new_diff.bid_id
-          AND flop_bid_lot.address_id = new_diff.address_id
+        WHERE flop_bid_lot.bid_id = start_at_diff.bid_id
+          AND flop_bid_lot.address_id = start_at_diff.address_id
           AND block_number > diff_block_number);
 BEGIN
     UPDATE maker.flop
-    SET lot = new_diff.lot
-    WHERE flop.bid_id = new_diff.bid_id
-      AND flop.address_id = new_diff.address_id
+    SET lot = new_lot
+    WHERE flop.bid_id = start_at_diff.bid_id
+      AND flop.address_id = start_at_diff.address_id
       AND flop.block_number >= diff_block_number
       AND (next_lot_diff_block IS NULL
         OR flop.block_number < next_lot_diff_block);
@@ -404,8 +459,15 @@ CREATE OR REPLACE FUNCTION maker.update_flop_lots() RETURNS TRIGGER
 AS
 $$
 BEGIN
-    PERFORM maker.insert_new_flop_lot(NEW);
-    PERFORM maker.update_flop_lots_until_next_diff(NEW);
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_new_flop_lot(NEW);
+        PERFORM maker.update_flop_lots_until_next_diff(NEW, NEW.lot);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.update_flop_lots_until_next_diff(
+                OLD,
+                flop_bid_lot_before_block(OLD.bid_id, OLD.address_id, OLD.header_id));
+        PERFORM maker.delete_obsolete_flop(OLD.bid_id, OLD.address_id, OLD.header_id);
+    END IF;
     RETURN NULL;
 END
 $$
@@ -413,12 +475,11 @@ $$
 -- +goose StatementEnd
 
 CREATE TRIGGER flop_lot
-    AFTER INSERT OR UPDATE
+    AFTER INSERT OR UPDATE OR DELETE
     ON maker.flop_bid_lot
     FOR EACH ROW
 EXECUTE PROCEDURE maker.update_flop_lots();
 
--- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.insert_new_flop_bid(new_diff maker.flop_bid_bid) RETURNS VOID AS
 $$
 WITH diff_block AS (
@@ -438,32 +499,31 @@ VALUES (new_diff.bid_id,
         new_diff.bid,
         (SELECT api.epoch_to_datetime(block_timestamp) FROM diff_block),
         flop_bid_time_created(new_diff.address_id, new_diff.bid_id))
-ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET bid = new_diff.bid;
+ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET bid = new_diff.bid
 $$
     LANGUAGE sql;
--- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.update_flop_bids_until_next_diff(new_diff maker.flop_bid_bid) RETURNS VOID
+CREATE OR REPLACE FUNCTION maker.update_flop_bids_until_next_diff(start_at_diff maker.flop_bid_bid, new_bid NUMERIC) RETURNS VOID
 AS
 $$
 DECLARE
     diff_block_number   BIGINT := (
         SELECT block_number
         FROM public.headers
-        WHERE id = new_diff.header_id);
+        WHERE id = start_at_diff.header_id);
     next_bid_diff_block BIGINT := (
         SELECT MIN(block_number)
         FROM maker.flop_bid_bid
                  LEFT JOIN public.headers ON flop_bid_bid.header_id = headers.id
-        WHERE flop_bid_bid.bid_id = new_diff.bid_id
-          AND flop_bid_bid.address_id = new_diff.address_id
+        WHERE flop_bid_bid.bid_id = start_at_diff.bid_id
+          AND flop_bid_bid.address_id = start_at_diff.address_id
           AND block_number > diff_block_number);
 BEGIN
     UPDATE maker.flop
-    SET bid = new_diff.bid
-    WHERE flop.bid_id = new_diff.bid_id
-      AND flop.address_id = new_diff.address_id
+    SET bid = new_bid
+    WHERE flop.bid_id = start_at_diff.bid_id
+      AND flop.address_id = start_at_diff.address_id
       AND flop.block_number >= diff_block_number
       AND (next_bid_diff_block IS NULL
         OR flop.block_number < next_bid_diff_block);
@@ -480,8 +540,15 @@ CREATE OR REPLACE FUNCTION maker.update_flop_bids() RETURNS TRIGGER
 AS
 $$
 BEGIN
-    PERFORM maker.insert_new_flop_bid(NEW);
-    PERFORM maker.update_flop_bids_until_next_diff(NEW);
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_new_flop_bid(NEW);
+        PERFORM maker.update_flop_bids_until_next_diff(NEW, NEW.bid);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.update_flop_bids_until_next_diff(
+                OLD,
+                flop_bid_bid_before_block(OLD.bid_id, OLD.address_id, OLD.header_id));
+        PERFORM maker.delete_obsolete_flop(OLD.bid_id, OLD.address_id, OLD.header_id);
+    END IF;
     RETURN NULL;
 END
 $$
@@ -489,37 +556,64 @@ $$
 -- +goose StatementEnd
 
 CREATE TRIGGER flop_bid
-    AFTER INSERT OR UPDATE
+    AFTER INSERT OR UPDATE OR DELETE
     ON maker.flop_bid_bid
     FOR EACH ROW
 EXECUTE PROCEDURE maker.update_flop_bids();
 
--- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.flop_created() RETURNS TRIGGER
+CREATE OR REPLACE FUNCTION maker.insert_flop_created(new_event maker.flop_kick) RETURNS VOID
 AS
 $$
-DECLARE
-    diff_timestamp TIMESTAMP := (
-        SELECT api.epoch_to_datetime(block_timestamp)
-        FROM public.headers
-        WHERE headers.id = NEW.header_id);
+UPDATE maker.flop
+SET created = api.epoch_to_datetime(headers.block_timestamp)
+FROM public.headers
+WHERE headers.id = new_event.header_id
+  AND flop.address_id = new_event.address_id
+  AND flop.bid_id = new_event.bid_id
+  AND flop.created IS NULL
+$$
+    LANGUAGE sql;
+
+COMMENT ON FUNCTION maker.insert_flop_created
+    IS E'@omit';
+
+CREATE OR REPLACE FUNCTION maker.clear_flop_created(old_event maker.flop_kick) RETURNS VOID
+AS
+$$
+UPDATE maker.flop
+SET created = flop_bid_time_created(old_event.address_id, old_event.bid_id)
+WHERE flop.address_id = old_event.address_id
+  AND flop.bid_id = old_event.bid_id
+$$
+    LANGUAGE sql;
+
+COMMENT ON FUNCTION maker.clear_flop_created
+    IS E'@omit';
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION maker.update_flop_created() RETURNS TRIGGER
+AS
+$$
 BEGIN
-    UPDATE maker.flop
-    SET created = diff_timestamp
-    WHERE flop.address_id = NEW.address_id
-      AND flop.bid_id = NEW.bid_id
-      AND flop.created IS NULL;
+    IF (TG_OP = 'INSERT') THEN
+        PERFORM maker.insert_flop_created(NEW);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.clear_flop_created(OLD);
+    END IF;
     RETURN NULL;
 END
 $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
 
+COMMENT ON FUNCTION maker.update_flop_created
+    IS E'@omit';
+
 CREATE TRIGGER flop_created_trigger
-    AFTER INSERT
+    AFTER INSERT OR DELETE
     ON maker.flop_kick
     FOR EACH ROW
-EXECUTE PROCEDURE maker.flop_created();
+EXECUTE PROCEDURE maker.update_flop_created();
 
 -- +goose Down
 DROP TRIGGER flop_guy ON maker.flop_bid_guy;
@@ -534,17 +628,20 @@ DROP FUNCTION maker.insert_new_flop_tic(maker.flop_bid_tic);
 DROP FUNCTION maker.insert_new_flop_end(maker.flop_bid_end);
 DROP FUNCTION maker.insert_new_flop_lot(maker.flop_bid_lot);
 DROP FUNCTION maker.insert_new_flop_bid(maker.flop_bid_bid);
-DROP FUNCTION maker.update_flop_guys_until_next_diff(maker.flop_bid_guy);
-DROP FUNCTION maker.update_flop_tics_until_next_diff(maker.flop_bid_tic);
-DROP FUNCTION maker.update_flop_ends_until_next_diff(maker.flop_bid_end);
-DROP FUNCTION maker.update_flop_lots_until_next_diff(maker.flop_bid_lot);
-DROP FUNCTION maker.update_flop_bids_until_next_diff(maker.flop_bid_bid);
+DROP FUNCTION maker.insert_flop_created(maker.flop_kick);
+DROP FUNCTION maker.update_flop_guys_until_next_diff(maker.flop_bid_guy, TEXT);
+DROP FUNCTION maker.update_flop_tics_until_next_diff(maker.flop_bid_tic, NUMERIC);
+DROP FUNCTION maker.update_flop_ends_until_next_diff(maker.flop_bid_end, NUMERIC);
+DROP FUNCTION maker.update_flop_lots_until_next_diff(maker.flop_bid_lot, NUMERIC);
+DROP FUNCTION maker.update_flop_bids_until_next_diff(maker.flop_bid_bid, NUMERIC);
+DROP FUNCTION maker.clear_flop_created(maker.flop_kick);
 DROP FUNCTION maker.update_flop_guys();
 DROP FUNCTION maker.update_flop_tics();
 DROP FUNCTION maker.update_flop_ends();
 DROP FUNCTION maker.update_flop_lots();
 DROP FUNCTION maker.update_flop_bids();
-DROP FUNCTION maker.flop_created();
+DROP FUNCTION maker.update_flop_created();
+DROP FUNCTION maker.delete_obsolete_flop(NUMERIC, INTEGER, INTEGER);
 DROP FUNCTION flop_bid_guy_before_block(NUMERIC, INTEGER, INTEGER);
 DROP FUNCTION flop_bid_tic_before_block(NUMERIC, INTEGER, INTEGER);
 DROP FUNCTION flop_bid_end_before_block(NUMERIC, INTEGER, INTEGER);

--- a/db/migrations/20190726141224_create_flap_table_and_triggers.sql
+++ b/db/migrations/20190726141224_create_flap_table_and_triggers.sql
@@ -11,7 +11,7 @@ CREATE TABLE maker.flap
     bid          NUMERIC   DEFAULT NULL,
     created      TIMESTAMP DEFAULT NULL,
     updated      TIMESTAMP NOT NULL,
-    PRIMARY KEY (block_number, bid_id, address_id)
+    PRIMARY KEY (address_id, bid_id, block_number)
 );
 
 COMMENT ON TABLE maker.flap
@@ -113,8 +113,48 @@ $$
 COMMENT ON FUNCTION flap_bid_time_created
     IS E'@omit';
 
-
 -- +goose StatementBegin
+CREATE OR REPLACE FUNCTION maker.delete_obsolete_flap(bid_id NUMERIC, address_id INTEGER, header_id INTEGER) RETURNS VOID AS
+$$
+DECLARE
+    flap_block      BIGINT     := (
+        SELECT block_number
+        FROM public.headers
+        WHERE id = header_id);
+    flap_state      maker.flap := (
+        SELECT (flap.address_id, block_number, flap.bid_id, guy, tic, "end", lot, bid, created, updated)
+        FROM maker.flap
+        WHERE flap.bid_id = delete_obsolete_flap.bid_id
+          AND flap.address_id = delete_obsolete_flap.address_id
+          AND flap.block_number = flap_block);
+    prev_flap_state maker.flap := (
+        SELECT (flap.address_id, block_number, flap.bid_id, guy, tic, "end", lot, bid, created, updated)
+        FROM maker.flap
+        WHERE flap.bid_id = delete_obsolete_flap.bid_id
+          AND flap.address_id = delete_obsolete_flap.address_id
+          AND flap.block_number < flap_block
+        ORDER BY flap.block_number DESC
+        LIMIT 1);
+BEGIN
+    DELETE
+    FROM maker.flap
+    WHERE flap.bid_id = delete_obsolete_flap.bid_id
+      AND flap.address_id = delete_obsolete_flap.address_id
+      AND flap.block_number = flap_block
+      AND (flap_state.guy IS NULL OR flap_state.guy = prev_flap_state.guy)
+      AND (flap_state.tic IS NULL OR flap_state.tic = prev_flap_state.tic)
+      AND (flap_state."end" IS NULL OR flap_state."end" = prev_flap_state."end")
+      AND (flap_state.lot IS NULL OR flap_state.lot = prev_flap_state.lot)
+      AND (flap_state.bid IS NULL OR flap_state.bid = prev_flap_state.bid);
+END
+$$
+    LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+COMMENT ON FUNCTION maker.delete_obsolete_flap
+    IS E'@omit';
+
+
 CREATE OR REPLACE FUNCTION maker.insert_new_flap_guy(new_diff maker.flap_bid_guy) RETURNS VOID AS
 $$
 WITH diff_block AS (
@@ -134,32 +174,31 @@ VALUES (new_diff.bid_id,
         flap_bid_bid_before_block(new_diff.bid_id, new_diff.address_id, new_diff.header_id),
         (SELECT api.epoch_to_datetime(block_timestamp) FROM diff_block),
         flap_bid_time_created(new_diff.address_id, new_diff.bid_id))
-ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET guy = new_diff.guy;
+ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET guy = new_diff.guy
 $$
     LANGUAGE sql;
--- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.update_flap_guys_until_next_diff(new_diff maker.flap_bid_guy) RETURNS VOID
+CREATE OR REPLACE FUNCTION maker.update_flap_guys_until_next_diff(start_at_diff maker.flap_bid_guy, new_guy TEXT) RETURNS VOID
 AS
 $$
 DECLARE
     diff_block_number   BIGINT := (
         SELECT block_number
         FROM public.headers
-        WHERE id = new_diff.header_id);
+        WHERE id = start_at_diff.header_id);
     next_guy_diff_block BIGINT := (
         SELECT MIN(block_number)
         FROM maker.flap_bid_guy
                  LEFT JOIN public.headers ON flap_bid_guy.header_id = headers.id
-        WHERE flap_bid_guy.bid_id = new_diff.bid_id
-          AND flap_bid_guy.address_id = new_diff.address_id
+        WHERE flap_bid_guy.bid_id = start_at_diff.bid_id
+          AND flap_bid_guy.address_id = start_at_diff.address_id
           AND block_number > diff_block_number);
 BEGIN
     UPDATE maker.flap
-    SET guy = new_diff.guy
-    WHERE flap.bid_id = new_diff.bid_id
-      AND flap.address_id = new_diff.address_id
+    SET guy = new_guy
+    WHERE flap.bid_id = start_at_diff.bid_id
+      AND flap.address_id = start_at_diff.address_id
       AND flap.block_number >= diff_block_number
       AND (next_guy_diff_block IS NULL
         OR flap.block_number < next_guy_diff_block);
@@ -176,8 +215,15 @@ CREATE OR REPLACE FUNCTION maker.update_flap_guys() RETURNS TRIGGER
 AS
 $$
 BEGIN
-    PERFORM maker.insert_new_flap_guy(NEW);
-    PERFORM maker.update_flap_guys_until_next_diff(NEW);
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_new_flap_guy(NEW);
+        PERFORM maker.update_flap_guys_until_next_diff(NEW, NEW.guy);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.update_flap_guys_until_next_diff(
+                OLD,
+                flap_bid_guy_before_block(OLD.bid_id, OLD.address_id, OLD.header_id));
+        PERFORM maker.delete_obsolete_flap(OLD.bid_id, OLD.address_id, OLD.header_id);
+    END IF;
     RETURN NULL;
 END
 $$
@@ -185,12 +231,11 @@ $$
 -- +goose StatementEnd
 
 CREATE TRIGGER flap_guy
-    AFTER INSERT OR UPDATE
+    AFTER INSERT OR UPDATE OR DELETE
     ON maker.flap_bid_guy
     FOR EACH ROW
 EXECUTE PROCEDURE maker.update_flap_guys();
 
--- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.insert_new_flap_tic(new_diff maker.flap_bid_tic) RETURNS VOID AS
 $$
 WITH diff_block AS (
@@ -210,32 +255,31 @@ VALUES (new_diff.bid_id,
         flap_bid_bid_before_block(new_diff.bid_id, new_diff.address_id, new_diff.header_id),
         (SELECT api.epoch_to_datetime(block_timestamp) FROM diff_block),
         flap_bid_time_created(new_diff.address_id, new_diff.bid_id))
-ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET tic = new_diff.tic;
+ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET tic = new_diff.tic
 $$
     LANGUAGE sql;
--- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.update_flap_tics_until_next_diff(new_diff maker.flap_bid_tic) RETURNS VOID
+CREATE OR REPLACE FUNCTION maker.update_flap_tics_until_next_diff(start_at_diff maker.flap_bid_tic, new_tic NUMERIC) RETURNS VOID
 AS
 $$
 DECLARE
     diff_block_number   BIGINT := (
         SELECT block_number
         FROM public.headers
-        WHERE id = new_diff.header_id);
+        WHERE id = start_at_diff.header_id);
     next_tic_diff_block BIGINT := (
         SELECT MIN(block_number)
         FROM maker.flap_bid_tic
                  LEFT JOIN public.headers ON flap_bid_tic.header_id = headers.id
-        WHERE flap_bid_tic.bid_id = new_diff.bid_id
-          AND flap_bid_tic.address_id = new_diff.address_id
+        WHERE flap_bid_tic.bid_id = start_at_diff.bid_id
+          AND flap_bid_tic.address_id = start_at_diff.address_id
           AND block_number > diff_block_number);
 BEGIN
     UPDATE maker.flap
-    SET tic = new_diff.tic
-    WHERE flap.bid_id = new_diff.bid_id
-      AND flap.address_id = new_diff.address_id
+    SET tic = new_tic
+    WHERE flap.bid_id = start_at_diff.bid_id
+      AND flap.address_id = start_at_diff.address_id
       AND flap.block_number >= diff_block_number
       AND (next_tic_diff_block IS NULL
         OR flap.block_number < next_tic_diff_block);
@@ -252,8 +296,15 @@ CREATE OR REPLACE FUNCTION maker.update_flap_tics() RETURNS TRIGGER
 AS
 $$
 BEGIN
-    PERFORM maker.insert_new_flap_tic(NEW);
-    PERFORM maker.update_flap_tics_until_next_diff(NEW);
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_new_flap_tic(NEW);
+        PERFORM maker.update_flap_tics_until_next_diff(NEW, NEW.tic);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.update_flap_tics_until_next_diff(
+                OLD,
+                flap_bid_tic_before_block(OLD.bid_id, OLD.address_id, OLD.header_id));
+        PERFORM maker.delete_obsolete_flap(OLD.bid_id, OLD.address_id, OLD.header_id);
+    END IF;
     RETURN NULL;
 END
 $$
@@ -261,12 +312,11 @@ $$
 -- +goose StatementEnd
 
 CREATE TRIGGER flap_tic
-    AFTER INSERT OR UPDATE
+    AFTER INSERT OR UPDATE OR DELETE
     ON maker.flap_bid_tic
     FOR EACH ROW
 EXECUTE PROCEDURE maker.update_flap_tics();
 
--- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.insert_new_flap_end(new_diff maker.flap_bid_end) RETURNS VOID AS
 $$
 WITH diff_block AS (
@@ -286,32 +336,31 @@ VALUES (new_diff.bid_id,
         flap_bid_bid_before_block(new_diff.bid_id, new_diff.address_id, new_diff.header_id),
         (SELECT api.epoch_to_datetime(block_timestamp) FROM diff_block),
         flap_bid_time_created(new_diff.address_id, new_diff.bid_id))
-ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET "end" = new_diff."end";
+ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET "end" = new_diff."end"
 $$
     LANGUAGE sql;
--- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.update_flap_ends_until_next_diff(new_diff maker.flap_bid_end) RETURNS VOID
+CREATE OR REPLACE FUNCTION maker.update_flap_ends_until_next_diff(start_at_diff maker.flap_bid_end, new_end NUMERIC) RETURNS VOID
 AS
 $$
 DECLARE
     diff_block_number   BIGINT := (
         SELECT block_number
         FROM public.headers
-        WHERE id = new_diff.header_id);
+        WHERE id = start_at_diff.header_id);
     next_end_diff_block BIGINT := (
         SELECT MIN(block_number)
         FROM maker.flap_bid_end
                  LEFT JOIN public.headers ON flap_bid_end.header_id = headers.id
-        WHERE flap_bid_end.bid_id = new_diff.bid_id
-          AND flap_bid_end.address_id = new_diff.address_id
+        WHERE flap_bid_end.bid_id = start_at_diff.bid_id
+          AND flap_bid_end.address_id = start_at_diff.address_id
           AND block_number > diff_block_number);
 BEGIN
     UPDATE maker.flap
-    SET "end" = new_diff."end"
-    WHERE flap.bid_id = new_diff.bid_id
-      AND flap.address_id = new_diff.address_id
+    SET "end" = new_end
+    WHERE flap.bid_id = start_at_diff.bid_id
+      AND flap.address_id = start_at_diff.address_id
       AND flap.block_number >= diff_block_number
       AND (next_end_diff_block IS NULL
         OR flap.block_number < next_end_diff_block);
@@ -328,8 +377,15 @@ CREATE OR REPLACE FUNCTION maker.update_flap_ends() RETURNS TRIGGER
 AS
 $$
 BEGIN
-    PERFORM maker.insert_new_flap_end(NEW);
-    PERFORM maker.update_flap_ends_until_next_diff(NEW);
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_new_flap_end(NEW);
+        PERFORM maker.update_flap_ends_until_next_diff(NEW, NEW."end");
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.update_flap_ends_until_next_diff(
+                OLD,
+                flap_bid_end_before_block(OLD.bid_id, OLD.address_id, OLD.header_id));
+        PERFORM maker.delete_obsolete_flap(OLD.bid_id, OLD.address_id, OLD.header_id);
+    END IF;
     RETURN NULL;
 END
 $$
@@ -337,12 +393,11 @@ $$
 -- +goose StatementEnd
 
 CREATE TRIGGER flap_end
-    AFTER INSERT OR UPDATE
+    AFTER INSERT OR UPDATE OR DELETE
     ON maker.flap_bid_end
     FOR EACH ROW
 EXECUTE PROCEDURE maker.update_flap_ends();
 
--- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.insert_new_flap_lot(new_diff maker.flap_bid_lot) RETURNS VOID AS
 $$
 WITH diff_block AS (
@@ -362,32 +417,31 @@ VALUES (new_diff.bid_id,
         flap_bid_bid_before_block(new_diff.bid_id, new_diff.address_id, new_diff.header_id),
         (SELECT api.epoch_to_datetime(block_timestamp) FROM diff_block),
         flap_bid_time_created(new_diff.address_id, new_diff.bid_id))
-ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET lot = new_diff.lot;
+ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET lot = new_diff.lot
 $$
     LANGUAGE sql;
--- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.update_flap_lots_until_next_diff(new_diff maker.flap_bid_lot) RETURNS VOID
+CREATE OR REPLACE FUNCTION maker.update_flap_lots_until_next_diff(start_at_diff maker.flap_bid_lot, new_lot NUMERIC) RETURNS VOID
 AS
 $$
 DECLARE
     diff_block_number   BIGINT := (
         SELECT block_number
         FROM public.headers
-        WHERE id = new_diff.header_id);
+        WHERE id = start_at_diff.header_id);
     next_lot_diff_block BIGINT := (
         SELECT MIN(block_number)
         FROM maker.flap_bid_lot
                  LEFT JOIN public.headers ON flap_bid_lot.header_id = headers.id
-        WHERE flap_bid_lot.bid_id = new_diff.bid_id
-          AND flap_bid_lot.address_id = new_diff.address_id
+        WHERE flap_bid_lot.bid_id = start_at_diff.bid_id
+          AND flap_bid_lot.address_id = start_at_diff.address_id
           AND block_number > diff_block_number);
 BEGIN
     UPDATE maker.flap
-    SET lot = new_diff.lot
-    WHERE flap.bid_id = new_diff.bid_id
-      AND flap.address_id = new_diff.address_id
+    SET lot = new_lot
+    WHERE flap.bid_id = start_at_diff.bid_id
+      AND flap.address_id = start_at_diff.address_id
       AND flap.block_number >= diff_block_number
       AND (next_lot_diff_block IS NULL
         OR flap.block_number < next_lot_diff_block);
@@ -404,8 +458,15 @@ CREATE OR REPLACE FUNCTION maker.update_flap_lots() RETURNS TRIGGER
 AS
 $$
 BEGIN
-    PERFORM maker.insert_new_flap_lot(NEW);
-    PERFORM maker.update_flap_lots_until_next_diff(NEW);
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_new_flap_lot(NEW);
+        PERFORM maker.update_flap_lots_until_next_diff(NEW, NEW.lot);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.update_flap_lots_until_next_diff(
+                OLD,
+                flap_bid_lot_before_block(OLD.bid_id, OLD.address_id, OLD.header_id));
+        PERFORM maker.delete_obsolete_flap(OLD.bid_id, OLD.address_id, OLD.header_id);
+    END IF;
     RETURN NULL;
 END
 $$
@@ -413,12 +474,11 @@ $$
 -- +goose StatementEnd
 
 CREATE TRIGGER flap_lot
-    AFTER INSERT OR UPDATE
+    AFTER INSERT OR UPDATE OR DELETE
     ON maker.flap_bid_lot
     FOR EACH ROW
 EXECUTE PROCEDURE maker.update_flap_lots();
 
--- +goose StatementBegin
 CREATE OR REPLACE FUNCTION maker.insert_new_flap_bid(new_diff maker.flap_bid_bid) RETURNS VOID AS
 $$
 WITH diff_block AS (
@@ -438,32 +498,31 @@ VALUES (new_diff.bid_id,
         new_diff.bid,
         (SELECT api.epoch_to_datetime(block_timestamp) FROM diff_block),
         flap_bid_time_created(new_diff.address_id, new_diff.bid_id))
-ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET bid = new_diff.bid;
+ON CONFLICT (block_number, bid_id, address_id) DO UPDATE SET bid = new_diff.bid
 $$
     LANGUAGE sql;
--- +goose StatementEnd
 
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.update_flap_bids_until_next_diff(new_diff maker.flap_bid_bid) RETURNS VOID
+CREATE OR REPLACE FUNCTION maker.update_flap_bids_until_next_diff(start_at_diff maker.flap_bid_bid, new_bid NUMERIC) RETURNS VOID
 AS
 $$
 DECLARE
     diff_block_number   BIGINT := (
         SELECT block_number
         FROM public.headers
-        WHERE id = new_diff.header_id);
+        WHERE id = start_at_diff.header_id);
     next_bid_diff_block BIGINT := (
         SELECT MIN(block_number)
         FROM maker.flap_bid_bid
                  LEFT JOIN public.headers ON flap_bid_bid.header_id = headers.id
-        WHERE flap_bid_bid.bid_id = new_diff.bid_id
-          AND flap_bid_bid.address_id = new_diff.address_id
+        WHERE flap_bid_bid.bid_id = start_at_diff.bid_id
+          AND flap_bid_bid.address_id = start_at_diff.address_id
           AND block_number > diff_block_number);
 BEGIN
     UPDATE maker.flap
-    SET bid = new_diff.bid
-    WHERE flap.bid_id = new_diff.bid_id
-      AND flap.address_id = new_diff.address_id
+    SET bid = new_bid
+    WHERE flap.bid_id = start_at_diff.bid_id
+      AND flap.address_id = start_at_diff.address_id
       AND flap.block_number >= diff_block_number
       AND (next_bid_diff_block IS NULL
         OR flap.block_number < next_bid_diff_block);
@@ -480,8 +539,15 @@ CREATE OR REPLACE FUNCTION maker.update_flap_bids() RETURNS TRIGGER
 AS
 $$
 BEGIN
-    PERFORM maker.insert_new_flap_bid(NEW);
-    PERFORM maker.update_flap_bids_until_next_diff(NEW);
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_new_flap_bid(NEW);
+        PERFORM maker.update_flap_bids_until_next_diff(NEW, NEW.bid);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.update_flap_bids_until_next_diff(
+                OLD,
+                flap_bid_bid_before_block(OLD.bid_id, OLD.address_id, OLD.header_id));
+        PERFORM maker.delete_obsolete_flap(OLD.bid_id, OLD.address_id, OLD.header_id);
+    END IF;
     RETURN NULL;
 END
 $$
@@ -489,37 +555,64 @@ $$
 -- +goose StatementEnd
 
 CREATE TRIGGER flap_bid
-    AFTER INSERT OR UPDATE
+    AFTER INSERT OR UPDATE OR DELETE
     ON maker.flap_bid_bid
     FOR EACH ROW
 EXECUTE PROCEDURE maker.update_flap_bids();
 
--- +goose StatementBegin
-CREATE OR REPLACE FUNCTION maker.flap_created() RETURNS TRIGGER
+CREATE OR REPLACE FUNCTION maker.insert_flap_created(new_event maker.flap_kick) RETURNS VOID
 AS
 $$
-DECLARE
-    diff_timestamp TIMESTAMP := (
-        SELECT api.epoch_to_datetime(block_timestamp)
-        FROM public.headers
-        WHERE headers.id = NEW.header_id);
+UPDATE maker.flap
+SET created = api.epoch_to_datetime(headers.block_timestamp)
+FROM public.headers
+WHERE headers.id = new_event.header_id
+  AND flap.address_id = new_event.address_id
+  AND flap.bid_id = new_event.bid_id
+  AND flap.created IS NULL
+$$
+    LANGUAGE sql;
+
+COMMENT ON FUNCTION maker.insert_flap_created
+    IS E'@omit';
+
+CREATE OR REPLACE FUNCTION maker.clear_flap_created(old_event maker.flap_kick) RETURNS VOID
+AS
+$$
+UPDATE maker.flap
+SET created = flap_bid_time_created(old_event.address_id, old_event.bid_id)
+WHERE flap.address_id = old_event.address_id
+  AND flap.bid_id = old_event.bid_id
+$$
+    LANGUAGE sql;
+
+COMMENT ON FUNCTION maker.clear_flap_created
+    IS E'@omit';
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION maker.update_flap_created() RETURNS TRIGGER
+AS
+$$
 BEGIN
-    UPDATE maker.flap
-    SET created = diff_timestamp
-    WHERE flap.address_id = NEW.address_id
-      AND flap.bid_id = NEW.bid_id
-      AND flap.created IS NULL;
+    IF (TG_OP = 'INSERT') THEN
+        PERFORM maker.insert_flap_created(NEW);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.clear_flap_created(OLD);
+    END IF;
     RETURN NULL;
 END
 $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
 
+COMMENT ON FUNCTION maker.update_flap_created
+    IS E'@omit';
+
 CREATE TRIGGER flap_created_trigger
-    AFTER INSERT
+    AFTER INSERT OR DELETE
     ON maker.flap_kick
     FOR EACH ROW
-EXECUTE PROCEDURE maker.flap_created();
+EXECUTE PROCEDURE maker.update_flap_created();
 
 -- +goose Down
 DROP TRIGGER flap_guy ON maker.flap_bid_guy;
@@ -534,17 +627,20 @@ DROP FUNCTION maker.insert_new_flap_tic(maker.flap_bid_tic);
 DROP FUNCTION maker.insert_new_flap_end(maker.flap_bid_end);
 DROP FUNCTION maker.insert_new_flap_lot(maker.flap_bid_lot);
 DROP FUNCTION maker.insert_new_flap_bid(maker.flap_bid_bid);
-DROP FUNCTION maker.update_flap_guys_until_next_diff(maker.flap_bid_guy);
-DROP FUNCTION maker.update_flap_tics_until_next_diff(maker.flap_bid_tic);
-DROP FUNCTION maker.update_flap_ends_until_next_diff(maker.flap_bid_end);
-DROP FUNCTION maker.update_flap_lots_until_next_diff(maker.flap_bid_lot);
-DROP FUNCTION maker.update_flap_bids_until_next_diff(maker.flap_bid_bid);
+DROP FUNCTION maker.insert_flap_created(maker.flap_kick);
+DROP FUNCTION maker.update_flap_guys_until_next_diff(maker.flap_bid_guy, TEXT);
+DROP FUNCTION maker.update_flap_tics_until_next_diff(maker.flap_bid_tic, NUMERIC);
+DROP FUNCTION maker.update_flap_ends_until_next_diff(maker.flap_bid_end, NUMERIC);
+DROP FUNCTION maker.update_flap_lots_until_next_diff(maker.flap_bid_lot, NUMERIC);
+DROP FUNCTION maker.update_flap_bids_until_next_diff(maker.flap_bid_bid, NUMERIC);
+DROP FUNCTION maker.clear_flap_created(maker.flap_kick);
 DROP FUNCTION maker.update_flap_guys();
 DROP FUNCTION maker.update_flap_tics();
 DROP FUNCTION maker.update_flap_ends();
 DROP FUNCTION maker.update_flap_lots();
 DROP FUNCTION maker.update_flap_bids();
-DROP FUNCTION maker.flap_created();
+DROP FUNCTION maker.update_flap_created();
+DROP FUNCTION maker.delete_obsolete_flap(NUMERIC, INTEGER, INTEGER);
 DROP FUNCTION flap_bid_guy_before_block(NUMERIC, INTEGER, INTEGER);
 DROP FUNCTION flap_bid_tic_before_block(NUMERIC, INTEGER, INTEGER);
 DROP FUNCTION flap_bid_end_before_block(NUMERIC, INTEGER, INTEGER);

--- a/transformers/component_tests/triggers/bid_creation/flap_kick_trigger_test.go
+++ b/transformers/component_tests/triggers/bid_creation/flap_kick_trigger_test.go
@@ -15,7 +15,7 @@ var _ = Describe("flap created trigger", func() {
 		flapKickModel = test_data.FlapKickModel()
 	})
 
-	Describe("updating flop created", func() {
+	Describe("updating flap created", func() {
 		bid_creation.SharedBidCreationTriggerTests(constants.FlapTable, test_data.FlapAddress(), &flapKickModel)
 	})
 })

--- a/transformers/component_tests/triggers/bid_creation/flip_kick_trigger_test.go
+++ b/transformers/component_tests/triggers/bid_creation/flip_kick_trigger_test.go
@@ -15,7 +15,7 @@ var _ = Describe("flip created trigger", func() {
 		flipKickModel = test_data.FlipKickModel()
 	})
 
-	Describe("updating flop created", func() {
+	Describe("updating flip created", func() {
 		bid_creation.SharedBidCreationTriggerTests(constants.FlipTable, test_data.EthFlipAddress(), &flipKickModel)
 	})
 })

--- a/transformers/storage/flap/repository_test.go
+++ b/transformers/storage/flap/repository_test.go
@@ -332,8 +332,8 @@ var _ = Describe("Flap storage repository", func() {
 				FieldTable:      constants.FlapBidBidTable,
 				ColumnName:      constants.BidColumn,
 			}
-			shared_behaviors.CommonBidSnapshotTriggerTests(triggerInput)
-			shared_behaviors.SharedBidHistoryTriggerTests(triggerInput)
+			shared_behaviors.InsertBidSnapshotTriggerTests(triggerInput)
+			shared_behaviors.UpdateBidSnapshotTriggerTests(triggerInput)
 
 			It("triggers an update to the flap table", func() {
 				err := repository.Create(diffID, fakeHeaderID, bidBidMetadata, fakeBidValue)
@@ -377,8 +377,8 @@ var _ = Describe("Flap storage repository", func() {
 				FieldTable:      constants.FlapBidLotTable,
 				ColumnName:      constants.LotColumn,
 			}
-			shared_behaviors.CommonBidSnapshotTriggerTests(triggerInput)
-			shared_behaviors.SharedBidHistoryTriggerTests(triggerInput)
+			shared_behaviors.InsertBidSnapshotTriggerTests(triggerInput)
+			shared_behaviors.UpdateBidSnapshotTriggerTests(triggerInput)
 
 			It("triggers an update to the flap table", func() {
 				err := repository.Create(diffID, fakeHeaderID, bidLotMetadata, fakeLotValue)
@@ -479,8 +479,8 @@ var _ = Describe("Flap storage repository", func() {
 			ColumnName:      constants.GuyColumn,
 			PackedValueType: types.Address,
 		}
-		shared_behaviors.CommonBidSnapshotTriggerTests(guyTriggerInput)
-		shared_behaviors.SharedBidHistoryTriggerTests(guyTriggerInput)
+		shared_behaviors.InsertBidSnapshotTriggerTests(guyTriggerInput)
+		shared_behaviors.UpdateBidSnapshotTriggerTests(guyTriggerInput)
 
 		var bidTicMetadata = types.ValueMetadata{
 			Name:        storage.Packed,
@@ -497,8 +497,8 @@ var _ = Describe("Flap storage repository", func() {
 			ColumnName:      constants.TicColumn,
 			PackedValueType: types.Uint48,
 		}
-		shared_behaviors.CommonBidSnapshotTriggerTests(ticTriggerInput)
-		shared_behaviors.SharedBidHistoryTriggerTests(ticTriggerInput)
+		shared_behaviors.InsertBidSnapshotTriggerTests(ticTriggerInput)
+		shared_behaviors.UpdateBidSnapshotTriggerTests(ticTriggerInput)
 
 		var bidEndMetadata = types.ValueMetadata{
 			Name:        storage.Packed,
@@ -515,7 +515,7 @@ var _ = Describe("Flap storage repository", func() {
 			ColumnName:      constants.EndColumn,
 			PackedValueType: types.Uint48,
 		}
-		shared_behaviors.CommonBidSnapshotTriggerTests(endTriggerInput)
-		shared_behaviors.SharedBidHistoryTriggerTests(endTriggerInput)
+		shared_behaviors.InsertBidSnapshotTriggerTests(endTriggerInput)
+		shared_behaviors.UpdateBidSnapshotTriggerTests(endTriggerInput)
 	})
 })

--- a/transformers/storage/flip/repository_test.go
+++ b/transformers/storage/flip/repository_test.go
@@ -282,8 +282,8 @@ var _ = Describe("Flip storage repository", func() {
 				FieldTable:      constants.FlipBidBidTable,
 				ColumnName:      constants.BidColumn,
 			}
-			shared_behaviors.FlipBidSnapshotTriggerTests(triggerInput)
-			shared_behaviors.SharedBidHistoryTriggerTests(triggerInput)
+			shared_behaviors.InsertFlipBidSnapshotTriggerTests(triggerInput)
+			shared_behaviors.UpdateBidSnapshotTriggerTests(triggerInput)
 		})
 
 		Describe("BidLot", func() {
@@ -315,8 +315,8 @@ var _ = Describe("Flip storage repository", func() {
 				FieldTable:      constants.FlipBidLotTable,
 				ColumnName:      constants.LotColumn,
 			}
-			shared_behaviors.FlipBidSnapshotTriggerTests(triggerInput)
-			shared_behaviors.SharedBidHistoryTriggerTests(triggerInput)
+			shared_behaviors.InsertFlipBidSnapshotTriggerTests(triggerInput)
+			shared_behaviors.UpdateBidSnapshotTriggerTests(triggerInput)
 		})
 
 		Describe("BidGuy, BidTic and BidEnd packed storage", func() {
@@ -392,8 +392,8 @@ var _ = Describe("Flip storage repository", func() {
 				ColumnName:      constants.GuyColumn,
 				PackedValueType: types.Address,
 			}
-			shared_behaviors.FlipBidSnapshotTriggerTests(guyTriggerInput)
-			shared_behaviors.SharedBidHistoryTriggerTests(guyTriggerInput)
+			shared_behaviors.InsertFlipBidSnapshotTriggerTests(guyTriggerInput)
+			shared_behaviors.UpdateBidSnapshotTriggerTests(guyTriggerInput)
 
 			var bidTicMetadata = types.ValueMetadata{
 				Name:        storage.Packed,
@@ -410,8 +410,8 @@ var _ = Describe("Flip storage repository", func() {
 				ColumnName:      constants.TicColumn,
 				PackedValueType: types.Uint48,
 			}
-			shared_behaviors.FlipBidSnapshotTriggerTests(ticTriggerInput)
-			shared_behaviors.SharedBidHistoryTriggerTests(ticTriggerInput)
+			shared_behaviors.InsertFlipBidSnapshotTriggerTests(ticTriggerInput)
+			shared_behaviors.UpdateBidSnapshotTriggerTests(ticTriggerInput)
 
 			var bidEndMetadata = types.ValueMetadata{
 				Name:        storage.Packed,
@@ -428,8 +428,8 @@ var _ = Describe("Flip storage repository", func() {
 				ColumnName:      constants.EndColumn,
 				PackedValueType: types.Uint48,
 			}
-			shared_behaviors.FlipBidSnapshotTriggerTests(endTriggerInput)
-			shared_behaviors.SharedBidHistoryTriggerTests(endTriggerInput)
+			shared_behaviors.InsertFlipBidSnapshotTriggerTests(endTriggerInput)
+			shared_behaviors.UpdateBidSnapshotTriggerTests(endTriggerInput)
 		})
 
 		Describe("BidUsr", func() {
@@ -460,8 +460,8 @@ var _ = Describe("Flip storage repository", func() {
 				FieldTable:      constants.FlipBidUsrTable,
 				ColumnName:      constants.UsrColumn,
 			}
-			shared_behaviors.FlipBidSnapshotTriggerTests(triggerInput)
-			shared_behaviors.SharedBidHistoryTriggerTests(triggerInput)
+			shared_behaviors.InsertFlipBidSnapshotTriggerTests(triggerInput)
+			shared_behaviors.UpdateBidSnapshotTriggerTests(triggerInput)
 		})
 
 		Describe("BidGal", func() {
@@ -492,8 +492,8 @@ var _ = Describe("Flip storage repository", func() {
 				FieldTable:      constants.FlipBidGalTable,
 				ColumnName:      constants.GalColumn,
 			}
-			shared_behaviors.FlipBidSnapshotTriggerTests(triggerInput)
-			shared_behaviors.SharedBidHistoryTriggerTests(triggerInput)
+			shared_behaviors.InsertFlipBidSnapshotTriggerTests(triggerInput)
+			shared_behaviors.UpdateBidSnapshotTriggerTests(triggerInput)
 		})
 
 		Describe("BidTab", func() {
@@ -525,8 +525,8 @@ var _ = Describe("Flip storage repository", func() {
 				FieldTable:      constants.FlipBidTabTable,
 				ColumnName:      constants.TabColumn,
 			}
-			shared_behaviors.FlipBidSnapshotTriggerTests(triggerInput)
-			shared_behaviors.SharedBidHistoryTriggerTests(triggerInput)
+			shared_behaviors.InsertFlipBidSnapshotTriggerTests(triggerInput)
+			shared_behaviors.UpdateBidSnapshotTriggerTests(triggerInput)
 		})
 	})
 })

--- a/transformers/storage/flop/repository_test.go
+++ b/transformers/storage/flop/repository_test.go
@@ -316,8 +316,8 @@ var _ = Describe("Flop storage repository", func() {
 				FieldTable:      constants.FlopBidBidTable,
 				ColumnName:      constants.BidColumn,
 			}
-			shared_behaviors.CommonBidSnapshotTriggerTests(triggerInput)
-			shared_behaviors.SharedBidHistoryTriggerTests(triggerInput)
+			shared_behaviors.InsertBidSnapshotTriggerTests(triggerInput)
+			shared_behaviors.UpdateBidSnapshotTriggerTests(triggerInput)
 
 			It("triggers an update to the flop table", func() {
 				err := repo.Create(diffID, fakeHeaderID, bidBidMetadata, fakeBidValue)
@@ -361,8 +361,8 @@ var _ = Describe("Flop storage repository", func() {
 				FieldTable:      constants.FlopBidLotTable,
 				ColumnName:      constants.LotColumn,
 			}
-			shared_behaviors.CommonBidSnapshotTriggerTests(triggerInput)
-			shared_behaviors.SharedBidHistoryTriggerTests(triggerInput)
+			shared_behaviors.InsertBidSnapshotTriggerTests(triggerInput)
+			shared_behaviors.UpdateBidSnapshotTriggerTests(triggerInput)
 
 			It("triggers an update to the flop table", func() {
 				err := repo.Create(diffID, fakeHeaderID, bidLotMetadata, fakeLotValue)
@@ -461,8 +461,8 @@ var _ = Describe("Flop storage repository", func() {
 				ColumnName:      constants.GuyColumn,
 				PackedValueType: types.Address,
 			}
-			shared_behaviors.CommonBidSnapshotTriggerTests(guyTriggerInput)
-			shared_behaviors.SharedBidHistoryTriggerTests(guyTriggerInput)
+			shared_behaviors.InsertBidSnapshotTriggerTests(guyTriggerInput)
+			shared_behaviors.UpdateBidSnapshotTriggerTests(guyTriggerInput)
 
 			var bidTicMetadata = types.ValueMetadata{
 				Name:        storage.Packed,
@@ -479,8 +479,8 @@ var _ = Describe("Flop storage repository", func() {
 				ColumnName:      constants.TicColumn,
 				PackedValueType: types.Uint48,
 			}
-			shared_behaviors.CommonBidSnapshotTriggerTests(ticTriggerInput)
-			shared_behaviors.SharedBidHistoryTriggerTests(ticTriggerInput)
+			shared_behaviors.InsertBidSnapshotTriggerTests(ticTriggerInput)
+			shared_behaviors.UpdateBidSnapshotTriggerTests(ticTriggerInput)
 
 			var bidEndMetadata = types.ValueMetadata{
 				Name:        storage.Packed,
@@ -497,8 +497,8 @@ var _ = Describe("Flop storage repository", func() {
 				ColumnName:      constants.EndColumn,
 				PackedValueType: types.Uint48,
 			}
-			shared_behaviors.CommonBidSnapshotTriggerTests(endTriggerInput)
-			shared_behaviors.SharedBidHistoryTriggerTests(endTriggerInput)
+			shared_behaviors.InsertBidSnapshotTriggerTests(endTriggerInput)
+			shared_behaviors.UpdateBidSnapshotTriggerTests(endTriggerInput)
 		})
 	})
 })


### PR DESCRIPTION
Here's another PR where we're making very similar changes to every auction's triggers. Plus, each individual trigger is undergoing very similar changes, with the exception of the `created` triggers which are a little simpler, since all the records pertaining to an individual bid have the same `created` value.