### PR TITLE
Add restart policy for Geth in docker-compose

### DIFF
--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -108,3 +108,4 @@ services:
       "--statediff.watchedaddresses", "0x81FE72B5A8d1A857d176C3E7d5Bd2679A9B85763", # CONTRACT_OSM_ETH_ADDRESS
       "--statediff.watchedaddresses", "0xb4eb54af9cc7882df0121d26c5b97e802915abe6", # CONTRACT_OSM_BAT_ADDRESS
     ]
+    restart: unless-stopped


### PR DESCRIPTION
- If using Geth and Geth dies, then the vdb containers restart
  continually without the possibility of ever succeeding :(