### PR TITLE
Typo in the Docker command.

### DIFF
--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -70,7 +70,7 @@ For execution on linux, replace instances of `host.docker.internal` with `localh
         - `--statediff.watchedaddresses <contract address>`
     - e.g.
     ```shell script
-        docker run -v /Users/elizabethengelman/Library/Ethereum:/root/.ethereum -p 8545:8545 -p 8546:8546 -p 30303:30303 statediffing-geth
+        docker run -v /Users/elizabethengelman/Library/Ethereum:/root/.ethereum -p 8545:8545 -p 8546:8546 -p 30303:30303 geth-statediffing
           --rpc --rpcaddr "0.0.0.0" --ws --wsaddr "0.0.0.0" --statediff --syncmode full --statediff.watchedaddresses <contract address>
           --statediff.watchedaddresses <contract address>
     ```


### PR DESCRIPTION
Created this PR as a workaround to get https://github.com/makerdao/vdb-mcd-transformers/pull/111 merged in, while still allowing our travis build to run with it's [encrypted env vars](https://docs.travis-ci.com/user/pull-requests/#pull-requests-and-security-restrictions).