### PR TITLE
Adds gomoderator docker to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_install:
 - echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
 - sudo apt-get update && sudo apt-get install yarn python3-pip -y
 - sudo pip3 install awscli
+- docker build dockerfiles/gomoderator
 script:
 - scripts/check_config.sh
 - env GO111MODULE=on make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
 - echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
 - sudo apt-get update && sudo apt-get install yarn python3-pip -y
 - sudo pip3 install awscli
-- docker build dockerfiles/gomoderator
+- docker build -f dockerfiles/gomoderator/Dockerfile .
 script:
 - scripts/check_config.sh
 - env GO111MODULE=on make test

--- a/dockerfiles/gomoderator/Dockerfile
+++ b/dockerfiles/gomoderator/Dockerfile
@@ -12,7 +12,6 @@ RUN git checkout $VDB_VERSION
 RUN go build
 WORKDIR /go/src/github.com/makerdao/vdb-mcd-transformers
 COPY . .
-RUN go build
 
 # app container
 FROM golang:alpine

--- a/dockerfiles/gomoderator/Dockerfile
+++ b/dockerfiles/gomoderator/Dockerfile
@@ -1,0 +1,38 @@
+FROM golang:alpine as builder
+
+RUN apk --update --no-cache add make git g++ linux-headers python3
+
+ARG VDB_VERSION=staging
+ENV GO111MODULE on
+
+WORKDIR /go/src/github.com/makerdao
+RUN git clone https://github.com/makerdao/vulcanizedb.git
+RUN git clone https://github.com/makerdao/vdb-mcd-transformers.git
+WORKDIR /go/src/github.com/makerdao/vulcanizedb
+RUN git checkout $VDB_VERSION
+RUN go build
+WORKDIR /go/src/github.com/makerdao/vdb-mcd-transformers
+RUN git checkout $VDB_VERSION
+RUN go build
+
+# app container
+FROM golang:alpine
+WORKDIR /go/src/github.com/makerdao/vulcanizedb
+
+# add certificates for node requests via https
+# bash for wait-for-it
+RUN apk update \
+        && apk upgrade \
+        && apk add --no-cache \
+        ca-certificates \
+        bash \
+        && update-ca-certificates 2>/dev/null || true
+
+# add go so we can build the plugin
+RUN apk add --update --no-cache git g++ linux-headers python3
+
+# get access to go.mod files in directories
+COPY --from=builder /go/src/github.com/makerdao/vulcanizedb .
+COPY --from=builder /go/src/github.com/makerdao/vdb-mcd-transformers/go.mod ./vdb/go.mod
+
+RUN python3 scripts/gomoderator.py ./ vdb/

--- a/dockerfiles/gomoderator/Dockerfile
+++ b/dockerfiles/gomoderator/Dockerfile
@@ -18,13 +18,6 @@ RUN go build
 FROM golang:alpine
 WORKDIR /go/src/github.com/makerdao/vulcanizedb
 
-# add certificates for node requests via https
-# bash for wait-for-it
-RUN apk update \
-        && apk upgrade \
-        && apk add --no-cache \
-        && update-ca-certificates 2>/dev/null || true
-
 # add go so we can build the plugin
 RUN apk add --update --no-cache git g++ linux-headers python3
 

--- a/dockerfiles/gomoderator/Dockerfile
+++ b/dockerfiles/gomoderator/Dockerfile
@@ -12,7 +12,6 @@ WORKDIR /go/src/github.com/makerdao/vulcanizedb
 RUN git checkout $VDB_VERSION
 RUN go build
 WORKDIR /go/src/github.com/makerdao/vdb-mcd-transformers
-RUN git checkout $VDB_VERSION
 RUN go build
 
 # app container
@@ -24,8 +23,6 @@ WORKDIR /go/src/github.com/makerdao/vulcanizedb
 RUN apk update \
         && apk upgrade \
         && apk add --no-cache \
-        ca-certificates \
-        bash \
         && update-ca-certificates 2>/dev/null || true
 
 # add go so we can build the plugin
@@ -33,6 +30,6 @@ RUN apk add --update --no-cache git g++ linux-headers python3
 
 # get access to go.mod files in directories
 COPY --from=builder /go/src/github.com/makerdao/vulcanizedb .
-COPY --from=builder /go/src/github.com/makerdao/vdb-mcd-transformers/go.mod ./vdb/go.mod
+COPY --from=builder /go/src/github.com/makerdao/vdb-mcd-transformers/go.mod ./mcd-transformers/go.mod
 
-RUN python3 scripts/gomoderator.py ./ vdb/
+RUN python3 scripts/gomoderator.py ./ mcd-transformers/

--- a/dockerfiles/gomoderator/Dockerfile
+++ b/dockerfiles/gomoderator/Dockerfile
@@ -7,11 +7,11 @@ ENV GO111MODULE on
 
 WORKDIR /go/src/github.com/makerdao
 RUN git clone https://github.com/makerdao/vulcanizedb.git
-RUN git clone https://github.com/makerdao/vdb-mcd-transformers.git
 WORKDIR /go/src/github.com/makerdao/vulcanizedb
 RUN git checkout $VDB_VERSION
 RUN go build
 WORKDIR /go/src/github.com/makerdao/vdb-mcd-transformers
+COPY . .
 RUN go build
 
 # app container


### PR DESCRIPTION
This PR contains a `Dockerfile` that is used in the `.travis.yml.` It should run `gomoderator` across both repos. Exit codes have been updated to be more explicit in this PR:
https://github.com/makerdao/vulcanizedb/pull/49