### PR TITLE
Update offer_id to type NUMERIC in log_item_update table

### DIFF
--- a/db/migrations/20200413153300_update_log_item_update_offer_id_type.sql
+++ b/db/migrations/20200413153300_update_log_item_update_offer_id_type.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE maker.log_item_update ALTER COLUMN offer_id TYPE NUMERIC;
+
+-- +goose Down
+
+ALTER TABLE maker.log_item_update ALTER COLUMN offer_id TYPE INT;
+

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -10053,7 +10053,7 @@ CREATE TABLE maker.log_item_update (
     log_id bigint NOT NULL,
     header_id integer NOT NULL,
     address_id integer NOT NULL,
-    offer_id integer
+    offer_id numeric
 );
 
 


### PR DESCRIPTION
After looking more at `LogItemUpdate` the offer id is a `uint` which is an alias to `uint256`: https://solidity.readthedocs.io/en/v0.5.3/types.html#integers in solidity. So this field should be bumped up to a `NUMERIC` to make sure it's big enough to fit a number that is potentially 32bytes.