### PR TITLE
Error when CLIENT_IPCPATH is not present with a useful message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ test_scripts/
 vulcanizedb.log
 db/migrations/00*.sql
 vdb-mcd-transformers
+.DS_Store

--- a/transformers/integration_tests/integration_tests_suite_test.go
+++ b/transformers/integration_tests/integration_tests_suite_test.go
@@ -1,7 +1,6 @@
 package integration_tests
 
 import (
-	"errors"
 	"io/ioutil"
 	"log"
 	"testing"
@@ -30,21 +29,15 @@ var _ = BeforeSuite(func() {
 	testConfig.SetConfigName("testing")
 	testConfig.AddConfigPath("$GOPATH/src/github.com/makerdao/vdb-mcd-transformers/environments/")
 	err := testConfig.ReadInConfig()
+	Expect(err).To(BeNil())
 	ipc = testConfig.GetString("client.ipcPath")
-	if err != nil {
-		logrus.Fatal(err)
-	}
 	// If we don't have an ipc path in the config file, check the env variable
 	if ipc == "" {
 		configErr := testConfig.BindEnv("url", "CLIENT_IPCPATH")
-		if configErr != nil {
-			logrus.Fatalf("Unable to bind url to CLIENT_IPCPATH env var")
-		}
+		Expect(configErr).To(BeNil(), "Unable to bind url to CLIENT_IPCPATH env var")
 		ipc = testConfig.GetString("url")
 	}
-	if ipc == "" {
-		logrus.Fatal(errors.New("testing.toml IPC path or $CLIENT_IPCPATH env variable need to be set"))
-	}
+	Expect(ipc).NotTo(BeEmpty(), "testing.toml IPC path or $CLIENT_IPCPATH env variable need to be set")
 
 	rpcClient, ethClient, clientErr := getClients(ipc)
 	Expect(clientErr).NotTo(HaveOccurred())


### PR DESCRIPTION
The integration tests fail when CLIENT_IPCPATH isn't present would fail without a useful error message. So I gave them one.

Example:

```
/Users/eric/Projects/go/bin/ginkgo -r transformers/integration_tests/
Running Suite: IntegrationTests Suite
=====================================
Random Seed: 1586885536
Will run 75 of 86 specs

Failure [0.178 seconds]
[BeforeSuite] BeforeSuite
/Users/eric/Projects/go/src/github.com/makerdao/vdb-mcd-transformers/transformers/integration_tests/integration_tests_suite_test.go:27

  testing.toml IPC path or $CLIENT_IPCPATH env variable need to be set
  Expected
      <string>:
  not to be empty

  /Users/eric/Projects/go/src/github.com/makerdao/vdb-mcd-transformers/transformers/integration_tests/integration_tests_suite_test.go:40
------------------------------

Ran 75 of 0 Specs in 0.178 seconds
FAIL! -- 0 Passed | 75 Failed | 0 Pending | 0 Skipped
--- FAIL: TestIntegrationTests (0.18s)
FAIL

Ginkgo ran 1 suite in 6.578962481s
Test Suite Failed
make: *** [integrationtest] Error 1
```