### PR TITLE
Drop trigger that updates Urn created timestamp

### DIFF
--- a/db/migrations/20200421142131_drop_urn_created_trigger.sql
+++ b/db/migrations/20200421142131_drop_urn_created_trigger.sql
@@ -1,0 +1,75 @@
+-- +goose Up
+DROP TRIGGER urn_ink ON maker.vat_urn_ink;
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION maker.update_urn_inks() RETURNS TRIGGER
+AS
+$$
+BEGIN
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_urn_ink(NEW);
+        PERFORM maker.update_urn_inks_until_next_diff(NEW, NEW.ink);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.update_urn_inks_until_next_diff(OLD, urn_ink_before_block(OLD.urn_id, OLD.header_id));
+        PERFORM maker.delete_obsolete_urn_state(OLD.urn_id, OLD.header_id);
+    END IF;
+    RETURN NULL;
+END
+$$
+    LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+DROP FUNCTION maker.update_urn_created(INTEGER);
+
+CREATE TRIGGER urn_ink
+    AFTER INSERT OR UPDATE OR DELETE
+    ON maker.vat_urn_ink
+    FOR EACH ROW
+EXECUTE PROCEDURE maker.update_urn_inks();
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TRIGGER urn_ink ON maker.vat_urn_ink;
+
+CREATE OR REPLACE FUNCTION maker.update_urn_created(urn_id INTEGER) RETURNS maker.vat_urn_ink
+AS
+$$
+BEGIN
+    UPDATE api.urn_snapshot
+    SET created = urn_time_created(urn_id)
+    FROM maker.urns
+             LEFT JOIN maker.ilks ON urns.ilk_id = ilks.id
+    WHERE urns.identifier = urn_snapshot.urn_identifier
+      AND ilks.identifier = urn_snapshot.ilk_identifier
+      AND urns.id = urn_id;
+    RETURN NULL;
+END
+$$
+    LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION maker.update_urn_inks() RETURNS TRIGGER
+AS
+$$
+BEGIN
+    IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
+        PERFORM maker.insert_urn_ink(NEW);
+        PERFORM maker.update_urn_inks_until_next_diff(NEW, NEW.ink);
+        PERFORM maker.update_urn_created(NEW.urn_id);
+    ELSIF (TG_OP = 'DELETE') THEN
+        PERFORM maker.update_urn_inks_until_next_diff(OLD, urn_ink_before_block(OLD.urn_id, OLD.header_id));
+        PERFORM maker.delete_obsolete_urn_state(OLD.urn_id, OLD.header_id);
+        PERFORM maker.update_urn_created(OLD.urn_id);
+    END IF;
+    RETURN NULL;
+END
+$$
+    LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+CREATE TRIGGER urn_ink
+    AFTER INSERT OR UPDATE OR DELETE
+    ON maker.vat_urn_ink
+    FOR EACH ROW
+EXECUTE PROCEDURE maker.update_urn_inks();

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -6622,11 +6622,9 @@ BEGIN
     IF (TG_OP IN ('INSERT', 'UPDATE')) THEN
         PERFORM maker.insert_urn_ink(NEW);
         PERFORM maker.update_urn_inks_until_next_diff(NEW, NEW.ink);
-        PERFORM maker.update_urn_created(NEW.urn_id);
     ELSIF (TG_OP = 'DELETE') THEN
         PERFORM maker.update_urn_inks_until_next_diff(OLD, urn_ink_before_block(OLD.urn_id, OLD.header_id));
         PERFORM maker.delete_obsolete_urn_state(OLD.urn_id, OLD.header_id);
-        PERFORM maker.update_urn_created(OLD.urn_id);
     END IF;
     RETURN NULL;
 END

--- a/transformers/storage/vat/repository_test.go
+++ b/transformers/storage/vat/repository_test.go
@@ -868,7 +868,9 @@ var _ = Describe("Vat storage repository", func() {
 				Expect(timeCreatedValues[1]).To(Equal(expectedTimeCreated))
 			})
 
-			It("updates time created for all the urn's states when new ink is added", func() {
+			// TODO: figure out a way to ensure accurate timestamps without including this in the trigger
+			// Including it in the trigger causes it to take ~5 mins for 0xc73e0383F3Aff3215E6f04B0331D58CeCf0Ab849
+			XIt("updates time created for all the urn's states when new ink is added", func() {
 				urnArtMetadata := types.GetValueMetadata(vat.UrnArt, map[types.Key]string{constants.Ilk: test_helpers.FakeIlk.Hex, constants.Guy: fakeGuy}, types.Uint256)
 				setupErr := repo.Create(diffID, headerOne.Id, urnArtMetadata, strconv.Itoa(rand.Int()))
 				Expect(setupErr).NotTo(HaveOccurred())
@@ -1062,7 +1064,9 @@ var _ = Describe("Vat storage repository", func() {
 					Expect(len(urnStates)).To(Equal(0))
 				})
 
-				It("updates time created for all urn's states", func() {
+				// TODO: figure out a way to ensure accurate timestamps without including this in the trigger
+				// Including it in the trigger causes it to take ~5 mins for 0xc73e0383F3Aff3215E6f04B0331D58CeCf0Ab849
+				XIt("updates time created for all urn's states", func() {
 					initialInk := rand.Int()
 					setupErrOne := repo.Create(diffID, headerOne.Id, urnInkMetadata, strconv.Itoa(initialInk))
 					Expect(setupErrOne).NotTo(HaveOccurred())


### PR DESCRIPTION
- Performing very slow for Urns that change a lot
- Tests marked as pending because we should figure out a way to
  get eventual consistency for this field, either by optimizing
  the query or replacing with a separate process