### PR TITLE
Vat can storage

### DIFF
--- a/db/migrations/20200429173048_create_vat_can_table.sql
+++ b/db/migrations/20200429173048_create_vat_can_table.sql
@@ -1,0 +1,25 @@
+-- +goose Up
+CREATE TABLE maker.vat_can
+(
+    id        SERIAL PRIMARY KEY,
+    diff_id   BIGINT  NOT NULL REFERENCES public.storage_diff (id) ON DELETE CASCADE,
+    header_id INTEGER NOT NULL REFERENCES public.headers (id) ON DELETE CASCADE,
+    bit       INTEGER NOT NULL REFERENCES public.addresses (id) ON DELETE CASCADE,
+    usr       INTEGER NOT NULL REFERENCES public.addresses (id) ON DELETE CASCADE,
+    can       NUMERIC NOT NULL,
+    UNIQUE (diff_id, header_id, bit, usr, can)
+);
+
+CREATE INDEX vat_can_header_id_index
+    ON maker.vat_can (header_id);
+CREATE INDEX vat_can_bit_index
+    ON maker.vat_can (bit);
+CREATE INDEX vat_can_usr_index
+    ON maker.vat_can (usr);
+
+-- +goose Down
+DROP INDEX maker.vat_can_header_id_index;
+DROP INDEX maker.vat_can_bit_index;
+DROP INDEX maker.vat_can_usr_index;
+
+DROP TABLE maker.vat_can;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -11710,6 +11710,40 @@ ALTER SEQUENCE maker.urns_id_seq OWNED BY maker.urns.id;
 
 
 --
+-- Name: vat_can; Type: TABLE; Schema: maker; Owner: -
+--
+
+CREATE TABLE maker.vat_can (
+    id integer NOT NULL,
+    diff_id bigint NOT NULL,
+    header_id integer NOT NULL,
+    "bit" integer NOT NULL,
+    usr integer NOT NULL,
+    can numeric NOT NULL
+);
+
+
+--
+-- Name: vat_can_id_seq; Type: SEQUENCE; Schema: maker; Owner: -
+--
+
+CREATE SEQUENCE maker.vat_can_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: vat_can_id_seq; Type: SEQUENCE OWNED BY; Schema: maker; Owner: -
+--
+
+ALTER SEQUENCE maker.vat_can_id_seq OWNED BY maker.vat_can.id;
+
+
+--
 -- Name: vat_dai; Type: TABLE; Schema: maker; Owner: -
 --
 
@@ -14398,6 +14432,13 @@ ALTER TABLE ONLY maker.urns ALTER COLUMN id SET DEFAULT nextval('maker.urns_id_s
 
 
 --
+-- Name: vat_can id; Type: DEFAULT; Schema: maker; Owner: -
+--
+
+ALTER TABLE ONLY maker.vat_can ALTER COLUMN id SET DEFAULT nextval('maker.vat_can_id_seq'::regclass);
+
+
+--
 -- Name: vat_dai id; Type: DEFAULT; Schema: maker; Owner: -
 --
 
@@ -16898,6 +16939,22 @@ ALTER TABLE ONLY maker.urns
 
 ALTER TABLE ONLY maker.urns
     ADD CONSTRAINT urns_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: vat_can vat_can_diff_id_header_id_bit_usr_can_key; Type: CONSTRAINT; Schema: maker; Owner: -
+--
+
+ALTER TABLE ONLY maker.vat_can
+    ADD CONSTRAINT vat_can_diff_id_header_id_bit_usr_can_key UNIQUE (diff_id, header_id, "bit", usr, can);
+
+
+--
+-- Name: vat_can vat_can_pkey; Type: CONSTRAINT; Schema: maker; Owner: -
+--
+
+ALTER TABLE ONLY maker.vat_can
+    ADD CONSTRAINT vat_can_pkey PRIMARY KEY (id);
 
 
 --
@@ -20118,6 +20175,27 @@ CREATE INDEX tick_log_index ON maker.tick USING btree (log_id);
 --
 
 CREATE INDEX urn_ilk_index ON maker.urns USING btree (ilk_id);
+
+
+--
+-- Name: vat_can_bit_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vat_can_bit_index ON maker.vat_can USING btree ("bit");
+
+
+--
+-- Name: vat_can_header_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vat_can_header_id_index ON maker.vat_can USING btree (header_id);
+
+
+--
+-- Name: vat_can_usr_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX vat_can_usr_index ON maker.vat_can USING btree (usr);
 
 
 --
@@ -24260,6 +24338,38 @@ ALTER TABLE ONLY maker.tick
 
 ALTER TABLE ONLY maker.urns
     ADD CONSTRAINT urns_ilk_id_fkey FOREIGN KEY (ilk_id) REFERENCES maker.ilks(id) ON DELETE CASCADE;
+
+
+--
+-- Name: vat_can vat_can_bit_fkey; Type: FK CONSTRAINT; Schema: maker; Owner: -
+--
+
+ALTER TABLE ONLY maker.vat_can
+    ADD CONSTRAINT vat_can_bit_fkey FOREIGN KEY ("bit") REFERENCES public.addresses(id) ON DELETE CASCADE;
+
+
+--
+-- Name: vat_can vat_can_diff_id_fkey; Type: FK CONSTRAINT; Schema: maker; Owner: -
+--
+
+ALTER TABLE ONLY maker.vat_can
+    ADD CONSTRAINT vat_can_diff_id_fkey FOREIGN KEY (diff_id) REFERENCES public.storage_diff(id) ON DELETE CASCADE;
+
+
+--
+-- Name: vat_can vat_can_header_id_fkey; Type: FK CONSTRAINT; Schema: maker; Owner: -
+--
+
+ALTER TABLE ONLY maker.vat_can
+    ADD CONSTRAINT vat_can_header_id_fkey FOREIGN KEY (header_id) REFERENCES public.headers(id) ON DELETE CASCADE;
+
+
+--
+-- Name: vat_can vat_can_usr_fkey; Type: FK CONSTRAINT; Schema: maker; Owner: -
+--
+
+ALTER TABLE ONLY maker.vat_can
+    ADD CONSTRAINT vat_can_usr_fkey FOREIGN KEY (usr) REFERENCES public.addresses(id) ON DELETE CASCADE;
 
 
 --

--- a/transformers/shared/constants/keys.go
+++ b/transformers/shared/constants/keys.go
@@ -24,6 +24,7 @@ import (
 // Storage keys
 const (
 	BidId     types.Key = "bid_id"
+	Bit       types.Key = "bit"
 	Cdpi      types.Key = "cdpi"
 	Flip      types.Key = "flip"
 	Guy       types.Key = "guy"

--- a/transformers/shared/constants/table.go
+++ b/transformers/shared/constants/table.go
@@ -170,6 +170,7 @@ const (
 	SpotLiveTable           = "spot_live"
 	SpotParTable            = "spot_par"
 	SpotVatTable            = "spot_vat"
+	VatCanTable             = "vat_can"
 	VatDaiTable             = "vat_dai"
 	VatDebtTable            = "vat_debt"
 	VatGemTable             = "vat_gem"

--- a/transformers/storage/cdp_manager/repository.go
+++ b/transformers/storage/cdp_manager/repository.go
@@ -26,7 +26,7 @@ import (
 const (
 	insertVatQuery      = `INSERT INTO maker.cdp_manager_vat (diff_id, header_id, vat) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING`
 	InsertCdpiQuery     = `INSERT INTO maker.cdp_manager_cdpi (diff_id, header_id, cdpi) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING`
-	insertUrnsQuery     = `INSERT INTO maker.cdp_manager_urns (diff_id, header_id, cdpi, urn) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
+	InsertUrnsQuery     = `INSERT INTO maker.cdp_manager_urns (diff_id, header_id, cdpi, urn) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
 	insertListPrevQuery = `INSERT INTO maker.cdp_manager_list_prev (diff_id, header_id, cdpi, prev) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
 	insertListNextQuery = `INSERT INTO maker.cdp_manager_list_next (diff_id, header_id, cdpi, next) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
 	InsertOwnsQuery     = `INSERT INTO maker.cdp_manager_owns (diff_id, header_id, cdpi, owner) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
@@ -87,7 +87,7 @@ func (repository CdpManagerStorageRepository) insertUrns(diffID, headerID int64,
 		return keyErr
 	}
 
-	_, writeErr := repository.db.Exec(insertUrnsQuery, diffID, headerID, cdpi, urns)
+	_, writeErr := repository.db.Exec(InsertUrnsQuery, diffID, headerID, cdpi, urns)
 	return writeErr
 }
 

--- a/transformers/storage/test_helpers/maker_storage_repository.go
+++ b/transformers/storage/test_helpers/maker_storage_repository.go
@@ -18,6 +18,7 @@ type MockMakerStorageRepository struct {
 	PotPieUsers             []string
 	SinKeys                 []string
 	Urns                    []storage.Urn
+	VatCanKeys              []storage.Can
 	VatWardsKeys            []string
 	WardsKeys               []string
 	GetCdpisCalled          bool
@@ -38,14 +39,16 @@ type MockMakerStorageRepository struct {
 	GetOwnersError          error
 	GetPotPieUsersCalled    bool
 	GetPotPieUsersError     error
-	GetVatSinKeysCalled     bool
-	GetVatSinKeysError      error
-	GetVowSinKeysCalled     bool
-	GetVowSinKeysError      error
 	GetUrnsCalled           bool
 	GetUrnsError            error
+	GetVatCanKeysCalled     bool
+	GetVatCanKeysError      error
+	GetVatSinKeysCalled     bool
+	GetVatSinKeysError      error
 	GetVatWardsKeysCalled   bool
 	GetVatWardsKeysError    error
+	GetVowSinKeysCalled     bool
+	GetVowSinKeysError      error
 	GetWardsKeysCalledWith  string
 	GetWardsKeysError       error
 }
@@ -108,6 +111,11 @@ func (repository *MockMakerStorageRepository) GetVowSinKeys() ([]string, error) 
 func (repository *MockMakerStorageRepository) GetUrns() ([]storage.Urn, error) {
 	repository.GetUrnsCalled = true
 	return repository.Urns, repository.GetUrnsError
+}
+
+func (repository *MockMakerStorageRepository) GetVatCanKeys() ([]storage.Can, error) {
+	repository.GetVatCanKeysCalled = true
+	return repository.VatCanKeys, repository.GetVatCanKeysError
 }
 
 func (repository *MockMakerStorageRepository) GetVatWardsAddresses() ([]string, error) {


### PR DESCRIPTION
This results in an *incomplete* set of `can` keys being available to the keys loader, enabling us to transform ~1/3 of the `can` diffs in the db. Tried to set things up so that we only need to modify the `MakerStorageRepository.GetVatCanKeys()` implementation if we find a way to identify the rest of the `msg.sender` values passed to `hope`/`nope`.