### PR TITLE
Vdb 1294 update docker compose config and directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,38 @@
 This repository is a collection of transformers to be used along with VDB as a plugin to fetch, transform and persist log events and storage slots of specified MCD contracts.
 
 ## Install
-### Dependencies
- - [VulcanizeDB](https://github.com/makerdao/vulcanizedb)
- - Go 1.12+
- - Postgres 11.2
+
+### Docker Setup
+
+This repository provides a docker-compose setup to manage the multiple container-based deployment for you, if at all possible you should use that setup.
+
+#### Dependencies
+ - Docker (the rest is handled by docker-compose)
+
+#### Database Initialization
+
+The database needs to be initialized once before bringing up the system. That can be by running, from the root directory, 
+
+```bash
+docker-compose -f dockerfiles/docker-compose.yml run execute ./run_migrations.sh
+```
+
+#### System Startup
+
+```bash
+docker-compose -f dockerfiles/docker-compose.yml up
+```
+
+### Manual Setup
+
+#### Dependencies
  - Ethereum Node
    - Use the patched version of [Go Ethereum](https://github.com/makerdao/go-ethereum) (1.8.23+) in order to have access to storage transformers and diffs.
    - [Parity 1.8.11+](https://github.com/paritytech/parity/releases)
-   
+ - [VulcanizeDB](https://github.com/makerdao/vulcanizedb)
+ - Go 1.12+
+ - Postgres 11.2
+    
 ### Getting the project
 Download the transformer codebase to your local local `GOPATH` via: `go get github.com/makerdao/vdb-mcd-transformers`
 
@@ -35,15 +59,9 @@ As mentioned above this repository is a plugin for VulcanizeDB.  As such it cann
 
 1. `execute` uses the raw Ethereum data that has been synced into Postgres and applies transformations to configured MCD contract data via [event](./transformers/events) and [storage](./transformers/storage) transformers. The VulcanizeDB repository includes a [general description](https://github.com/makerdao/vulcanizedb/blob/staging/documentation/custom-transformers.md) about transformers.
 
-These core commands can be run via Docker a provided docker-compose setup. This can be done as follows: 
-
-1. `Run docker-compose -f dockerfiles/docker-compose.yml run execute ./run_migrations.sh` (to initially setup the database).
-2. `docker-compose up`
-
-
 The core commands can also be run via images or built and run via the command line interface. In either method, a postgres database will first need to be created:
 1. Install Postgres
-1. Create a user for yourself that is able run migrations and add extensions.
+   1. Create a user for yourself that is able run migrations and add extensions.
 1. `createdb vulcanize_public`
 1. Migrate the database using the `make migrate` task in this repository.
 
@@ -60,7 +78,13 @@ Note that, as with other commands, executing this requires either a config file 
 
 ### Running With Docker
 
-**NOTE** The database must be migrated once before running the `headerSync` command, otherwise the database will not be able to properly create its schema.
+#### Database Initialization
+
+**NOTE** The database must be migrated once before running the `headerSync` command, otherwise the database will not be able to properly create its schema. Assuming you are not using the `docker-compose` setup above you can migrate the database once using:
+
+```
+docker run -e DATABASE_USER=<user> -e DATABASE_PASSWORD=<pw> -e DATABASE_HOSTNAME=<host> -e DATABASE_PORT=<port> -e DATABASE_NAME=<name> -e CLIENT_IPCPATH=<path> makerdao/vdb-execute:latest ./run_migrations.sh
+```
 
 #### Running `headerSync`
 `headerSync` Docker images are located in the [MakerDao Dockerhub organization](https://hub.docker.com/repository/docker/makerdao/vdb-headersync).

--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@
 1. [License](#license)
 
 ## Background
-This repository is a collection of transformers to be used along with VDB as a plugin to fetch, transform and persist log events and storage slots of
-specified MCD contracts.
+This repository is a collection of transformers to be used along with VDB as a plugin to fetch, transform and persist log events and storage slots of specified MCD contracts.
 
 ## Install
 ### Dependencies
@@ -20,37 +19,35 @@ specified MCD contracts.
  - Go 1.12+
  - Postgres 11.2
  - Ethereum Node
-   - [Go Ethereum](https://ethereum.github.io/go-ethereum/downloads/) (1.8.23+)
+   - Use the patched version of [Go Ethereum](https://github.com/makerdao/go-ethereum) (1.8.23+) in order to have access to storage transformers and diffs.
    - [Parity 1.8.11+](https://github.com/paritytech/parity/releases)
    
 ### Getting the project
-Download the transformer codebase to your local local `GOPATH` via:
-`go get github.com/makerdao/vdb-mcd-transformers`
+Download the transformer codebase to your local local `GOPATH` via: `go get github.com/makerdao/vdb-mcd-transformers`
 
 ## Usage
 
 ### Plugin
-As mentioned above this repository is a plugin for VulcanizeDB.  As such it cannot be run as a standalone executable,
-but instead is intended to be included as part of a VulcanizeDB core command. There are two VulcanizeDB core commands that 
-are required for events and storage slots to be transformed and persisted to the Postgres database.
 
-1. `headerSync` fetches raw Ethereum data and syncs it into VulcanizeDB's Postgres database where then it can be used for
-transformations. More information about the `headerSync` command can be found in the [VulcanizeDB repository](https://github.com/makerdao/vulcanizedb/blob/staging/documentation/data-syncing.md#headersync).
+As mentioned above this repository is a plugin for VulcanizeDB.  As such it cannot be run as a standalone executable, but instead is intended to be included as part of a VulcanizeDB core command. There are two VulcanizeDB core commands that are required for events and storage slots to be transformed and persisted to the Postgres database.
 
-1. `execute` uses the raw Ethereum data that has been synced into Postgres and applies transformations to configured MCD
-contract data via [event](./transformers/events) and [storage](./transformers/storage) transformers. The VulcanizeDB
-repository includes a [general description](https://github.com/makerdao/vulcanizedb/blob/staging/documentation/custom-transformers.md)
-about transformers.
+1. `headerSync` fetches raw Ethereum data and syncs it into VulcanizeDB's Postgres database where then it can be used for transformations. More information about the `headerSync` command can be found in the [VulcanizeDB repository](https://github.com/makerdao/vulcanizedb/blob/staging/documentation/data-syncing.md#headersync).
 
-These core commands can be run via Docker images which is the preferred method, or they can be built and run via the
-command line interface. In either method, a postgres database will first need to be created:
+1. `execute` uses the raw Ethereum data that has been synced into Postgres and applies transformations to configured MCD contract data via [event](./transformers/events) and [storage](./transformers/storage) transformers. The VulcanizeDB repository includes a [general description](https://github.com/makerdao/vulcanizedb/blob/staging/documentation/custom-transformers.md) about transformers.
+
+These core commands can be run via Docker a provided docker-compose setup. This can be done as follows: 
+
+1. `Run docker-compose -f dockerfiles/docker-compose.yml run execute ./run_migrations.sh` (to initially setup the database).
+2. `docker-compose up`
+
+
+The core commands can also be run via images or built and run via the command line interface. In either method, a postgres database will first need to be created:
 1. Install Postgres
 1. Create a user for yourself that is able run migrations and add extensions.
 1. `createdb vulcanize_public`
-1. Migrating the database manually is unnecessary as the commands handle this.
+1. Migrate the database using the `make migrate` task in this repository.
 
-In some cases (such as recent Ubuntu systems), it may be necessary to overcome failures of password authentication from
-localhost. To allow access on Ubuntu, set localhost connections via hostname, ipv4, and ipv6 from peer/md5 to trust in: /etc/postgresql/<version>/pg_hba.conf
+In some cases (such as recent Ubuntu systems), it may be necessary to overcome failures of password authentication from localhost. To allow access on Ubuntu, set localhost connections via hostname, ipv4, and ipv6 from peer/md5 to trust in: /etc/postgresql/<version>/pg_hba.conf
 
 (It should be noted that trusted auth should only be enabled on systems without sensitive data in them: development and local test databases)
 
@@ -62,6 +59,9 @@ After that, you can run something like `./vdb-mcd-transformers backfillUrns --st
 Note that, as with other commands, executing this requires either a config file or env vars to specify the database and ethereum node connection.
 
 ### Running With Docker
+
+**NOTE** The database must be migrated once before running the `headerSync` command, otherwise the database will not be able to properly create its schema.
+
 #### Running `headerSync`
 `headerSync` Docker images are located in the [MakerDao Dockerhub organization](https://hub.docker.com/repository/docker/makerdao/vdb-headersync).
 
@@ -69,16 +69,13 @@ Start `headerSync`:
 ```
 docker run -e DATABASE_USER=<user> -e DATABASE_PASSWORD=<pw> -e DATABASE_HOSTNAME=<host> -e DATABASE_PORT=<port> -e DATABASE_NAME=<name> -e STARTING_BLOCK_NUMBER=<starting block number> -e CLIENT_IPCPATH=<path> makerdao/vdb-headersync:latest
 ```
-- `STARTING_BLOCK_NUMBER` indicates where to start syncing raw headers. If you don't care about headers before the contracts
-of interest were deployed, it is recommended to use the earliest deployment block of those contracts. Otherwise, the command
-will sync all headers starting at the genesis block.
-- To allow the docker container to connect to a local database and a local Ethereum node:
-    - when running on Linux include `--network=host`
-    - when running on MacOSX use `host.docker.internal` as the `DATABASE_HOSTNAME` and as the host in the `CLIENT_IPCPATH`
+- `STARTING_BLOCK_NUMBER` indicates where to start syncing raw headers. If you don't care about headers before the contracts of interest were deployed, it is recommended to use the earliest deployment block of those contracts. Otherwise, the command will sync all headers starting at the genesis block.
+- To allow the docker container to connect to a local database and a local Ethereum node: 
+  - when running on Linux include `--network=host` 
+  - when running on MacOSX use `host.docker.internal` as the `DATABASE_HOSTNAME` and as the host in the `CLIENT_IPCPATH`
 
 #### Running `execute`
-`execute` Docker images are located in the [MakerDao Dockerhub organization](https://hub.docker.com/repository/docker/makerdao/vdb-execute).
-See the [Docker README](./dockerfiles/README.md) for further information.
+`execute` Docker images are located in the [MakerDao Dockerhub organization](https://hub.docker.com/repository/docker/makerdao/vdb-execute). See the [Docker README](./dockerfiles/README.md) for further information.
 
 ### With the CLI
 
@@ -94,8 +91,7 @@ See the [Docker README](./dockerfiles/README.md) for further information.
 For more information, see the [VulcanizeDB data-syncing documentation](https://github.com/makerdao/vulcanizedb/blob/staging/documentation/data-syncing.md).
 
 #### Running `execute`
-Instead of running `execute`, you will also need to `compose` the transformer initializer plugin prior to execution. This
-step is not explicitly required when using Docker because it is included in the `vdb-execute` container.
+Instead of running `execute`, you will also need to `compose` the transformer initializer plugin prior to execution. This step is not explicitly required when using Docker because it is included in the `vdb-execute` container.
 
 There is a convenience command called `composeAndExecute` in `vulcanizedb` which encapsulates both composing the plugin, and then
 executing it. 

--- a/dockerfiles/execute/Dockerfile
+++ b/dockerfiles/execute/Dockerfile
@@ -55,6 +55,7 @@ COPY --from=builder /go/src/github.com/pressly/goose/cmd/goose/goose goose
 COPY --from=builder /go/src/github.com/makerdao/vdb-mcd-transformers/db/migrations/* db/migrations/
 COPY --from=builder /go/src/github.com/makerdao/vdb-mcd-transformers/plugins/transformerExporter.so plugins/transformerExporter.so
 COPY --from=builder /go/src/github.com/makerdao/vdb-mcd-transformers/dockerfiles/wait-for-it.sh .
+COPY --from=builder /go/src/github.com/makerdao/vdb-mcd-transformers/dockerfiles/execute/run_migrations.sh .
 
 # need to execute with a shell to access env variables
 CMD ["./startup_script.sh"]

--- a/dockerfiles/execute/run_migrations.sh
+++ b/dockerfiles/execute/run_migrations.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Runs the migrations and executes transformers
+
+MISSING_VAR_MESSAGE=" is required and no value was given"
+
+function testDatabaseVariables() {
+  for a in DATABASE_NAME DATABASE_HOSTNAME DATABASE_PORT DATABASE_USER DATABASE_PASSWORD
+  do
+    eval arg="$"$a
+    test $arg
+    if [ $? -ne 0 ]; then
+      echo $a $MISSING_VAR_MESSAGE
+      exit 1
+    fi
+  done
+}
+
+if test -z "$VDB_PG_CONNECT"; then
+  # Exits if the variable tests fail
+  testDatabaseVariables
+  if [ $? -ne 0 ]; then
+    exit 1
+  fi
+
+  # Construct the connection string for postgres
+  VDB_PG_CONNECT=postgresql://$DATABASE_USER:$DATABASE_PASSWORD@$DATABASE_HOSTNAME:$DATABASE_PORT/$DATABASE_NAME?sslmode=disable
+fi
+
+# Run the DB migrations
+echo "Connecting with: $VDB_PG_CONNECT"
+./goose -dir db/migrations postgres "$VDB_PG_CONNECT" up
+
+if [ $? -ne 0 ]; then
+  echo "Could not run migrations. Are the database details correct?"
+  exit 1
+fi

--- a/dockerfiles/execute/startup_script.sh
+++ b/dockerfiles/execute/startup_script.sh
@@ -1,39 +1,5 @@
 #!/bin/sh
-# Runs the migrations and executes transformers
-
-MISSING_VAR_MESSAGE=" is required and no value was given"
-
-function testDatabaseVariables() {
-  for a in DATABASE_NAME DATABASE_HOSTNAME DATABASE_PORT DATABASE_USER DATABASE_PASSWORD
-  do
-    eval arg="$"$a
-    test $arg
-    if [ $? -ne 0 ]; then
-      echo $a $MISSING_VAR_MESSAGE
-      exit 1
-    fi
-  done
-}
-
-if test -z "$VDB_PG_CONNECT"; then
-  # Exits if the variable tests fail
-  testDatabaseVariables
-  if [ $? -ne 0 ]; then
-    exit 1
-  fi
-
-  # Construct the connection string for postgres
-  VDB_PG_CONNECT=postgresql://$DATABASE_USER:$DATABASE_PASSWORD@$DATABASE_HOSTNAME:$DATABASE_PORT/$DATABASE_NAME?sslmode=disable
-fi
-
-# Run the DB migrations
-echo "Connecting with: $VDB_PG_CONNECT"
-./goose -dir db/migrations postgres "$VDB_PG_CONNECT" up
-
-if [ $? -ne 0 ]; then
-  echo "Could not run migrations. Are the database details correct?"
-  exit 1
-fi
+source run_migrations.sh
 
 DIFF_STARTING_BLOCK="-1"
 


### PR DESCRIPTION
Extract run-migrations from startup-script, and then reference the docker-compose setup in the directions first.

This PR has a bit of a chicken-and-egg problem as the Docker image needs to be updated before the directions are correct. I validated this using a local image, but that's not a perfect setup.