### PR TITLE
(VDB-1335) storage transformer verbose errors

### DIFF
--- a/backfill/fork/fork_suite_test.go
+++ b/backfill/fork/fork_suite_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestFork(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Fork Suite")
+	RunSpecs(t, "BackFill Fork Suite")
 }
 
 var _ = BeforeSuite(func() {

--- a/cmd/backfillUrns.go
+++ b/cmd/backfillUrns.go
@@ -35,7 +35,7 @@ var backfillUrnsCmd = &cobra.Command{
 	Short: "Backfill diffs for urns, looking up diffs based on associated events",
 	Long: `Fetch diffs when events indicate the state of an Urn changed at a given block.
 Optionally pass a starting block number to backfill since a given block.
-Optionally pass events to watch (frob, grab) to backfill based off of certain events.`,
+Optionally pass events to watch (fork, frob, grab) to backfill based off of certain events.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		err := backfillUrns()
 		if err != nil {
@@ -49,7 +49,7 @@ Optionally pass events to watch (frob, grab) to backfill based off of certain ev
 func init() {
 	rootCmd.AddCommand(backfillUrnsCmd)
 	backfillUrnsCmd.Flags().IntVarP(&startingBlock, "starting-block", "s", 0, "starting block for backfilling diffs derived from urn events")
-	backfillUrnsCmd.Flags().StringSliceVarP(&eventsToBackFill, "events-to-backfill", "e", []string{"frob", "grab"}, "events to back-fill")
+	backfillUrnsCmd.Flags().StringSliceVarP(&eventsToBackFill, "events-to-backfill", "e", []string{"fork", "frob", "grab"}, "events to back-fill")
 }
 
 func backfillUrns() error {

--- a/transformers/component_tests/cat/configured_transformer_test.go
+++ b/transformers/component_tests/cat/configured_transformer_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Executing the transformer", func() {
 		db                = test_config.NewTestDB(test_config.NewTestNode())
 		contractAddress   = test_data.CatAddress()
 		keccakOfAddress   = types.HexToKeccak256Hash(contractAddress)
-		repository        = cat.CatStorageRepository{ContractAddress: contractAddress}
+		repository        = cat.StorageRepository{ContractAddress: contractAddress}
 		storageKeysLookup = storage.NewKeysLookup(cat.NewKeysLoader(&mcdStorage.MakerStorageRepository{}, contractAddress))
 		transformer       = storage.Transformer{
 			Address:           common.HexToAddress(contractAddress),

--- a/transformers/component_tests/cdp_manager/configured_transformer_test.go
+++ b/transformers/component_tests/cdp_manager/configured_transformer_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Executing the transformer", func() {
 	var (
 		db                = test_config.NewTestDB(test_config.NewTestNode())
 		storageKeysLookup = storage.NewKeysLookup(cdp_manager.NewKeysLoader(&mcdStorage.MakerStorageRepository{}))
-		repository        = cdp_manager.CdpManagerStorageRepository{}
+		repository        = cdp_manager.StorageRepository{}
 		contractAddress   = test_data.CdpManagerAddress()
 		keccakOfAddress   = types.HexToKeccak256Hash(contractAddress)
 		transformer       = storage.Transformer{

--- a/transformers/component_tests/flap/configured_transformer_test.go
+++ b/transformers/component_tests/flap/configured_transformer_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Executing the flap transformer", func() {
 		db                = test_config.NewTestDB(test_config.NewTestNode())
 		contractAddress   = test_data.FlapAddress()
 		keccakOfAddress   = types.HexToKeccak256Hash(contractAddress)
-		repository        = flap.FlapStorageRepository{ContractAddress: contractAddress}
+		repository        = flap.StorageRepository{ContractAddress: contractAddress}
 		storageKeysLookup = storage.NewKeysLookup(flap.NewKeysLoader(&mcdStorage.MakerStorageRepository{}, contractAddress))
 		header            = fakes.FakeHeader
 		transformer       storage.Transformer

--- a/transformers/component_tests/flip/configured_transformer_test.go
+++ b/transformers/component_tests/flip/configured_transformer_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Executing the flip transformer", func() {
 		db                = test_config.NewTestDB(test_config.NewTestNode())
 		contractAddress   = test_data.FlipEthAddress()
 		keccakAddress     = types.HexToKeccak256Hash(contractAddress)
-		repository        = flip.FlipStorageRepository{ContractAddress: contractAddress}
+		repository        = flip.StorageRepository{ContractAddress: contractAddress}
 		storageKeysLookup = storage.NewKeysLookup(flip.NewKeysLoader(&mcdStorage.MakerStorageRepository{}, contractAddress))
 		header            = fakes.FakeHeader
 		transformer       storage.Transformer

--- a/transformers/component_tests/flop/configured_transformer_test.go
+++ b/transformers/component_tests/flop/configured_transformer_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Executing the flop transformer", func() {
 		db                     = test_config.NewTestDB(test_config.NewTestNode())
 		flopperContractAddress = test_data.FlopAddress()
 		keccakOfAddress        = types.HexToKeccak256Hash(flopperContractAddress)
-		repository             = flop.FlopStorageRepository{ContractAddress: flopperContractAddress}
+		repository             = flop.StorageRepository{ContractAddress: flopperContractAddress}
 		storageKeysLookup      = storage.NewKeysLookup(flop.NewKeysLoader(&mcdStorage.MakerStorageRepository{}, flopperContractAddress))
 		header                 = fakes.FakeHeader
 		transformer            storage.Transformer

--- a/transformers/component_tests/jug/configured_transformer_test.go
+++ b/transformers/component_tests/jug/configured_transformer_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Executing the transformer", func() {
 		contractAddress   = test_data.JugAddress()
 		keccakOfAddress   = types.HexToKeccak256Hash(contractAddress)
 		storageKeysLookup = storage.NewKeysLookup(jug.NewKeysLoader(&mcdStorage.MakerStorageRepository{}, contractAddress))
-		repository        = jug.JugStorageRepository{ContractAddress: contractAddress}
+		repository        = jug.StorageRepository{ContractAddress: contractAddress}
 		transformer       = storage.Transformer{
 			Address:           common.HexToAddress(contractAddress),
 			StorageKeysLookup: storageKeysLookup,

--- a/transformers/component_tests/pot/configured_transformer_test.go
+++ b/transformers/component_tests/pot/configured_transformer_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Executing the transformer", func() {
 		storageKeysLookup = storage.NewKeysLookup(pot.NewKeysLoader(&mcdStorage.MakerStorageRepository{}, test_data.PotAddress()))
 		contractAddress   = test_data.PotAddress()
 		keccakOfAddress   = types.HexToKeccak256Hash(contractAddress)
-		repository        = pot.PotStorageRepository{ContractAddress: contractAddress}
+		repository        = pot.StorageRepository{ContractAddress: contractAddress}
 		transformer       = storage.Transformer{
 			Address:           common.HexToAddress(contractAddress),
 			StorageKeysLookup: storageKeysLookup,

--- a/transformers/component_tests/queries/all_flops_query_test.go
+++ b/transformers/component_tests/queries/all_flops_query_test.go
@@ -17,7 +17,7 @@ import (
 
 var _ = Describe("All flops query", func() {
 	var (
-		flopRepo               flop.FlopStorageRepository
+		flopRepo               flop.StorageRepository
 		headerRepo             datastore.HeaderRepository
 		contractAddress        = fakes.RandomString(42)
 		blockOne, timestampOne int
@@ -26,7 +26,7 @@ var _ = Describe("All flops query", func() {
 
 	BeforeEach(func() {
 		test_config.CleanTestDB(db)
-		flopRepo = flop.FlopStorageRepository{}
+		flopRepo = flop.StorageRepository{}
 		flopRepo.SetDB(db)
 		headerRepo = repositories.NewHeaderRepository(db)
 

--- a/transformers/component_tests/queries/all_urns_query_test.go
+++ b/transformers/component_tests/queries/all_urns_query_test.go
@@ -22,7 +22,7 @@ import (
 
 var _ = Describe("All Urns function", func() {
 	var (
-		vatRepo                vat.VatStorageRepository
+		vatRepo                vat.StorageRepository
 		headerRepo             datastore.HeaderRepository
 		headerOne              core.Header
 		blockOne, timestampOne int
@@ -36,7 +36,7 @@ var _ = Describe("All Urns function", func() {
 
 	BeforeEach(func() {
 		test_config.CleanTestDB(db)
-		vatRepo = vat.VatStorageRepository{}
+		vatRepo = vat.StorageRepository{}
 		vatRepo.SetDB(db)
 		headerRepo = repositories.NewHeaderRepository(db)
 

--- a/transformers/component_tests/queries/bite_event_computed_columns_test.go
+++ b/transformers/component_tests/queries/bite_event_computed_columns_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Bite event computed columns", func() {
 		headerOne              core.Header
 		biteGethLog            types.Log
 		biteEvent              event.InsertionModel
-		vatRepository          vat.VatStorageRepository
+		vatRepository          vat.StorageRepository
 		headerRepository       datastore.HeaderRepository
 	)
 

--- a/transformers/component_tests/queries/flip_bid_snapshot_computed_columns_test.go
+++ b/transformers/component_tests/queries/flip_bid_snapshot_computed_columns_test.go
@@ -97,7 +97,7 @@ var _ = Describe("flip_bid_snapshot computed columns", func() {
 		It("returns urn_state for a flip_bid_snapshot", func() {
 			urnSetupData := test_helpers.GetUrnSetupData()
 			urnMetadata := test_helpers.GetUrnMetadata(test_helpers.FakeIlk.Hex, test_data.FlipKickModel().ColumnValues[constants.UsrColumn].(string))
-			vatRepository := vat.VatStorageRepository{}
+			vatRepository := vat.StorageRepository{}
 			vatRepository.SetDB(db)
 			test_helpers.CreateUrn(db, urnSetupData, headerOne, urnMetadata, vatRepository)
 

--- a/transformers/component_tests/queries/frob_event_computed_columns_test.go
+++ b/transformers/component_tests/queries/frob_event_computed_columns_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Frob event computed columns", func() {
 		headerOne              core.Header
 		frobGethLog            types.Log
 		frobEvent              event.InsertionModel
-		vatRepository          vat.VatStorageRepository
+		vatRepository          vat.StorageRepository
 		headerRepository       datastore.HeaderRepository
 	)
 

--- a/transformers/component_tests/queries/get_queued_sin_query_test.go
+++ b/transformers/component_tests/queries/get_queued_sin_query_test.go
@@ -47,7 +47,7 @@ var _ = Describe("QueuedSin", func() {
 		logId                  int64
 		rawEra                 int
 		sinMappingMetadata     types.ValueMetadata
-		vowRepository          vow.VowStorageRepository
+		vowRepository          vow.StorageRepository
 		diffID                 int64
 	)
 
@@ -66,7 +66,7 @@ var _ = Describe("QueuedSin", func() {
 
 		diffID = storage_helper.CreateFakeDiffRecord(db)
 
-		vowRepository = vow.VowStorageRepository{}
+		vowRepository = vow.StorageRepository{}
 		vowRepository.SetDB(db)
 		sinMappingKeys := map[types.Key]string{constants.Timestamp: fakeEra}
 		sinMappingMetadata = types.GetValueMetadata(vow.SinMapping, sinMappingKeys, types.Uint256)

--- a/transformers/component_tests/queries/get_urn_query_test.go
+++ b/transformers/component_tests/queries/get_urn_query_test.go
@@ -19,7 +19,7 @@ import (
 
 var _ = Describe("Single urn view", func() {
 	var (
-		vatRepo                vat.VatStorageRepository
+		vatRepo                vat.StorageRepository
 		headerRepo             datastore.HeaderRepository
 		urnOne, urnTwo         string
 		blockOne, timestampOne int
@@ -31,7 +31,7 @@ var _ = Describe("Single urn view", func() {
 
 	BeforeEach(func() {
 		test_config.CleanTestDB(db)
-		vatRepo = vat.VatStorageRepository{}
+		vatRepo = vat.StorageRepository{}
 		vatRepo.SetDB(db)
 		headerRepo = repositories.NewHeaderRepository(db)
 

--- a/transformers/component_tests/queries/managed_cdp_computed_columns_test.go
+++ b/transformers/component_tests/queries/managed_cdp_computed_columns_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Managed CDP computed columns", func() {
 		It("returns urn_state for a managed_cdp", func() {
 			urnSetupData := test_helpers.GetUrnSetupData()
 			urnMetadata := test_helpers.GetUrnMetadata(test_helpers.FakeIlk.Hex, test_data.FakeUrn)
-			vatRepository := vat.VatStorageRepository{}
+			vatRepository := vat.StorageRepository{}
 			vatRepository.SetDB(db)
 			test_helpers.CreateUrn(db, urnSetupData, headerOne, urnMetadata, vatRepository)
 			expectedUrn := test_helpers.UrnState{

--- a/transformers/component_tests/queries/managed_cdp_test.go
+++ b/transformers/component_tests/queries/managed_cdp_test.go
@@ -35,7 +35,7 @@ import (
 var _ = Describe("Managed CDP trigger-populated table", func() {
 	var (
 		headerRepo             datastore.HeaderRepository
-		repo                   cdp_manager.CdpManagerStorageRepository
+		repo                   cdp_manager.StorageRepository
 		fakeCdpi               = rand.Int()
 		headerOne              core.Header
 		blockOne, timestampOne int
@@ -45,7 +45,7 @@ var _ = Describe("Managed CDP trigger-populated table", func() {
 	BeforeEach(func() {
 		test_config.CleanTestDB(db)
 		headerRepo = repositories.NewHeaderRepository(db)
-		repo = cdp_manager.CdpManagerStorageRepository{}
+		repo = cdp_manager.StorageRepository{}
 		repo.SetDB(db)
 
 		blockOne = rand.Int()

--- a/transformers/component_tests/queries/queued_sin_computed_columns_test.go
+++ b/transformers/component_tests/queries/queued_sin_computed_columns_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Queued sin computed columns", func() {
 			headerOne              core.Header
 			fakeTab                = strconv.Itoa(rand.Int())
 			sinMappingMetadata     types.ValueMetadata
-			vowRepository          vow.VowStorageRepository
+			vowRepository          vow.StorageRepository
 			headerRepository       datastore.HeaderRepository
 			diffID                 int64
 		)
@@ -59,7 +59,7 @@ var _ = Describe("Queued sin computed columns", func() {
 
 			diffID = storage_helper.CreateFakeDiffRecord(db)
 
-			vowRepository = vow.VowStorageRepository{}
+			vowRepository = vow.StorageRepository{}
 			vowRepository.SetDB(db)
 			sinMappingKeys := map[types.Key]string{constants.Timestamp: fakeEra}
 			sinMappingMetadata = types.GetValueMetadata(vow.SinMapping, sinMappingKeys, types.Uint256)

--- a/transformers/component_tests/queries/test_helpers/test_helpers.go
+++ b/transformers/component_tests/queries/test_helpers/test_helpers.go
@@ -208,7 +208,7 @@ func CreateJugRecords(db *postgres.DB, header core.Header, valuesMap map[string]
 	InsertValues(db, &repository, header, valuesMap, metadatas)
 }
 
-func CreateSpotRecords(db *postgres.DB, header core.Header, valuesMap map[string]interface{}, metadatas []types.ValueMetadata, repository spot.SpotStorageRepository) {
+func CreateSpotRecords(db *postgres.DB, header core.Header, valuesMap map[string]interface{}, metadatas []types.ValueMetadata, repository spot.StorageRepository) {
 	InsertValues(db, &repository, header, valuesMap, metadatas)
 }
 
@@ -224,7 +224,7 @@ func CreateIlk(db *postgres.DB, header core.Header, valuesMap map[string]interfa
 		vatRepo  vat.StorageRepository
 		catRepo  cat.CatStorageRepository
 		jugRepo  jug.JugStorageRepository
-		spotRepo spot.SpotStorageRepository
+		spotRepo spot.StorageRepository
 	)
 	vatRepo.SetDB(db)
 	catRepo.SetDB(db)

--- a/transformers/component_tests/queries/test_helpers/test_helpers.go
+++ b/transformers/component_tests/queries/test_helpers/test_helpers.go
@@ -416,7 +416,7 @@ func CreateFlap(db *postgres.DB, header core.Header, valuesMap map[string]interf
 }
 
 func CreateFlip(db *postgres.DB, header core.Header, valuesMap map[string]interface{}, flipMetadatas []types.ValueMetadata, contractAddress string) {
-	flipRepo := flip.FlipStorageRepository{ContractAddress: contractAddress}
+	flipRepo := flip.StorageRepository{ContractAddress: contractAddress}
 	flipRepo.SetDB(db)
 	InsertValues(db, &flipRepo, header, valuesMap, flipMetadatas)
 }

--- a/transformers/component_tests/queries/test_helpers/test_helpers.go
+++ b/transformers/component_tests/queries/test_helpers/test_helpers.go
@@ -404,7 +404,7 @@ func InsertValues(db *postgres.DB, repo vdbStorageFactory.Repository, header cor
 }
 
 func CreateFlop(db *postgres.DB, header core.Header, valuesMap map[string]interface{}, flopMetadatas []types.ValueMetadata, contractAddress string) {
-	flopRepo := flop.FlopStorageRepository{ContractAddress: contractAddress}
+	flopRepo := flop.StorageRepository{ContractAddress: contractAddress}
 	flopRepo.SetDB(db)
 	InsertValues(db, &flopRepo, header, valuesMap, flopMetadatas)
 }

--- a/transformers/component_tests/queries/test_helpers/test_helpers.go
+++ b/transformers/component_tests/queries/test_helpers/test_helpers.go
@@ -196,7 +196,7 @@ func IlkSnapshotFromValues(ilk, updated, created string, ilkValues map[string]in
 	}
 }
 
-func CreateVatRecords(db *postgres.DB, header core.Header, valuesMap map[string]interface{}, metadatas []types.ValueMetadata, repository vat.VatStorageRepository) {
+func CreateVatRecords(db *postgres.DB, header core.Header, valuesMap map[string]interface{}, metadatas []types.ValueMetadata, repository vat.StorageRepository) {
 	InsertValues(db, &repository, header, valuesMap, metadatas)
 }
 
@@ -213,7 +213,7 @@ func CreateSpotRecords(db *postgres.DB, header core.Header, valuesMap map[string
 }
 
 // Creates urn by creating necessary state diffs and the corresponding header
-func CreateUrn(db *postgres.DB, setupData map[string]interface{}, header core.Header, metadata UrnMetadata, vatRepo vat.VatStorageRepository) {
+func CreateUrn(db *postgres.DB, setupData map[string]interface{}, header core.Header, metadata UrnMetadata, vatRepo vat.StorageRepository) {
 	// This also creates the ilk if it doesn't exist
 	urnMetadata := []types.ValueMetadata{metadata.UrnInk, metadata.UrnArt}
 	InsertValues(db, &vatRepo, header, setupData, urnMetadata)
@@ -221,7 +221,7 @@ func CreateUrn(db *postgres.DB, setupData map[string]interface{}, header core.He
 
 func CreateIlk(db *postgres.DB, header core.Header, valuesMap map[string]interface{}, vatMetadatas, catMetadatas, jugMetadatas, spotMetadatas []types.ValueMetadata) {
 	var (
-		vatRepo  vat.VatStorageRepository
+		vatRepo  vat.StorageRepository
 		catRepo  cat.CatStorageRepository
 		jugRepo  jug.JugStorageRepository
 		spotRepo spot.SpotStorageRepository

--- a/transformers/component_tests/queries/test_helpers/test_helpers.go
+++ b/transformers/component_tests/queries/test_helpers/test_helpers.go
@@ -204,7 +204,7 @@ func CreateCatRecords(db *postgres.DB, header core.Header, valuesMap map[string]
 	InsertValues(db, &repository, header, valuesMap, metadatas)
 }
 
-func CreateJugRecords(db *postgres.DB, header core.Header, valuesMap map[string]interface{}, metadatas []types.ValueMetadata, repository jug.JugStorageRepository) {
+func CreateJugRecords(db *postgres.DB, header core.Header, valuesMap map[string]interface{}, metadatas []types.ValueMetadata, repository jug.StorageRepository) {
 	InsertValues(db, &repository, header, valuesMap, metadatas)
 }
 
@@ -223,7 +223,7 @@ func CreateIlk(db *postgres.DB, header core.Header, valuesMap map[string]interfa
 	var (
 		vatRepo  vat.StorageRepository
 		catRepo  cat.CatStorageRepository
-		jugRepo  jug.JugStorageRepository
+		jugRepo  jug.StorageRepository
 		spotRepo spot.StorageRepository
 	)
 	vatRepo.SetDB(db)

--- a/transformers/component_tests/queries/test_helpers/test_helpers.go
+++ b/transformers/component_tests/queries/test_helpers/test_helpers.go
@@ -422,7 +422,7 @@ func CreateFlip(db *postgres.DB, header core.Header, valuesMap map[string]interf
 }
 
 func CreateManagedCdp(db *postgres.DB, header core.Header, valuesMap map[string]interface{}, metadatas []types.ValueMetadata) error {
-	cdpManagerRepo := cdp_manager.CdpManagerStorageRepository{}
+	cdpManagerRepo := cdp_manager.StorageRepository{}
 	cdpManagerRepo.SetDB(db)
 	_, err := shared.GetOrCreateUrn(valuesMap[cdp_manager.Urns].(string), valuesMap[cdp_manager.Ilks].(string), db)
 	if err != nil {

--- a/transformers/component_tests/queries/test_helpers/test_helpers.go
+++ b/transformers/component_tests/queries/test_helpers/test_helpers.go
@@ -200,7 +200,7 @@ func CreateVatRecords(db *postgres.DB, header core.Header, valuesMap map[string]
 	InsertValues(db, &repository, header, valuesMap, metadatas)
 }
 
-func CreateCatRecords(db *postgres.DB, header core.Header, valuesMap map[string]interface{}, metadatas []types.ValueMetadata, repository cat.CatStorageRepository) {
+func CreateCatRecords(db *postgres.DB, header core.Header, valuesMap map[string]interface{}, metadatas []types.ValueMetadata, repository cat.StorageRepository) {
 	InsertValues(db, &repository, header, valuesMap, metadatas)
 }
 
@@ -222,7 +222,7 @@ func CreateUrn(db *postgres.DB, setupData map[string]interface{}, header core.He
 func CreateIlk(db *postgres.DB, header core.Header, valuesMap map[string]interface{}, vatMetadatas, catMetadatas, jugMetadatas, spotMetadatas []types.ValueMetadata) {
 	var (
 		vatRepo  vat.StorageRepository
-		catRepo  cat.CatStorageRepository
+		catRepo  cat.StorageRepository
 		jugRepo  jug.StorageRepository
 		spotRepo spot.StorageRepository
 	)

--- a/transformers/component_tests/queries/test_helpers/test_helpers.go
+++ b/transformers/component_tests/queries/test_helpers/test_helpers.go
@@ -410,7 +410,7 @@ func CreateFlop(db *postgres.DB, header core.Header, valuesMap map[string]interf
 }
 
 func CreateFlap(db *postgres.DB, header core.Header, valuesMap map[string]interface{}, flapMetadatas []types.ValueMetadata, contractAddress string) {
-	flapRepo := flap.FlapStorageRepository{ContractAddress: contractAddress}
+	flapRepo := flap.StorageRepository{ContractAddress: contractAddress}
 	flapRepo.SetDB(db)
 	InsertValues(db, &flapRepo, header, valuesMap, flapMetadatas)
 }

--- a/transformers/component_tests/queries/total_ink_query_test.go
+++ b/transformers/component_tests/queries/total_ink_query_test.go
@@ -17,7 +17,7 @@ import (
 
 var _ = Describe("total ink query", func() {
 	var (
-		vatRepo                vat.VatStorageRepository
+		vatRepo                vat.StorageRepository
 		headerRepo             datastore.HeaderRepository
 		urnOne                 string
 		urnTwo                 string
@@ -27,7 +27,7 @@ var _ = Describe("total ink query", func() {
 
 	BeforeEach(func() {
 		test_config.CleanTestDB(db)
-		vatRepo = vat.VatStorageRepository{}
+		vatRepo = vat.StorageRepository{}
 		vatRepo.SetDB(db)
 		headerRepo = repositories.NewHeaderRepository(db)
 

--- a/transformers/component_tests/queries/urn_bid_events_test.go
+++ b/transformers/component_tests/queries/urn_bid_events_test.go
@@ -49,7 +49,7 @@ var _ = Describe("urn bid events query", func() {
 		logFourID := test_data.CreateTestLog(headerOneID, db).ID
 
 		// insert records used in join
-		repo := flip.FlipStorageRepository{ContractAddress: ethFlipAddress}
+		repo := flip.StorageRepository{ContractAddress: ethFlipAddress}
 		repo.SetDB(db)
 
 		ethIlkErr := repo.Create(diffID, headerOneID, flip.IlkMetadata, test_helpers.FakeIlk.Hex)

--- a/transformers/component_tests/queries/urn_snapshot_computed_columns_test.go
+++ b/transformers/component_tests/queries/urn_snapshot_computed_columns_test.go
@@ -48,7 +48,7 @@ var _ = Describe("urn_snapshot computed columns", func() {
 		logIdOne,
 		logIdTwo int64
 		vatRepository    vat.StorageRepository
-		catRepository    cat.CatStorageRepository
+		catRepository    cat.StorageRepository
 		jugRepository    jug.StorageRepository
 		headerRepository datastore.HeaderRepository
 	)

--- a/transformers/component_tests/queries/urn_snapshot_computed_columns_test.go
+++ b/transformers/component_tests/queries/urn_snapshot_computed_columns_test.go
@@ -49,7 +49,7 @@ var _ = Describe("urn_snapshot computed columns", func() {
 		logIdTwo int64
 		vatRepository    vat.StorageRepository
 		catRepository    cat.CatStorageRepository
-		jugRepository    jug.JugStorageRepository
+		jugRepository    jug.StorageRepository
 		headerRepository datastore.HeaderRepository
 	)
 

--- a/transformers/component_tests/queries/urn_snapshot_computed_columns_test.go
+++ b/transformers/component_tests/queries/urn_snapshot_computed_columns_test.go
@@ -47,7 +47,7 @@ var _ = Describe("urn_snapshot computed columns", func() {
 		headerTwo core.Header
 		logIdOne,
 		logIdTwo int64
-		vatRepository    vat.VatStorageRepository
+		vatRepository    vat.StorageRepository
 		catRepository    cat.CatStorageRepository
 		jugRepository    jug.JugStorageRepository
 		headerRepository datastore.HeaderRepository

--- a/transformers/component_tests/spot/configured_transformer_test.go
+++ b/transformers/component_tests/spot/configured_transformer_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Executing the transformer", func() {
 		contractAddress   = test_data.SpotAddress()
 		keccakOfAddress   = types.HexToKeccak256Hash(contractAddress)
 		storageKeysLookup = storage.NewKeysLookup(spot.NewKeysLoader(&mcdStorage.MakerStorageRepository{}, contractAddress))
-		repository        = spot.SpotStorageRepository{ContractAddress: contractAddress}
+		repository        = spot.StorageRepository{ContractAddress: contractAddress}
 		transformer       = storage.Transformer{
 			Address:           common.HexToAddress(contractAddress),
 			StorageKeysLookup: storageKeysLookup,

--- a/transformers/component_tests/triggers/bid_event_trigger_test.go
+++ b/transformers/component_tests/triggers/bid_event_trigger_test.go
@@ -200,7 +200,7 @@ var _ = Describe("Updating bid_event table", func() {
 	Describe("inserting events after flip-specific diffs", func() {
 		var (
 			flipAddress   = test_data.FlipEthAddress()
-			flipRepo      flip.FlipStorageRepository
+			flipRepo      flip.StorageRepository
 			flipKickModel event.InsertionModel
 			diffID        int64
 		)
@@ -208,7 +208,7 @@ var _ = Describe("Updating bid_event table", func() {
 		BeforeEach(func() {
 			flipAddressID, addressErr := shared.GetOrCreateAddress(flipAddress, db)
 			Expect(addressErr).NotTo(HaveOccurred())
-			flipRepo = flip.FlipStorageRepository{ContractAddress: flipAddress}
+			flipRepo = flip.StorageRepository{ContractAddress: flipAddress}
 			flipRepo.SetDB(db)
 			diffID = CreateFakeDiffRecord(db)
 			flipKickModel = test_data.FlipKickModel()
@@ -255,7 +255,7 @@ var _ = Describe("Updating bid_event table", func() {
 	Describe("when flip-specific diffs are inserted after events", func() {
 		var (
 			flipAddress   string
-			flipRepo      flip.FlipStorageRepository
+			flipRepo      flip.StorageRepository
 			diffID        int64
 			flipKickModel event.InsertionModel
 		)
@@ -264,7 +264,7 @@ var _ = Describe("Updating bid_event table", func() {
 			flipAddress = test_data.FlipEthAddress()
 			flipAddressID, addressErr := shared.GetOrCreateAddress(flipAddress, db)
 			Expect(addressErr).NotTo(HaveOccurred())
-			flipRepo = flip.FlipStorageRepository{ContractAddress: flipAddress}
+			flipRepo = flip.StorageRepository{ContractAddress: flipAddress}
 			flipRepo.SetDB(db)
 			diffID = CreateFakeDiffRecord(db)
 			flipKickModel = test_data.FlipKickModel()
@@ -318,7 +318,7 @@ var _ = Describe("Updating bid_event table", func() {
 			headerTwo          core.Header
 			flipAddress        string
 			usrOne, usrTwo     string
-			flipRepo           flip.FlipStorageRepository
+			flipRepo           flip.StorageRepository
 			bidOneID, bidTwoID int
 			diffID,
 			logTwoID,
@@ -337,7 +337,7 @@ var _ = Describe("Updating bid_event table", func() {
 			ethFlipAddressID, ethFlipAddressErr := shared.GetOrCreateAddress(flipAddress, db)
 			Expect(ethFlipAddressErr).NotTo(HaveOccurred())
 
-			flipRepo = flip.FlipStorageRepository{ContractAddress: flipAddress}
+			flipRepo = flip.StorageRepository{ContractAddress: flipAddress}
 			flipRepo.SetDB(db)
 			diffID = CreateFakeDiffRecord(db)
 

--- a/transformers/component_tests/vat/configured_transformer_test.go
+++ b/transformers/component_tests/vat/configured_transformer_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Executing the transformer", func() {
 	var (
 		db                = test_config.NewTestDB(test_config.NewTestNode())
 		storageKeysLookup = storage.NewKeysLookup(vat.NewKeysLoader(&mcdStorage.MakerStorageRepository{}))
-		repository        = vat.VatStorageRepository{}
+		repository        = vat.StorageRepository{}
 		contractAddress   = test_data.VatAddress()
 		keccakOfAddress   = types.HexToKeccak256Hash(contractAddress)
 		transformer       = storage.Transformer{

--- a/transformers/component_tests/vow/configured_transformer_test.go
+++ b/transformers/component_tests/vow/configured_transformer_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Executing the transformer", func() {
 		vowAddress        = test_data.VowAddress()
 		keccakOfAddress   = types.HexToKeccak256Hash(vowAddress)
 		storageKeysLookup = storage.NewKeysLookup(vow.NewKeysLoader(&mcdStorage.MakerStorageRepository{}, vowAddress))
-		repository        = vow.VowStorageRepository{ContractAddress: vowAddress}
+		repository        = vow.StorageRepository{ContractAddress: vowAddress}
 		transformer       = storage.Transformer{
 			Address:           common.HexToAddress(vowAddress),
 			StorageKeysLookup: storageKeysLookup,

--- a/transformers/shared/utilities.go
+++ b/transformers/shared/utilities.go
@@ -150,7 +150,7 @@ func InsertRecordWithAddress(diffID, headerID int64, query, value, contractAddre
 	return tx.Commit()
 }
 
-func InsertRecordWithAddressAndBidId(diffID, headerID int64, query, bidId, value, contractAddress string, db *postgres.DB) error {
+func InsertRecordWithAddressAndBidID(diffID, headerID int64, query, bidId, value, contractAddress string, db *postgres.DB) error {
 	tx, txErr := db.Beginx()
 	if txErr != nil {
 		return txErr

--- a/transformers/storage/cat/initializer/initializer.go
+++ b/transformers/storage/cat/initializer/initializer.go
@@ -28,5 +28,5 @@ var catAddress = constants.GetContractAddress("MCD_CAT")
 var StorageTransformerInitializer storage.TransformerInitializer = storage.Transformer{
 	Address:           common.HexToAddress(constants.GetContractAddress("MCD_CAT")),
 	StorageKeysLookup: storage.NewKeysLookup(cat.NewKeysLoader(&mcdStorage.MakerStorageRepository{}, catAddress)),
-	Repository:        &cat.CatStorageRepository{ContractAddress: catAddress},
+	Repository:        &cat.StorageRepository{ContractAddress: catAddress},
 }.NewTransformer

--- a/transformers/storage/cat/keys_loader.go
+++ b/transformers/storage/cat/keys_loader.go
@@ -17,6 +17,8 @@
 package cat
 
 import (
+	"fmt"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	mcdStorage "github.com/makerdao/vdb-mcd-transformers/transformers/storage"
@@ -67,11 +69,11 @@ func (loader *keysLoader) LoadMappings() (map[common.Hash]types.ValueMetadata, e
 	mappings := loadStaticMappings()
 	mappings, ilkErr := loader.addIlkKeys(mappings)
 	if ilkErr != nil {
-		return nil, ilkErr
+		return nil, fmt.Errorf("error adding ilk keys to cat keys loader: %w", ilkErr)
 	}
 	mappings, wardsErr := loader.addWardsKeys(mappings)
 	if wardsErr != nil {
-		return nil, wardsErr
+		return nil, fmt.Errorf("error adding wards keys to cat keys loader: %w", wardsErr)
 	}
 	return mappings, nil
 }
@@ -79,7 +81,7 @@ func (loader *keysLoader) LoadMappings() (map[common.Hash]types.ValueMetadata, e
 func (loader *keysLoader) addIlkKeys(mappings map[common.Hash]types.ValueMetadata) (map[common.Hash]types.ValueMetadata, error) {
 	ilks, err := loader.storageRepository.GetIlks()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error getting ilks: %w", err)
 	}
 	for _, ilk := range ilks {
 		mappings[getIlkFlipKey(ilk)] = getIlkFlipMetadata(ilk)
@@ -92,7 +94,7 @@ func (loader *keysLoader) addIlkKeys(mappings map[common.Hash]types.ValueMetadat
 func (loader *keysLoader) addWardsKeys(mappings map[common.Hash]types.ValueMetadata) (map[common.Hash]types.ValueMetadata, error) {
 	addresses, err := loader.storageRepository.GetWardsAddresses(loader.contractAddress)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error getting wards addresses: %w", err)
 	}
 	return wards.AddWardsKeys(mappings, addresses)
 }

--- a/transformers/storage/cat/repository.go
+++ b/transformers/storage/cat/repository.go
@@ -71,7 +71,7 @@ func (repository *CatStorageRepository) insertIlkFlip(diffID, headerID int64, me
 	if err != nil {
 		return err
 	}
-	return repository.insertFieldWithIlk(diffID, headerID, ilk, IlkFlip, InsertCatIlkFlipQuery, flip)
+	return shared.InsertFieldWithIlk(diffID, headerID, ilk, IlkFlip, InsertCatIlkFlipQuery, flip, repository.db)
 }
 
 func (repository *CatStorageRepository) insertIlkChop(diffID, headerID int64, metadata types.ValueMetadata, chop string) error {
@@ -79,7 +79,7 @@ func (repository *CatStorageRepository) insertIlkChop(diffID, headerID int64, me
 	if err != nil {
 		return err
 	}
-	return repository.insertFieldWithIlk(diffID, headerID, ilk, IlkChop, InsertCatIlkChopQuery, chop)
+	return shared.InsertFieldWithIlk(diffID, headerID, ilk, IlkChop, InsertCatIlkChopQuery, chop, repository.db)
 }
 
 func (repository *CatStorageRepository) insertIlkLump(diffID, headerID int64, metadata types.ValueMetadata, lump string) error {
@@ -87,31 +87,7 @@ func (repository *CatStorageRepository) insertIlkLump(diffID, headerID int64, me
 	if err != nil {
 		return err
 	}
-	return repository.insertFieldWithIlk(diffID, headerID, ilk, IlkLump, InsertCatIlkLumpQuery, lump)
-}
-
-func (repository *CatStorageRepository) insertFieldWithIlk(diffID, headerID int64, ilk, variableName, query, value string) error {
-	tx, txErr := repository.db.Beginx()
-	if txErr != nil {
-		return txErr
-	}
-	ilkID, ilkErr := shared.GetOrCreateIlkInTransaction(ilk, tx)
-	if ilkErr != nil {
-		rollbackErr := tx.Rollback()
-		if rollbackErr != nil {
-			return shared.FormatRollbackError("ilk", ilkErr.Error())
-		}
-		return ilkErr
-	}
-	_, writeErr := tx.Exec(query, diffID, headerID, ilkID, value)
-	if writeErr != nil {
-		rollbackErr := tx.Rollback()
-		if rollbackErr != nil {
-			return shared.FormatRollbackError(variableName, writeErr.Error())
-		}
-		return writeErr
-	}
-	return tx.Commit()
+	return shared.InsertFieldWithIlk(diffID, headerID, ilk, IlkLump, InsertCatIlkLumpQuery, lump, repository.db)
 }
 
 func getIlk(keys map[types.Key]string) (string, error) {

--- a/transformers/storage/cat/repository_test.go
+++ b/transformers/storage/cat/repository_test.go
@@ -26,7 +26,7 @@ import (
 var _ = Describe("Cat storage repository", func() {
 	var (
 		db                   = test_config.NewTestDB(test_config.NewTestNode())
-		repo                 cat.CatStorageRepository
+		repo                 cat.StorageRepository
 		diffID, fakeHeaderID int64
 		fakeAddress          = "0x" + fakes.RandomString(40)
 		fakeUint256          = strconv.Itoa(rand.Intn(1000000))
@@ -34,7 +34,7 @@ var _ = Describe("Cat storage repository", func() {
 
 	BeforeEach(func() {
 		test_config.CleanTestDB(db)
-		repo = cat.CatStorageRepository{ContractAddress: test_data.CatAddress()}
+		repo = cat.StorageRepository{ContractAddress: test_data.CatAddress()}
 		repo.SetDB(db)
 		headerRepository := repositories.NewHeaderRepository(db)
 		var insertHeaderErr error

--- a/transformers/storage/cdp_manager/initializer/initializer.go
+++ b/transformers/storage/cdp_manager/initializer/initializer.go
@@ -27,5 +27,5 @@ import (
 var StorageTransformerInitializer storage.TransformerInitializer = storage.Transformer{
 	Address:           common.HexToAddress(constants.GetContractAddress("CDP_MANAGER")),
 	StorageKeysLookup: storage.NewKeysLookup(cdp_manager.NewKeysLoader(&mcdStorage.MakerStorageRepository{})),
-	Repository:        &cdp_manager.CdpManagerStorageRepository{},
+	Repository:        &cdp_manager.StorageRepository{},
 }.NewTransformer

--- a/transformers/storage/cdp_manager/repository_test.go
+++ b/transformers/storage/cdp_manager/repository_test.go
@@ -43,13 +43,13 @@ import (
 var _ = Describe("CDP Manager storage repository", func() {
 	var (
 		db                   = test_config.NewTestDB(test_config.NewTestNode())
-		repository           cdp_manager.CdpManagerStorageRepository
+		repository           cdp_manager.StorageRepository
 		diffID, fakeHeaderID int64
 	)
 
 	BeforeEach(func() {
 		test_config.CleanTestDB(db)
-		repository = cdp_manager.CdpManagerStorageRepository{}
+		repository = cdp_manager.StorageRepository{}
 		repository.SetDB(db)
 		headerRepository := repositories.NewHeaderRepository(db)
 		var insertHeaderErr error

--- a/transformers/storage/flap/initializer/initializer.go
+++ b/transformers/storage/flap/initializer/initializer.go
@@ -29,5 +29,5 @@ var StorageTransformerInitializer storage.TransformerInitializer = storage.Trans
 	StorageKeysLookup: storage.NewKeysLookup(flap.NewKeysLoader(
 		&mcdStorage.MakerStorageRepository{},
 		constants.GetContractAddress("MCD_FLAP"))),
-	Repository: &flap.FlapStorageRepository{ContractAddress: constants.GetContractAddress("MCD_FLAP")},
+	Repository: &flap.StorageRepository{ContractAddress: constants.GetContractAddress("MCD_FLAP")},
 }.NewTransformer

--- a/transformers/storage/flap/keys_loader.go
+++ b/transformers/storage/flap/keys_loader.go
@@ -86,7 +86,7 @@ func (loader *keysLoader) addWardsKeys(mappings map[common.Hash]types.ValueMetad
 }
 
 func (loader *keysLoader) loadBidKeys(mappings map[common.Hash]types.ValueMetadata) (map[common.Hash]types.ValueMetadata, error) {
-	bidIds, getBidIdsErr := loader.storageRepository.GetFlapBidIds(loader.contractAddress)
+	bidIds, getBidIdsErr := loader.storageRepository.GetFlapBidIDs(loader.contractAddress)
 	if getBidIdsErr != nil {
 		return nil, getBidIdsErr
 	}

--- a/transformers/storage/flap/keys_loader_test.go
+++ b/transformers/storage/flap/keys_loader_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Flap storage keys loader", func() {
 			Keys: nil,
 			Type: types.Uint256,
 		}))
-		Expect(mappings[flap.TtlAndTauStorageKey]).To(Equal(types.ValueMetadata{
+		Expect(mappings[flap.TTLAndTauStorageKey]).To(Equal(types.ValueMetadata{
 			Name:        mcdStorage.Packed,
 			Type:        types.PackedSlot,
 			PackedTypes: map[int]types.ValueType{0: types.Uint48, 1: types.Uint48},

--- a/transformers/storage/flap/keys_loader_test.go
+++ b/transformers/storage/flap/keys_loader_test.go
@@ -119,7 +119,7 @@ var _ = Describe("Flap storage keys loader", func() {
 	Describe("flap bids", func() {
 		Describe("when getting flap bid IDs fails", func() {
 			It("returns error", func() {
-				storageRepository.GetFlapBidIdsError = fakes.FakeError
+				storageRepository.GetFlapBidIDsError = fakes.FakeError
 
 				_, err := storageKeysLoader.LoadMappings()
 
@@ -139,7 +139,7 @@ var _ = Describe("Flap storage keys loader", func() {
 			)
 
 			BeforeEach(func() {
-				storageRepository.FlapBidIds = []string{bidId}
+				storageRepository.FlapBidIDs = []string{bidId}
 				var err error
 				mappings, err = storageKeysLoader.LoadMappings()
 				Expect(err).NotTo(HaveOccurred())

--- a/transformers/storage/flap/repository.go
+++ b/transformers/storage/flap/repository.go
@@ -93,7 +93,7 @@ func (repository *FlapStorageRepository) insertBidBid(diffID, headerID int64, me
 	if err != nil {
 		return err
 	}
-	return shared.InsertRecordWithAddressAndBidId(diffID, headerID, insertBidBidQuery, bidId, bid, repository.ContractAddress, repository.db)
+	return shared.InsertRecordWithAddressAndBidID(diffID, headerID, insertBidBidQuery, bidId, bid, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlapStorageRepository) insertBidLot(diffID, headerID int64, metadata types.ValueMetadata, lot string) error {
@@ -101,7 +101,7 @@ func (repository *FlapStorageRepository) insertBidLot(diffID, headerID int64, me
 	if err != nil {
 		return err
 	}
-	return shared.InsertRecordWithAddressAndBidId(diffID, headerID, insertBidLotQuery, bidId, lot, repository.ContractAddress, repository.db)
+	return shared.InsertRecordWithAddressAndBidID(diffID, headerID, insertBidLotQuery, bidId, lot, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlapStorageRepository) insertBidGuy(diffID, headerID int64, metadata types.ValueMetadata, guy string) error {
@@ -109,7 +109,7 @@ func (repository *FlapStorageRepository) insertBidGuy(diffID, headerID int64, me
 	if err != nil {
 		return err
 	}
-	return shared.InsertRecordWithAddressAndBidId(diffID, headerID, insertBidGuyQuery, bidId, guy, repository.ContractAddress, repository.db)
+	return shared.InsertRecordWithAddressAndBidID(diffID, headerID, insertBidGuyQuery, bidId, guy, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlapStorageRepository) insertBidTic(diffID, headerID int64, metadata types.ValueMetadata, tic string) error {
@@ -117,7 +117,7 @@ func (repository *FlapStorageRepository) insertBidTic(diffID, headerID int64, me
 	if err != nil {
 		return err
 	}
-	return shared.InsertRecordWithAddressAndBidId(diffID, headerID, insertBidTicQuery, bidId, tic, repository.ContractAddress, repository.db)
+	return shared.InsertRecordWithAddressAndBidID(diffID, headerID, insertBidTicQuery, bidId, tic, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlapStorageRepository) insertBidEnd(diffID, headerID int64, metadata types.ValueMetadata, end string) error {
@@ -125,7 +125,7 @@ func (repository *FlapStorageRepository) insertBidEnd(diffID, headerID int64, me
 	if err != nil {
 		return err
 	}
-	return shared.InsertRecordWithAddressAndBidId(diffID, headerID, insertBidEndQuery, bidId, end, repository.ContractAddress, repository.db)
+	return shared.InsertRecordWithAddressAndBidID(diffID, headerID, insertBidEndQuery, bidId, end, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlapStorageRepository) insertPackedValueRecord(diffID, headerID int64, metadata types.ValueMetadata, packedValues map[int]string) error {

--- a/transformers/storage/flap/repository.go
+++ b/transformers/storage/flap/repository.go
@@ -15,7 +15,7 @@ const (
 	insertVatQuery    = `INSERT INTO maker.flap_vat (diff_id, header_id, address_id, vat) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
 	insertGemQuery    = `INSERT INTO maker.flap_gem (diff_id, header_id, address_id, gem) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
 	insertBegQuery    = `INSERT INTO maker.flap_beg (diff_id, header_id, address_id, beg) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
-	insertTtlQuery    = `INSERT INTO maker.flap_ttl (diff_id, header_id, address_id, ttl) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
+	insertTTLQuery    = `INSERT INTO maker.flap_ttl (diff_id, header_id, address_id, ttl) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
 	insertTauQuery    = `INSERT INTO maker.flap_tau (diff_id, header_id, address_id, tau) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
 	InsertKicksQuery  = `INSERT INTO maker.flap_kicks (diff_id, header_id, address_id, kicks) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
 	insertLiveQuery   = `INSERT INTO maker.flap_live (diff_id, header_id, address_id, live) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
@@ -26,12 +26,12 @@ const (
 	insertBidEndQuery = `INSERT INTO maker.flap_bid_end (diff_id, header_id, address_id, bid_id, "end") VALUES ($1, $2, $3, $4, $5) ON CONFLICT DO NOTHING`
 )
 
-type FlapStorageRepository struct {
+type StorageRepository struct {
 	db              *postgres.DB
 	ContractAddress string
 }
 
-func (repository *FlapStorageRepository) Create(diffID, headerID int64, metadata types.ValueMetadata, value interface{}) error {
+func (repository *StorageRepository) Create(diffID, headerID int64, metadata types.ValueMetadata, value interface{}) error {
 	switch metadata.Name {
 	case storage.Vat:
 		return repository.insertVat(diffID, headerID, value.(string))
@@ -56,84 +56,137 @@ func (repository *FlapStorageRepository) Create(diffID, headerID int64, metadata
 	}
 }
 
-func (repository *FlapStorageRepository) SetDB(db *postgres.DB) {
+func (repository *StorageRepository) SetDB(db *postgres.DB) {
 	repository.db = db
 }
 
-func (repository *FlapStorageRepository) insertVat(diffID, headerID int64, vat string) error {
-	return shared.InsertRecordWithAddress(diffID, headerID, insertVatQuery, vat, repository.ContractAddress, repository.db)
-}
-
-func (repository *FlapStorageRepository) insertGem(diffID, headerID int64, gem string) error {
-	return shared.InsertRecordWithAddress(diffID, headerID, insertGemQuery, gem, repository.ContractAddress, repository.db)
-}
-
-func (repository *FlapStorageRepository) insertBeg(diffID, headerID int64, beg string) error {
-	return shared.InsertRecordWithAddress(diffID, headerID, insertBegQuery, beg, repository.ContractAddress, repository.db)
-}
-
-func (repository *FlapStorageRepository) insertTtl(diffID, headerID int64, ttl string) error {
-	return shared.InsertRecordWithAddress(diffID, headerID, insertTtlQuery, ttl, repository.ContractAddress, repository.db)
-}
-
-func (repository *FlapStorageRepository) insertTau(diffID, headerID int64, tau string) error {
-	return shared.InsertRecordWithAddress(diffID, headerID, insertTauQuery, tau, repository.ContractAddress, repository.db)
-}
-
-func (repository *FlapStorageRepository) insertKicks(diffID, headerID int64, kicks string) error {
-	return shared.InsertRecordWithAddress(diffID, headerID, InsertKicksQuery, kicks, repository.ContractAddress, repository.db)
-}
-
-func (repository *FlapStorageRepository) insertLive(diffID, headerID int64, live string) error {
-	return shared.InsertRecordWithAddress(diffID, headerID, insertLiveQuery, live, repository.ContractAddress, repository.db)
-}
-
-func (repository *FlapStorageRepository) insertBidBid(diffID, headerID int64, metadata types.ValueMetadata, bid string) error {
-	bidId, err := getBidId(metadata.Keys)
+func (repository *StorageRepository) insertVat(diffID, headerID int64, vat string) error {
+	err := shared.InsertRecordWithAddress(diffID, headerID, insertVatQuery, vat, repository.ContractAddress, repository.db)
 	if err != nil {
-		return err
+		return fmt.Errorf("error inserting flap vat %s from diff ID %d: %w", vat, diffID, err)
 	}
-	return shared.InsertRecordWithAddressAndBidID(diffID, headerID, insertBidBidQuery, bidId, bid, repository.ContractAddress, repository.db)
+	return nil
 }
 
-func (repository *FlapStorageRepository) insertBidLot(diffID, headerID int64, metadata types.ValueMetadata, lot string) error {
-	bidId, err := getBidId(metadata.Keys)
+func (repository *StorageRepository) insertGem(diffID, headerID int64, gem string) error {
+	err := shared.InsertRecordWithAddress(diffID, headerID, insertGemQuery, gem, repository.ContractAddress, repository.db)
 	if err != nil {
-		return err
+		return fmt.Errorf("error inserting flap gem %s from diff ID %d: %w", gem, diffID, err)
 	}
-	return shared.InsertRecordWithAddressAndBidID(diffID, headerID, insertBidLotQuery, bidId, lot, repository.ContractAddress, repository.db)
+	return nil
 }
 
-func (repository *FlapStorageRepository) insertBidGuy(diffID, headerID int64, metadata types.ValueMetadata, guy string) error {
-	bidId, err := getBidId(metadata.Keys)
+func (repository *StorageRepository) insertBeg(diffID, headerID int64, beg string) error {
+	err := shared.InsertRecordWithAddress(diffID, headerID, insertBegQuery, beg, repository.ContractAddress, repository.db)
 	if err != nil {
-		return err
+		return fmt.Errorf("error inserting flap beg %s from diff ID %d: %w", beg, diffID, err)
 	}
-	return shared.InsertRecordWithAddressAndBidID(diffID, headerID, insertBidGuyQuery, bidId, guy, repository.ContractAddress, repository.db)
+	return nil
 }
 
-func (repository *FlapStorageRepository) insertBidTic(diffID, headerID int64, metadata types.ValueMetadata, tic string) error {
-	bidId, err := getBidId(metadata.Keys)
+func (repository *StorageRepository) insertTTL(diffID, headerID int64, ttl string) error {
+	err := shared.InsertRecordWithAddress(diffID, headerID, insertTTLQuery, ttl, repository.ContractAddress, repository.db)
 	if err != nil {
-		return err
+		return fmt.Errorf("error inserting flap ttl %s from diff ID %d: %w", ttl, diffID, err)
 	}
-	return shared.InsertRecordWithAddressAndBidID(diffID, headerID, insertBidTicQuery, bidId, tic, repository.ContractAddress, repository.db)
+	return nil
 }
 
-func (repository *FlapStorageRepository) insertBidEnd(diffID, headerID int64, metadata types.ValueMetadata, end string) error {
-	bidId, err := getBidId(metadata.Keys)
+func (repository *StorageRepository) insertTau(diffID, headerID int64, tau string) error {
+	err := shared.InsertRecordWithAddress(diffID, headerID, insertTauQuery, tau, repository.ContractAddress, repository.db)
 	if err != nil {
-		return err
+		return fmt.Errorf("error inserting flap tau %s from diff ID %d: %w", tau, diffID, err)
 	}
-	return shared.InsertRecordWithAddressAndBidID(diffID, headerID, insertBidEndQuery, bidId, end, repository.ContractAddress, repository.db)
+	return nil
 }
 
-func (repository *FlapStorageRepository) insertPackedValueRecord(diffID, headerID int64, metadata types.ValueMetadata, packedValues map[int]string) error {
+func (repository *StorageRepository) insertKicks(diffID, headerID int64, kicks string) error {
+	err := shared.InsertRecordWithAddress(diffID, headerID, InsertKicksQuery, kicks, repository.ContractAddress, repository.db)
+	if err != nil {
+		return fmt.Errorf("error inserting flap kicks %s from diff ID %d: %w", kicks, diffID, err)
+	}
+	return nil
+}
+
+func (repository *StorageRepository) insertLive(diffID, headerID int64, live string) error {
+	err := shared.InsertRecordWithAddress(diffID, headerID, insertLiveQuery, live, repository.ContractAddress, repository.db)
+	if err != nil {
+		return fmt.Errorf("error inserting flap live %s from diff ID %d: %w", live, diffID, err)
+	}
+	return nil
+}
+
+func (repository *StorageRepository) insertBidBid(diffID, headerID int64, metadata types.ValueMetadata, bid string) error {
+	bidID, err := getBidID(metadata.Keys)
+	if err != nil {
+		return fmt.Errorf("error getting bid ID for flap bid bid: %w", err)
+	}
+	insertErr := shared.InsertRecordWithAddressAndBidID(diffID, headerID, insertBidBidQuery, bidID, bid, repository.ContractAddress, repository.db)
+	if insertErr != nil {
+		msg := fmt.Sprintf("error inserting flap bid %s bid %s from diff ID %d", bidID, bid, diffID)
+		return fmt.Errorf("%s: %w", msg, insertErr)
+	}
+	return nil
+}
+
+func (repository *StorageRepository) insertBidLot(diffID, headerID int64, metadata types.ValueMetadata, lot string) error {
+	bidID, err := getBidID(metadata.Keys)
+	if err != nil {
+		return fmt.Errorf("error getting bid ID for flap bid lot: %w", err)
+	}
+	insertErr := shared.InsertRecordWithAddressAndBidID(diffID, headerID, insertBidLotQuery, bidID, lot, repository.ContractAddress, repository.db)
+	if insertErr != nil {
+		msg := fmt.Sprintf("error inserting flap bid %s lot %s from diff ID %d", bidID, lot, diffID)
+		return fmt.Errorf("%s: %w", msg, insertErr)
+	}
+	return nil
+}
+
+func (repository *StorageRepository) insertBidGuy(diffID, headerID int64, metadata types.ValueMetadata, guy string) error {
+	bidID, err := getBidID(metadata.Keys)
+	if err != nil {
+		return fmt.Errorf("error getting bid ID for flap bid guy: %w", err)
+	}
+	insertErr := shared.InsertRecordWithAddressAndBidID(diffID, headerID, insertBidGuyQuery, bidID, guy, repository.ContractAddress, repository.db)
+	if insertErr != nil {
+		msg := fmt.Sprintf("error inserting flap bid %s guy %s from diff ID %d", bidID, guy, diffID)
+		return fmt.Errorf("%s: %w", msg, insertErr)
+	}
+	return nil
+}
+
+func (repository *StorageRepository) insertBidTic(diffID, headerID int64, metadata types.ValueMetadata, tic string) error {
+	bidID, err := getBidID(metadata.Keys)
+	if err != nil {
+		return fmt.Errorf("error getting bid ID for flap bid tic: %w", err)
+	}
+	insertErr := shared.InsertRecordWithAddressAndBidID(diffID, headerID, insertBidTicQuery, bidID, tic, repository.ContractAddress, repository.db)
+	if insertErr != nil {
+		msg := fmt.Sprintf("error inserting flap bid %s tic %s from diff ID %d", bidID, tic, diffID)
+		return fmt.Errorf("%s: %w", msg, insertErr)
+	}
+	return nil
+}
+
+func (repository *StorageRepository) insertBidEnd(diffID, headerID int64, metadata types.ValueMetadata, end string) error {
+	bidID, err := getBidID(metadata.Keys)
+	if err != nil {
+		return fmt.Errorf("error getting bid ID for flap bid end: %w", err)
+	}
+	insertErr := shared.InsertRecordWithAddressAndBidID(diffID, headerID, insertBidEndQuery, bidID, end, repository.ContractAddress, repository.db)
+	if insertErr != nil {
+		msg := fmt.Sprintf("error inserting flap bid %s end %s from diff ID %d", bidID, end, diffID)
+		return fmt.Errorf("%s: %w", msg, insertErr)
+	}
+	return nil
+}
+
+func (repository *StorageRepository) insertPackedValueRecord(diffID, headerID int64, metadata types.ValueMetadata, packedValues map[int]string) error {
 	for order, value := range packedValues {
 		var insertErr error
 		switch metadata.PackedNames[order] {
 		case storage.Ttl:
-			insertErr = repository.insertTtl(diffID, headerID, value)
+			insertErr = repository.insertTTL(diffID, headerID, value)
 		case storage.Tau:
 			insertErr = repository.insertTau(diffID, headerID, value)
 		case storage.BidGuy:
@@ -146,13 +199,13 @@ func (repository *FlapStorageRepository) insertPackedValueRecord(diffID, headerI
 			panic(fmt.Sprintf("unrecognized flap contract storage name in packed values: %s", metadata.Name))
 		}
 		if insertErr != nil {
-			return insertErr
+			return fmt.Errorf("error inserting flap packed value from diff ID %d: %w", diffID, insertErr)
 		}
 	}
 	return nil
 }
 
-func getBidId(keys map[types.Key]string) (string, error) {
+func getBidID(keys map[types.Key]string) (string, error) {
 	bid, ok := keys[constants.BidId]
 	if !ok {
 		return "", types.ErrMetadataMalformed{MissingData: constants.BidId}

--- a/transformers/storage/flap/repository_test.go
+++ b/transformers/storage/flap/repository_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Flap storage repository", func() {
 	var (
 		db                   = test_config.NewTestDB(test_config.NewTestNode())
 		flapContractAddress  = test_data.FlapAddress()
-		repository           = &flap.FlapStorageRepository{ContractAddress: flapContractAddress}
+		repository           = &flap.StorageRepository{ContractAddress: flapContractAddress}
 		blockNumber          int64
 		diffID, fakeHeaderID int64
 	)

--- a/transformers/storage/flip/initializers/flip_initializer_generator.go
+++ b/transformers/storage/flip/initializers/flip_initializer_generator.go
@@ -27,6 +27,6 @@ func GenerateStorageTransformerInitializer(contractAddress string) storage.Trans
 	return storage.Transformer{
 		Address:           common.HexToAddress(contractAddress),
 		StorageKeysLookup: storage.NewKeysLookup(flip.NewKeysLoader(&mcdStorage.MakerStorageRepository{}, contractAddress)),
-		Repository:        &flip.FlipStorageRepository{ContractAddress: contractAddress},
+		Repository:        &flip.StorageRepository{ContractAddress: contractAddress},
 	}.NewTransformer
 }

--- a/transformers/storage/flip/keys_loader.go
+++ b/transformers/storage/flip/keys_loader.go
@@ -17,6 +17,8 @@
 package flip
 
 import (
+	"fmt"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
@@ -40,10 +42,10 @@ var (
 	BegKey      = common.HexToHash(vdbStorage.IndexFour)
 	BegMetadata = types.GetValueMetadata(mcdStorage.Beg, nil, types.Uint256)
 
-	TtlAndTauStorageKey = common.HexToHash(vdbStorage.IndexFive)
+	TTLAndTauStorageKey = common.HexToHash(vdbStorage.IndexFive)
 	ttlAndTauTypes      = map[int]types.ValueType{0: types.Uint48, 1: types.Uint48}
 	ttlAndTauNames      = map[int]string{0: mcdStorage.Ttl, 1: mcdStorage.Tau}
-	TtlAndTauMetadata   = types.GetValueMetadataForPackedSlot(mcdStorage.Packed, nil, types.PackedSlot, ttlAndTauNames, ttlAndTauTypes)
+	TTLAndTauMetadata   = types.GetValueMetadataForPackedSlot(mcdStorage.Packed, nil, types.PackedSlot, ttlAndTauNames, ttlAndTauTypes)
 
 	KicksKey      = common.HexToHash(vdbStorage.IndexSix)
 	KicksMetadata = types.GetValueMetadata(mcdStorage.Kicks, nil, types.Uint256)
@@ -69,35 +71,39 @@ func (loader *keysLoader) LoadMappings() (map[common.Hash]types.ValueMetadata, e
 	mappings := loadStaticMappings()
 	mappings, wardsErr := loader.loadWardsKeys(mappings)
 	if wardsErr != nil {
-		return nil, wardsErr
+		return nil, fmt.Errorf("error adding ward keys to flip keys loader: %w", wardsErr)
 	}
-	return loader.loadBidKeys(mappings)
+	mappings, bidErr := loader.loadBidKeys(mappings)
+	if bidErr != nil {
+		return nil, fmt.Errorf("error adding bid keys to flip keys loader: %w", bidErr)
+	}
+	return mappings, nil
 }
 
 func (loader *keysLoader) loadWardsKeys(mappings map[common.Hash]types.ValueMetadata) (map[common.Hash]types.ValueMetadata, error) {
 	addresses, err := loader.storageRepository.GetWardsAddresses(loader.contractAddress)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error getting wards addresses: %w", err)
 	}
 	return wards.AddWardsKeys(mappings, addresses)
 }
 
 func (loader *keysLoader) loadBidKeys(mappings map[common.Hash]types.ValueMetadata) (map[common.Hash]types.ValueMetadata, error) {
-	bidIds, bidErr := loader.storageRepository.GetFlipBidIDs(loader.contractAddress)
+	bidIDs, bidErr := loader.storageRepository.GetFlipBidIDs(loader.contractAddress)
 	if bidErr != nil {
-		return nil, bidErr
+		return nil, fmt.Errorf("error getting flip bid IDs: %w", bidErr)
 	}
-	for _, bidId := range bidIds {
-		hexBidId, convertErr := shared.ConvertIntStringToHex(bidId)
+	for _, bidID := range bidIDs {
+		hexBidID, convertErr := shared.ConvertIntStringToHex(bidID)
 		if convertErr != nil {
-			return nil, convertErr
+			return nil, fmt.Errorf("error converting int string to hex: %w", convertErr)
 		}
-		mappings[getBidBidKey(hexBidId)] = getBidBidMetadata(bidId)
-		mappings[getBidLotKey(hexBidId)] = getBidLotMetadata(bidId)
-		mappings[getBidGuyTicEndKey(hexBidId)] = getBidGuyTicEndMetadata(bidId)
-		mappings[getBidUsrKey(hexBidId)] = getBidUsrMetadata(bidId)
-		mappings[getBidGalKey(hexBidId)] = getBidGalMetadata(bidId)
-		mappings[getBidTabKey(hexBidId)] = getBidTabMetadata(bidId)
+		mappings[getBidBidKey(hexBidID)] = getBidBidMetadata(bidID)
+		mappings[getBidLotKey(hexBidID)] = getBidLotMetadata(bidID)
+		mappings[getBidGuyTicEndKey(hexBidID)] = getBidGuyTicEndMetadata(bidID)
+		mappings[getBidUsrKey(hexBidID)] = getBidUsrMetadata(bidID)
+		mappings[getBidGalKey(hexBidID)] = getBidGalMetadata(bidID)
+		mappings[getBidTabKey(hexBidID)] = getBidTabMetadata(bidID)
 	}
 	return mappings, nil
 }
@@ -107,63 +113,63 @@ func loadStaticMappings() map[common.Hash]types.ValueMetadata {
 	mappings[VatKey] = VatMetadata
 	mappings[IlkKey] = IlkMetadata
 	mappings[BegKey] = BegMetadata
-	mappings[TtlAndTauStorageKey] = TtlAndTauMetadata
+	mappings[TTLAndTauStorageKey] = TTLAndTauMetadata
 	mappings[KicksKey] = KicksMetadata
 	return mappings
 }
 
-func getBidBidKey(hexBidId string) common.Hash {
-	return vdbStorage.GetKeyForMapping(BidsMappingIndex, hexBidId)
+func getBidBidKey(hexBidID string) common.Hash {
+	return vdbStorage.GetKeyForMapping(BidsMappingIndex, hexBidID)
 }
 
-func getBidBidMetadata(bidId string) types.ValueMetadata {
-	keys := map[types.Key]string{constants.BidId: bidId}
+func getBidBidMetadata(bidID string) types.ValueMetadata {
+	keys := map[types.Key]string{constants.BidId: bidID}
 	return types.GetValueMetadata(mcdStorage.BidBid, keys, types.Uint256)
 }
 
-func getBidLotKey(hexBidId string) common.Hash {
-	return vdbStorage.GetIncrementedKey(getBidBidKey(hexBidId), 1)
+func getBidLotKey(hexBidID string) common.Hash {
+	return vdbStorage.GetIncrementedKey(getBidBidKey(hexBidID), 1)
 }
 
-func getBidLotMetadata(bidId string) types.ValueMetadata {
-	keys := map[types.Key]string{constants.BidId: bidId}
+func getBidLotMetadata(bidID string) types.ValueMetadata {
+	keys := map[types.Key]string{constants.BidId: bidID}
 	return types.GetValueMetadata(mcdStorage.BidLot, keys, types.Uint256)
 }
 
-func getBidGuyTicEndKey(hexBidId string) common.Hash {
-	return vdbStorage.GetIncrementedKey(getBidBidKey(hexBidId), 2)
+func getBidGuyTicEndKey(hexBidID string) common.Hash {
+	return vdbStorage.GetIncrementedKey(getBidBidKey(hexBidID), 2)
 }
 
-func getBidGuyTicEndMetadata(bidId string) types.ValueMetadata {
-	keys := map[types.Key]string{constants.BidId: bidId}
+func getBidGuyTicEndMetadata(bidID string) types.ValueMetadata {
+	keys := map[types.Key]string{constants.BidId: bidID}
 	packedTypes := map[int]types.ValueType{0: types.Address, 1: types.Uint48, 2: types.Uint48}
 	packedNames := map[int]string{0: mcdStorage.BidGuy, 1: mcdStorage.BidTic, 2: mcdStorage.BidEnd}
 	return types.GetValueMetadataForPackedSlot(mcdStorage.Packed, keys, types.PackedSlot, packedNames, packedTypes)
 }
 
-func getBidUsrKey(hexBidId string) common.Hash {
-	return vdbStorage.GetIncrementedKey(getBidBidKey(hexBidId), 3)
+func getBidUsrKey(hexBidID string) common.Hash {
+	return vdbStorage.GetIncrementedKey(getBidBidKey(hexBidID), 3)
 }
 
-func getBidUsrMetadata(bidId string) types.ValueMetadata {
-	keys := map[types.Key]string{constants.BidId: bidId}
+func getBidUsrMetadata(bidID string) types.ValueMetadata {
+	keys := map[types.Key]string{constants.BidId: bidID}
 	return types.GetValueMetadata(mcdStorage.BidUsr, keys, types.Address)
 }
 
-func getBidGalKey(hexBidId string) common.Hash {
-	return vdbStorage.GetIncrementedKey(getBidBidKey(hexBidId), 4)
+func getBidGalKey(hexBidID string) common.Hash {
+	return vdbStorage.GetIncrementedKey(getBidBidKey(hexBidID), 4)
 }
 
-func getBidGalMetadata(bidId string) types.ValueMetadata {
-	keys := map[types.Key]string{constants.BidId: bidId}
+func getBidGalMetadata(bidID string) types.ValueMetadata {
+	keys := map[types.Key]string{constants.BidId: bidID}
 	return types.GetValueMetadata(mcdStorage.BidGal, keys, types.Address)
 }
 
-func getBidTabKey(hexBidId string) common.Hash {
-	return vdbStorage.GetIncrementedKey(getBidBidKey(hexBidId), 5)
+func getBidTabKey(hexBidID string) common.Hash {
+	return vdbStorage.GetIncrementedKey(getBidBidKey(hexBidID), 5)
 }
 
-func getBidTabMetadata(bidId string) types.ValueMetadata {
-	keys := map[types.Key]string{constants.BidId: bidId}
+func getBidTabMetadata(bidID string) types.ValueMetadata {
+	keys := map[types.Key]string{constants.BidId: bidID}
 	return types.GetValueMetadata(mcdStorage.BidTab, keys, types.Uint256)
 }

--- a/transformers/storage/flip/keys_loader.go
+++ b/transformers/storage/flip/keys_loader.go
@@ -83,7 +83,7 @@ func (loader *keysLoader) loadWardsKeys(mappings map[common.Hash]types.ValueMeta
 }
 
 func (loader *keysLoader) loadBidKeys(mappings map[common.Hash]types.ValueMetadata) (map[common.Hash]types.ValueMetadata, error) {
-	bidIds, bidErr := loader.storageRepository.GetFlipBidIds(loader.contractAddress)
+	bidIds, bidErr := loader.storageRepository.GetFlipBidIDs(loader.contractAddress)
 	if bidErr != nil {
 		return nil, bidErr
 	}

--- a/transformers/storage/flip/keys_loader_test.go
+++ b/transformers/storage/flip/keys_loader_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Flip storage keys loader", func() {
 		Expect(mappings[flip.VatKey]).To(Equal(flip.VatMetadata))
 		Expect(mappings[flip.IlkKey]).To(Equal(flip.IlkMetadata))
 		Expect(mappings[flip.BegKey]).To(Equal(flip.BegMetadata))
-		Expect(mappings[flip.TtlAndTauStorageKey]).To(Equal(flip.TtlAndTauMetadata))
+		Expect(mappings[flip.TTLAndTauStorageKey]).To(Equal(flip.TTLAndTauMetadata))
 		Expect(mappings[flip.KicksKey]).To(Equal(flip.KicksMetadata))
 	})
 

--- a/transformers/storage/flip/keys_loader_test.go
+++ b/transformers/storage/flip/keys_loader_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Flip storage keys loader", func() {
 	Describe("bid", func() {
 		Describe("when loading bid IDs fails", func() {
 			It("returns error", func() {
-				storageRepository.GetFlipBidIdsError = fakes.FakeError
+				storageRepository.GetFlipBidIDsError = fakes.FakeError
 
 				_, err := storageKeysLoader.LoadMappings()
 
@@ -108,7 +108,7 @@ var _ = Describe("Flip storage keys loader", func() {
 			)
 
 			BeforeEach(func() {
-				storageRepository.FlipBidIds = []string{fakeBidId}
+				storageRepository.FlipBidIDs = []string{fakeBidId}
 				var err error
 				mappings, err = storageKeysLoader.LoadMappings()
 				Expect(err).NotTo(HaveOccurred())

--- a/transformers/storage/flip/repository.go
+++ b/transformers/storage/flip/repository.go
@@ -103,7 +103,7 @@ func (repository *FlipStorageRepository) insertBidBid(diffID, headerID int64, me
 		return err
 	}
 
-	return shared.InsertRecordWithAddressAndBidId(diffID, headerID, InsertFlipBidBidQuery, bidId, bid, repository.ContractAddress, repository.db)
+	return shared.InsertRecordWithAddressAndBidID(diffID, headerID, InsertFlipBidBidQuery, bidId, bid, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlipStorageRepository) insertBidLot(diffID, headerID int64, metadata types.ValueMetadata, lot string) error {
@@ -112,7 +112,7 @@ func (repository *FlipStorageRepository) insertBidLot(diffID, headerID int64, me
 		return err
 	}
 
-	return shared.InsertRecordWithAddressAndBidId(diffID, headerID, InsertFlipBidLotQuery, bidId, lot, repository.ContractAddress, repository.db)
+	return shared.InsertRecordWithAddressAndBidID(diffID, headerID, InsertFlipBidLotQuery, bidId, lot, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlipStorageRepository) insertBidGuy(diffID, headerID int64, metadata types.ValueMetadata, guy string) error {
@@ -121,7 +121,7 @@ func (repository *FlipStorageRepository) insertBidGuy(diffID, headerID int64, me
 		return err
 	}
 
-	return shared.InsertRecordWithAddressAndBidId(diffID, headerID, InsertFlipBidGuyQuery, bidId, guy, repository.ContractAddress, repository.db)
+	return shared.InsertRecordWithAddressAndBidID(diffID, headerID, InsertFlipBidGuyQuery, bidId, guy, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlipStorageRepository) insertBidTic(diffID, headerID int64, metadata types.ValueMetadata, tic string) error {
@@ -130,7 +130,7 @@ func (repository *FlipStorageRepository) insertBidTic(diffID, headerID int64, me
 		return err
 	}
 
-	return shared.InsertRecordWithAddressAndBidId(diffID, headerID, InsertFlipBidTicQuery, bidId, tic, repository.ContractAddress, repository.db)
+	return shared.InsertRecordWithAddressAndBidID(diffID, headerID, InsertFlipBidTicQuery, bidId, tic, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlipStorageRepository) insertBidEnd(diffID, headerID int64, metadata types.ValueMetadata, end string) error {
@@ -139,7 +139,7 @@ func (repository *FlipStorageRepository) insertBidEnd(diffID, headerID int64, me
 		return err
 	}
 
-	return shared.InsertRecordWithAddressAndBidId(diffID, headerID, InsertFlipBidEndQuery, bidId, end, repository.ContractAddress, repository.db)
+	return shared.InsertRecordWithAddressAndBidID(diffID, headerID, InsertFlipBidEndQuery, bidId, end, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlipStorageRepository) insertBidUsr(diffID, headerID int64, metadata types.ValueMetadata, usr string) error {
@@ -148,7 +148,7 @@ func (repository *FlipStorageRepository) insertBidUsr(diffID, headerID int64, me
 		return err
 	}
 
-	return shared.InsertRecordWithAddressAndBidId(diffID, headerID, InsertFlipBidUsrQuery, bidId, usr, repository.ContractAddress, repository.db)
+	return shared.InsertRecordWithAddressAndBidID(diffID, headerID, InsertFlipBidUsrQuery, bidId, usr, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlipStorageRepository) insertBidGal(diffID, headerID int64, metadata types.ValueMetadata, gal string) error {
@@ -157,7 +157,7 @@ func (repository *FlipStorageRepository) insertBidGal(diffID, headerID int64, me
 		return err
 	}
 
-	return shared.InsertRecordWithAddressAndBidId(diffID, headerID, InsertFlipBidGalQuery, bidId, gal, repository.ContractAddress, repository.db)
+	return shared.InsertRecordWithAddressAndBidID(diffID, headerID, InsertFlipBidGalQuery, bidId, gal, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlipStorageRepository) insertBidTab(diffID, headerID int64, metadata types.ValueMetadata, tab string) error {
@@ -166,7 +166,7 @@ func (repository *FlipStorageRepository) insertBidTab(diffID, headerID int64, me
 		return err
 	}
 
-	return shared.InsertRecordWithAddressAndBidId(diffID, headerID, InsertFlipBidTabQuery, bidId, tab, repository.ContractAddress, repository.db)
+	return shared.InsertRecordWithAddressAndBidID(diffID, headerID, InsertFlipBidTabQuery, bidId, tab, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlipStorageRepository) insertPackedValueRecord(diffID, headerID int64, metadata types.ValueMetadata, packedValues map[int]string) error {

--- a/transformers/storage/flip/repository.go
+++ b/transformers/storage/flip/repository.go
@@ -16,7 +16,7 @@ const (
 	insertFlipVatQuery   = `INSERT INTO maker.flip_vat (diff_id, header_id, address_id, vat) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
 	insertFlipIlkQuery   = `INSERT INTO maker.flip_ilk (diff_id, header_id, address_id, ilk_id) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
 	insertFlipBegQuery   = `INSERT INTO maker.flip_beg (diff_id, header_id, address_id, beg) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
-	insertFlipTtlQuery   = `INSERT INTO maker.flip_ttl (diff_id, header_id, address_id, ttl) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
+	insertFlipTTLQuery   = `INSERT INTO maker.flip_ttl (diff_id, header_id, address_id, ttl) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
 	insertFlipTauQuery   = `INSERT INTO maker.flip_tau (diff_id, header_id, address_id, tau) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
 	InsertFlipKicksQuery = `INSERT INTO maker.flip_kicks (diff_id, header_id, address_id, kicks) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
 
@@ -30,12 +30,12 @@ const (
 	InsertFlipBidTabQuery = `INSERT INTO maker.flip_bid_tab (diff_id, header_id, address_id, bid_id, tab) VALUES ($1, $2, $3, $4, $5) ON CONFLICT DO NOTHING`
 )
 
-type FlipStorageRepository struct {
+type StorageRepository struct {
 	ContractAddress string
 	db              *postgres.DB
 }
 
-func (repository *FlipStorageRepository) Create(diffID, headerID int64, metadata types.ValueMetadata, value interface{}) error {
+func (repository *StorageRepository) Create(diffID, headerID int64, metadata types.ValueMetadata, value interface{}) error {
 	switch metadata.Name {
 	case storage.Vat:
 		return repository.insertVat(diffID, headerID, value.(string))
@@ -64,117 +64,284 @@ func (repository *FlipStorageRepository) Create(diffID, headerID int64, metadata
 	}
 }
 
-func (repository *FlipStorageRepository) SetDB(db *postgres.DB) {
+func (repository *StorageRepository) SetDB(db *postgres.DB) {
 	repository.db = db
 }
 
-func (repository *FlipStorageRepository) insertVat(diffID, headerID int64, vat string) error {
-	return shared.InsertRecordWithAddress(diffID, headerID, insertFlipVatQuery, vat, repository.ContractAddress, repository.db)
+func (repository *StorageRepository) insertVat(diffID, headerID int64, vat string) error {
+	err := shared.InsertRecordWithAddress(
+		diffID,
+		headerID,
+		insertFlipVatQuery,
+		vat,
+		repository.ContractAddress,
+		repository.db)
+	if err != nil {
+		msgToFormat := "error inserting flip %s vat %s from diff ID %d"
+		msg := fmt.Sprintf(msgToFormat, repository.ContractAddress, vat, diffID)
+		return fmt.Errorf("%s: %w", msg, err)
+	}
+	return nil
 }
 
-func (repository *FlipStorageRepository) insertIlk(diffID, headerID int64, ilk string) error {
+func (repository *StorageRepository) insertIlk(diffID, headerID int64, ilk string) error {
 	ilkID, ilkErr := shared.GetOrCreateIlk(ilk, repository.db)
 	if ilkErr != nil {
-		return ilkErr
+		return fmt.Errorf("error getting or creating ilk for flip ilk: %w", ilkErr)
 	}
-
-	return shared.InsertRecordWithAddress(diffID, headerID, insertFlipIlkQuery, strconv.FormatInt(ilkID, 10), repository.ContractAddress, repository.db)
+	insertErr := shared.InsertRecordWithAddress(
+		diffID,
+		headerID,
+		insertFlipIlkQuery,
+		strconv.FormatInt(ilkID, 10),
+		repository.ContractAddress,
+		repository.db)
+	if insertErr != nil {
+		msgToFormat := "error inserting flip %s ilk %s from diff ID %d"
+		msg := fmt.Sprintf(msgToFormat, repository.ContractAddress, ilk, diffID)
+		return fmt.Errorf("%s: %w", msg, insertErr)
+	}
+	return nil
 }
 
-func (repository *FlipStorageRepository) insertBeg(diffID, headerID int64, beg string) error {
-	return shared.InsertRecordWithAddress(diffID, headerID, insertFlipBegQuery, beg, repository.ContractAddress, repository.db)
-}
-
-func (repository *FlipStorageRepository) insertTtl(diffID, headerID int64, ttl string) error {
-	return shared.InsertRecordWithAddress(diffID, headerID, insertFlipTtlQuery, ttl, repository.ContractAddress, repository.db)
-}
-
-func (repository *FlipStorageRepository) insertTau(diffID, headerID int64, tau string) error {
-	return shared.InsertRecordWithAddress(diffID, headerID, insertFlipTauQuery, tau, repository.ContractAddress, repository.db)
-}
-
-func (repository *FlipStorageRepository) insertKicks(diffID, headerID int64, kicks string) error {
-	return shared.InsertRecordWithAddress(diffID, headerID, InsertFlipKicksQuery, kicks, repository.ContractAddress, repository.db)
-}
-
-func (repository *FlipStorageRepository) insertBidBid(diffID, headerID int64, metadata types.ValueMetadata, bid string) error {
-	bidId, err := getBidId(metadata.Keys)
+func (repository *StorageRepository) insertBeg(diffID, headerID int64, beg string) error {
+	err := shared.InsertRecordWithAddress(
+		diffID,
+		headerID,
+		insertFlipBegQuery,
+		beg,
+		repository.ContractAddress,
+		repository.db)
 	if err != nil {
-		return err
+		msgToFormat := "error inserting flip %s beg %s from diff ID %d"
+		msg := fmt.Sprintf(msgToFormat, repository.ContractAddress, beg, diffID)
+		return fmt.Errorf("%s: %w", msg, err)
 	}
-
-	return shared.InsertRecordWithAddressAndBidID(diffID, headerID, InsertFlipBidBidQuery, bidId, bid, repository.ContractAddress, repository.db)
+	return nil
 }
 
-func (repository *FlipStorageRepository) insertBidLot(diffID, headerID int64, metadata types.ValueMetadata, lot string) error {
-	bidId, err := getBidId(metadata.Keys)
+func (repository *StorageRepository) insertTTL(diffID, headerID int64, ttl string) error {
+	err := shared.InsertRecordWithAddress(
+		diffID,
+		headerID,
+		insertFlipTTLQuery,
+		ttl,
+		repository.ContractAddress,
+		repository.db)
 	if err != nil {
-		return err
+		msgToFormat := "error inserting flip %s ttl %s from diff ID %d"
+		msg := fmt.Sprintf(msgToFormat, repository.ContractAddress, ttl, diffID)
+		return fmt.Errorf("%s: %w", msg, err)
 	}
-
-	return shared.InsertRecordWithAddressAndBidID(diffID, headerID, InsertFlipBidLotQuery, bidId, lot, repository.ContractAddress, repository.db)
+	return nil
 }
 
-func (repository *FlipStorageRepository) insertBidGuy(diffID, headerID int64, metadata types.ValueMetadata, guy string) error {
-	bidId, err := getBidId(metadata.Keys)
+func (repository *StorageRepository) insertTau(diffID, headerID int64, tau string) error {
+	err := shared.InsertRecordWithAddress(
+		diffID,
+		headerID,
+		insertFlipTauQuery,
+		tau,
+		repository.ContractAddress,
+		repository.db)
 	if err != nil {
-		return err
+		msgToFormat := "error inserting flip %s tau %s from diff ID %d"
+		msg := fmt.Sprintf(msgToFormat, repository.ContractAddress, tau, diffID)
+		return fmt.Errorf("%s: %w", msg, err)
 	}
-
-	return shared.InsertRecordWithAddressAndBidID(diffID, headerID, InsertFlipBidGuyQuery, bidId, guy, repository.ContractAddress, repository.db)
+	return nil
 }
 
-func (repository *FlipStorageRepository) insertBidTic(diffID, headerID int64, metadata types.ValueMetadata, tic string) error {
-	bidId, err := getBidId(metadata.Keys)
+func (repository *StorageRepository) insertKicks(diffID, headerID int64, kicks string) error {
+	err := shared.InsertRecordWithAddress(
+		diffID,
+		headerID,
+		InsertFlipKicksQuery,
+		kicks,
+		repository.ContractAddress,
+		repository.db)
 	if err != nil {
-		return err
+		msgToFormat := "error inserting flip %s kicks %s from diff ID %d"
+		msg := fmt.Sprintf(msgToFormat, repository.ContractAddress, kicks, diffID)
+		return fmt.Errorf("%s: %w", msg, err)
 	}
-
-	return shared.InsertRecordWithAddressAndBidID(diffID, headerID, InsertFlipBidTicQuery, bidId, tic, repository.ContractAddress, repository.db)
+	return nil
 }
 
-func (repository *FlipStorageRepository) insertBidEnd(diffID, headerID int64, metadata types.ValueMetadata, end string) error {
-	bidId, err := getBidId(metadata.Keys)
+func (repository *StorageRepository) insertBidBid(diffID, headerID int64, metadata types.ValueMetadata, bid string) error {
+	bidID, err := getBidID(metadata.Keys)
 	if err != nil {
-		return err
+		return fmt.Errorf("error getting bid ID for flip bid bid: %w", err)
 	}
-
-	return shared.InsertRecordWithAddressAndBidID(diffID, headerID, InsertFlipBidEndQuery, bidId, end, repository.ContractAddress, repository.db)
+	insertErr := shared.InsertRecordWithAddressAndBidID(
+		diffID,
+		headerID,
+		InsertFlipBidBidQuery,
+		bidID,
+		bid,
+		repository.ContractAddress,
+		repository.db)
+	if insertErr != nil {
+		msgToFormat := "error inserting flip %s bid %s bid %s from diff ID %d"
+		msg := fmt.Sprintf(msgToFormat, repository.ContractAddress, bidID, bid, diffID)
+		return fmt.Errorf("%s: %w", msg, insertErr)
+	}
+	return nil
 }
 
-func (repository *FlipStorageRepository) insertBidUsr(diffID, headerID int64, metadata types.ValueMetadata, usr string) error {
-	bidId, err := getBidId(metadata.Keys)
+func (repository *StorageRepository) insertBidLot(diffID, headerID int64, metadata types.ValueMetadata, lot string) error {
+	bidID, err := getBidID(metadata.Keys)
 	if err != nil {
-		return err
+		return fmt.Errorf("error getting bid ID for flip bid lot: %w", err)
 	}
-
-	return shared.InsertRecordWithAddressAndBidID(diffID, headerID, InsertFlipBidUsrQuery, bidId, usr, repository.ContractAddress, repository.db)
+	insertErr := shared.InsertRecordWithAddressAndBidID(
+		diffID,
+		headerID,
+		InsertFlipBidLotQuery,
+		bidID,
+		lot,
+		repository.ContractAddress,
+		repository.db)
+	if insertErr != nil {
+		msgToFormat := "error inserting flip %s bid %s lot %s from diff ID %d"
+		msg := fmt.Sprintf(msgToFormat, repository.ContractAddress, bidID, lot, diffID)
+		return fmt.Errorf("%s: %w", msg, insertErr)
+	}
+	return nil
 }
 
-func (repository *FlipStorageRepository) insertBidGal(diffID, headerID int64, metadata types.ValueMetadata, gal string) error {
-	bidId, err := getBidId(metadata.Keys)
+func (repository *StorageRepository) insertBidGuy(diffID, headerID int64, metadata types.ValueMetadata, guy string) error {
+	bidID, err := getBidID(metadata.Keys)
 	if err != nil {
-		return err
+		return fmt.Errorf("error getting bid ID for flip bid guy: %w", err)
 	}
-
-	return shared.InsertRecordWithAddressAndBidID(diffID, headerID, InsertFlipBidGalQuery, bidId, gal, repository.ContractAddress, repository.db)
+	insertErr := shared.InsertRecordWithAddressAndBidID(
+		diffID,
+		headerID,
+		InsertFlipBidGuyQuery,
+		bidID,
+		guy,
+		repository.ContractAddress,
+		repository.db)
+	if insertErr != nil {
+		msgToFormat := "error inserting flip %s bid %s guy %s from diff ID %d"
+		msg := fmt.Sprintf(msgToFormat, repository.ContractAddress, bidID, guy, diffID)
+		return fmt.Errorf("%s: %w", msg, insertErr)
+	}
+	return nil
 }
 
-func (repository *FlipStorageRepository) insertBidTab(diffID, headerID int64, metadata types.ValueMetadata, tab string) error {
-	bidId, err := getBidId(metadata.Keys)
+func (repository *StorageRepository) insertBidTic(diffID, headerID int64, metadata types.ValueMetadata, tic string) error {
+	bidID, err := getBidID(metadata.Keys)
 	if err != nil {
-		return err
+		return fmt.Errorf("error getting bid ID for flip bid tic: %w", err)
 	}
-
-	return shared.InsertRecordWithAddressAndBidID(diffID, headerID, InsertFlipBidTabQuery, bidId, tab, repository.ContractAddress, repository.db)
+	insertErr := shared.InsertRecordWithAddressAndBidID(
+		diffID,
+		headerID,
+		InsertFlipBidTicQuery,
+		bidID,
+		tic,
+		repository.ContractAddress,
+		repository.db)
+	if insertErr != nil {
+		msgToFormat := "error inserting flip %s bid %s tic %s from diff ID %d"
+		msg := fmt.Sprintf(msgToFormat, repository.ContractAddress, bidID, tic, diffID)
+		return fmt.Errorf("%s: %w", msg, insertErr)
+	}
+	return nil
 }
 
-func (repository *FlipStorageRepository) insertPackedValueRecord(diffID, headerID int64, metadata types.ValueMetadata, packedValues map[int]string) error {
+func (repository *StorageRepository) insertBidEnd(diffID, headerID int64, metadata types.ValueMetadata, end string) error {
+	bidID, err := getBidID(metadata.Keys)
+	if err != nil {
+		return fmt.Errorf("error getting bid ID for flip bid end: %w", err)
+	}
+	insertErr := shared.InsertRecordWithAddressAndBidID(
+		diffID,
+		headerID,
+		InsertFlipBidEndQuery,
+		bidID,
+		end,
+		repository.ContractAddress,
+		repository.db)
+	if insertErr != nil {
+		msgToFormat := "error inserting flip %s bid %s end %s from diff ID %d"
+		msg := fmt.Sprintf(msgToFormat, repository.ContractAddress, bidID, end, diffID)
+		return fmt.Errorf("%s: %w", msg, insertErr)
+	}
+	return nil
+}
+
+func (repository *StorageRepository) insertBidUsr(diffID, headerID int64, metadata types.ValueMetadata, usr string) error {
+	bidID, err := getBidID(metadata.Keys)
+	if err != nil {
+		return fmt.Errorf("error getting bid ID for flip bid usr: %w", err)
+	}
+	insertErr := shared.InsertRecordWithAddressAndBidID(
+		diffID,
+		headerID,
+		InsertFlipBidUsrQuery,
+		bidID,
+		usr,
+		repository.ContractAddress,
+		repository.db)
+	if insertErr != nil {
+		msgToFormat := "error inserting flip %s bid %s usr %s from diff ID %d"
+		msg := fmt.Sprintf(msgToFormat, repository.ContractAddress, bidID, usr, diffID)
+		return fmt.Errorf("%s: %w", msg, insertErr)
+	}
+	return nil
+}
+
+func (repository *StorageRepository) insertBidGal(diffID, headerID int64, metadata types.ValueMetadata, gal string) error {
+	bidID, err := getBidID(metadata.Keys)
+	if err != nil {
+		return fmt.Errorf("error getting bid ID for flip bid gal: %w", err)
+	}
+	insertErr := shared.InsertRecordWithAddressAndBidID(
+		diffID,
+		headerID,
+		InsertFlipBidGalQuery,
+		bidID,
+		gal,
+		repository.ContractAddress,
+		repository.db)
+	if insertErr != nil {
+		msgToFormat := "error inserting flip %s bid %s gal %s from diff ID %d"
+		msg := fmt.Sprintf(msgToFormat, repository.ContractAddress, bidID, gal, diffID)
+		return fmt.Errorf("%s: %w", msg, insertErr)
+	}
+	return nil
+}
+
+func (repository *StorageRepository) insertBidTab(diffID, headerID int64, metadata types.ValueMetadata, tab string) error {
+	bidID, err := getBidID(metadata.Keys)
+	if err != nil {
+		return fmt.Errorf("error getting bid ID for flip bid tab: %w", err)
+	}
+	insertErr := shared.InsertRecordWithAddressAndBidID(
+		diffID,
+		headerID,
+		InsertFlipBidTabQuery,
+		bidID,
+		tab,
+		repository.ContractAddress,
+		repository.db)
+	if insertErr != nil {
+		msgToFormat := "error inserting flip %s bid %s tab %s from diff ID %d"
+		msg := fmt.Sprintf(msgToFormat, repository.ContractAddress, bidID, tab, diffID)
+		return fmt.Errorf("%s: %w", msg, insertErr)
+	}
+	return nil
+}
+
+func (repository *StorageRepository) insertPackedValueRecord(diffID, headerID int64, metadata types.ValueMetadata, packedValues map[int]string) error {
 	for order, value := range packedValues {
 		var insertErr error
 		switch metadata.PackedNames[order] {
 		case storage.Ttl:
-			insertErr = repository.insertTtl(diffID, headerID, value)
+			insertErr = repository.insertTTL(diffID, headerID, value)
 		case storage.Tau:
 			insertErr = repository.insertTau(diffID, headerID, value)
 		case storage.BidGuy:
@@ -187,16 +354,16 @@ func (repository *FlipStorageRepository) insertPackedValueRecord(diffID, headerI
 			panic(fmt.Sprintf("unrecognized flip contract storage name in packed values: %s", metadata.Name))
 		}
 		if insertErr != nil {
-			return insertErr
+			return fmt.Errorf("error inserting flip packed value from diff ID %d: %w", diffID, insertErr)
 		}
 	}
 	return nil
 }
 
-func getBidId(keys map[types.Key]string) (string, error) {
-	bidId, ok := keys[constants.BidId]
+func getBidID(keys map[types.Key]string) (string, error) {
+	bidID, ok := keys[constants.BidId]
 	if !ok {
 		return "", types.ErrMetadataMalformed{MissingData: constants.BidId}
 	}
-	return bidId, nil
+	return bidID, nil
 }

--- a/transformers/storage/flip/repository.go
+++ b/transformers/storage/flip/repository.go
@@ -69,7 +69,7 @@ func (repository *FlipStorageRepository) SetDB(db *postgres.DB) {
 }
 
 func (repository *FlipStorageRepository) insertVat(diffID, headerID int64, vat string) error {
-	return repository.insertRecordWithAddress(diffID, headerID, insertFlipVatQuery, vat)
+	return shared.InsertRecordWithAddress(diffID, headerID, insertFlipVatQuery, vat, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlipStorageRepository) insertIlk(diffID, headerID int64, ilk string) error {
@@ -78,23 +78,23 @@ func (repository *FlipStorageRepository) insertIlk(diffID, headerID int64, ilk s
 		return ilkErr
 	}
 
-	return repository.insertRecordWithAddress(diffID, headerID, insertFlipIlkQuery, strconv.FormatInt(ilkID, 10))
+	return shared.InsertRecordWithAddress(diffID, headerID, insertFlipIlkQuery, strconv.FormatInt(ilkID, 10), repository.ContractAddress, repository.db)
 }
 
 func (repository *FlipStorageRepository) insertBeg(diffID, headerID int64, beg string) error {
-	return repository.insertRecordWithAddress(diffID, headerID, insertFlipBegQuery, beg)
+	return shared.InsertRecordWithAddress(diffID, headerID, insertFlipBegQuery, beg, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlipStorageRepository) insertTtl(diffID, headerID int64, ttl string) error {
-	return repository.insertRecordWithAddress(diffID, headerID, insertFlipTtlQuery, ttl)
+	return shared.InsertRecordWithAddress(diffID, headerID, insertFlipTtlQuery, ttl, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlipStorageRepository) insertTau(diffID, headerID int64, tau string) error {
-	return repository.insertRecordWithAddress(diffID, headerID, insertFlipTauQuery, tau)
+	return shared.InsertRecordWithAddress(diffID, headerID, insertFlipTauQuery, tau, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlipStorageRepository) insertKicks(diffID, headerID int64, kicks string) error {
-	return repository.insertRecordWithAddress(diffID, headerID, InsertFlipKicksQuery, kicks)
+	return shared.InsertRecordWithAddress(diffID, headerID, InsertFlipKicksQuery, kicks, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlipStorageRepository) insertBidBid(diffID, headerID int64, metadata types.ValueMetadata, bid string) error {
@@ -103,7 +103,7 @@ func (repository *FlipStorageRepository) insertBidBid(diffID, headerID int64, me
 		return err
 	}
 
-	return repository.insertRecordWithAddressAndBidId(diffID, headerID, InsertFlipBidBidQuery, bidId, bid)
+	return shared.InsertRecordWithAddressAndBidId(diffID, headerID, InsertFlipBidBidQuery, bidId, bid, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlipStorageRepository) insertBidLot(diffID, headerID int64, metadata types.ValueMetadata, lot string) error {
@@ -112,7 +112,7 @@ func (repository *FlipStorageRepository) insertBidLot(diffID, headerID int64, me
 		return err
 	}
 
-	return repository.insertRecordWithAddressAndBidId(diffID, headerID, InsertFlipBidLotQuery, bidId, lot)
+	return shared.InsertRecordWithAddressAndBidId(diffID, headerID, InsertFlipBidLotQuery, bidId, lot, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlipStorageRepository) insertBidGuy(diffID, headerID int64, metadata types.ValueMetadata, guy string) error {
@@ -121,7 +121,7 @@ func (repository *FlipStorageRepository) insertBidGuy(diffID, headerID int64, me
 		return err
 	}
 
-	return repository.insertRecordWithAddressAndBidId(diffID, headerID, InsertFlipBidGuyQuery, bidId, guy)
+	return shared.InsertRecordWithAddressAndBidId(diffID, headerID, InsertFlipBidGuyQuery, bidId, guy, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlipStorageRepository) insertBidTic(diffID, headerID int64, metadata types.ValueMetadata, tic string) error {
@@ -130,7 +130,7 @@ func (repository *FlipStorageRepository) insertBidTic(diffID, headerID int64, me
 		return err
 	}
 
-	return repository.insertRecordWithAddressAndBidId(diffID, headerID, InsertFlipBidTicQuery, bidId, tic)
+	return shared.InsertRecordWithAddressAndBidId(diffID, headerID, InsertFlipBidTicQuery, bidId, tic, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlipStorageRepository) insertBidEnd(diffID, headerID int64, metadata types.ValueMetadata, end string) error {
@@ -139,7 +139,7 @@ func (repository *FlipStorageRepository) insertBidEnd(diffID, headerID int64, me
 		return err
 	}
 
-	return repository.insertRecordWithAddressAndBidId(diffID, headerID, InsertFlipBidEndQuery, bidId, end)
+	return shared.InsertRecordWithAddressAndBidId(diffID, headerID, InsertFlipBidEndQuery, bidId, end, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlipStorageRepository) insertBidUsr(diffID, headerID int64, metadata types.ValueMetadata, usr string) error {
@@ -148,7 +148,7 @@ func (repository *FlipStorageRepository) insertBidUsr(diffID, headerID int64, me
 		return err
 	}
 
-	return repository.insertRecordWithAddressAndBidId(diffID, headerID, InsertFlipBidUsrQuery, bidId, usr)
+	return shared.InsertRecordWithAddressAndBidId(diffID, headerID, InsertFlipBidUsrQuery, bidId, usr, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlipStorageRepository) insertBidGal(diffID, headerID int64, metadata types.ValueMetadata, gal string) error {
@@ -157,7 +157,7 @@ func (repository *FlipStorageRepository) insertBidGal(diffID, headerID int64, me
 		return err
 	}
 
-	return repository.insertRecordWithAddressAndBidId(diffID, headerID, InsertFlipBidGalQuery, bidId, gal)
+	return shared.InsertRecordWithAddressAndBidId(diffID, headerID, InsertFlipBidGalQuery, bidId, gal, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlipStorageRepository) insertBidTab(diffID, headerID int64, metadata types.ValueMetadata, tab string) error {
@@ -166,7 +166,7 @@ func (repository *FlipStorageRepository) insertBidTab(diffID, headerID int64, me
 		return err
 	}
 
-	return repository.insertRecordWithAddressAndBidId(diffID, headerID, InsertFlipBidTabQuery, bidId, tab)
+	return shared.InsertRecordWithAddressAndBidId(diffID, headerID, InsertFlipBidTabQuery, bidId, tab, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlipStorageRepository) insertPackedValueRecord(diffID, headerID int64, metadata types.ValueMetadata, packedValues map[int]string) error {
@@ -191,57 +191,6 @@ func (repository *FlipStorageRepository) insertPackedValueRecord(diffID, headerI
 		}
 	}
 	return nil
-}
-
-func (repository *FlipStorageRepository) insertRecordWithAddress(diffID, headerID int64, query, value string) error {
-	tx, txErr := repository.db.Beginx()
-	if txErr != nil {
-		return txErr
-	}
-
-	addressId, addressErr := shared.GetOrCreateAddressInTransaction(repository.ContractAddress, tx)
-	if addressErr != nil {
-		rollbackErr := tx.Rollback()
-		if rollbackErr != nil {
-			return shared.FormatRollbackError("flip address", addressErr.Error())
-		}
-		return addressErr
-	}
-	_, insertErr := tx.Exec(query, diffID, headerID, addressId, value)
-	if insertErr != nil {
-		rollbackErr := tx.Rollback()
-		if rollbackErr != nil {
-			return shared.FormatRollbackError("flip field with address", insertErr.Error())
-		}
-		return insertErr
-	}
-
-	return tx.Commit()
-}
-
-func (repository *FlipStorageRepository) insertRecordWithAddressAndBidId(diffID, headerID int64, query, bidId, value string) error {
-	tx, txErr := repository.db.Beginx()
-	if txErr != nil {
-		return txErr
-	}
-	addressId, addressErr := shared.GetOrCreateAddressInTransaction(repository.ContractAddress, tx)
-	if addressErr != nil {
-		rollbackErr := tx.Rollback()
-		if rollbackErr != nil {
-			return shared.FormatRollbackError("flip address", addressErr.Error())
-		}
-		return addressErr
-	}
-	_, insertErr := tx.Exec(query, diffID, headerID, addressId, bidId, value)
-	if insertErr != nil {
-		rollbackErr := tx.Rollback()
-		if rollbackErr != nil {
-			errorString := fmt.Sprintf("flip field with address for bid id %s", bidId)
-			return shared.FormatRollbackError(errorString, insertErr.Error())
-		}
-		return insertErr
-	}
-	return tx.Commit()
 }
 
 func getBidId(keys map[types.Key]string) (string, error) {

--- a/transformers/storage/flip/repository_test.go
+++ b/transformers/storage/flip/repository_test.go
@@ -24,7 +24,7 @@ import (
 var _ = Describe("Flip storage repository", func() {
 	var (
 		db                   = test_config.NewTestDB(test_config.NewTestNode())
-		repo                 = &flip.FlipStorageRepository{ContractAddress: test_data.FlipEthAddress()}
+		repo                 = &flip.StorageRepository{ContractAddress: test_data.FlipEthAddress()}
 		diffID, fakeHeaderID int64
 	)
 

--- a/transformers/storage/flop/initializer/initializer.go
+++ b/transformers/storage/flop/initializer/initializer.go
@@ -29,5 +29,5 @@ var StorageTransformerInitializer storage.TransformerInitializer = storage.Trans
 	StorageKeysLookup: storage.NewKeysLookup(flop.NewKeysLoader(
 		&mcdStorage.MakerStorageRepository{},
 		constants.GetContractAddress("MCD_FLOP"))),
-	Repository: &flop.FlopStorageRepository{ContractAddress: constants.GetContractAddress("MCD_FLOP")},
+	Repository: &flop.StorageRepository{ContractAddress: constants.GetContractAddress("MCD_FLOP")},
 }.NewTransformer

--- a/transformers/storage/flop/keys_loader.go
+++ b/transformers/storage/flop/keys_loader.go
@@ -17,6 +17,8 @@
 package flop
 
 import (
+	"fmt"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
@@ -43,10 +45,10 @@ var (
 	PadKey      = common.HexToHash(vdbStorage.IndexFive)
 	PadMetadata = types.GetValueMetadata(mcdStorage.Pad, nil, types.Uint256)
 
-	TtlAndTauKey      = common.HexToHash(vdbStorage.IndexSix)
+	TTLAndTauKey      = common.HexToHash(vdbStorage.IndexSix)
 	ttlAndTauTypes    = map[int]types.ValueType{0: types.Uint48, 1: types.Uint48}
 	ttlAndTauNames    = map[int]string{0: mcdStorage.Ttl, 1: mcdStorage.Tau}
-	TtlAndTauMetadata = types.GetValueMetadataForPackedSlot(mcdStorage.Packed, nil, types.PackedSlot, ttlAndTauNames, ttlAndTauTypes)
+	TTLAndTauMetadata = types.GetValueMetadataForPackedSlot(mcdStorage.Packed, nil, types.PackedSlot, ttlAndTauNames, ttlAndTauTypes)
 
 	KicksKey      = common.HexToHash(vdbStorage.IndexSeven)
 	KicksMetadata = types.GetValueMetadata(mcdStorage.Kicks, nil, types.Uint256)
@@ -75,76 +77,80 @@ func (loader *keysLoader) SetDB(db *postgres.DB) {
 }
 
 func (loader *keysLoader) LoadMappings() (map[common.Hash]types.ValueMetadata, error) {
-	mappings := loadStaticMappings()
-	mappings, wardsErr := loader.loadWardsKeys(mappings)
+	mappings := getStaticMappings()
+	mappings, wardsErr := loader.addWardsKeys(mappings)
 	if wardsErr != nil {
-		return nil, wardsErr
+		return nil, fmt.Errorf("error adding wards keys to flop storage transformer: %w", wardsErr)
 	}
-	return loader.loadBidKeys(mappings)
-}
-
-func (loader *keysLoader) loadWardsKeys(mappings map[common.Hash]types.ValueMetadata) (map[common.Hash]types.ValueMetadata, error) {
-	addresses, err := loader.storageRepository.GetWardsAddresses(loader.contractAddress)
-	if err != nil {
-		return nil, err
-	}
-	return wards.AddWardsKeys(mappings, addresses)
-}
-
-func (loader *keysLoader) loadBidKeys(mappings map[common.Hash]types.ValueMetadata) (map[common.Hash]types.ValueMetadata, error) {
-	bidIds, getBidsErr := loader.storageRepository.GetFlopBidIds(loader.contractAddress)
-	if getBidsErr != nil {
-		return nil, getBidsErr
-	}
-	for _, bidId := range bidIds {
-		hexBidId, convertErr := shared.ConvertIntStringToHex(bidId)
-		if convertErr != nil {
-			return nil, convertErr
-		}
-		mappings[getBidBidKey(hexBidId)] = getBidBidMetadata(bidId)
-		mappings[getBidLotKey(hexBidId)] = getBidLotMetadata(bidId)
-		mappings[getBidGuyTicEndKey(hexBidId)] = getBidGuyTicEndMetadata(bidId)
+	mappings, bidsErr := loader.addBidKeys(mappings)
+	if bidsErr != nil {
+		return nil, fmt.Errorf("error adding bids keys to flop storage transformer: %w", bidsErr)
 	}
 	return mappings, nil
 }
 
-func loadStaticMappings() map[common.Hash]types.ValueMetadata {
+func (loader *keysLoader) addWardsKeys(mappings map[common.Hash]types.ValueMetadata) (map[common.Hash]types.ValueMetadata, error) {
+	addresses, err := loader.storageRepository.GetWardsAddresses(loader.contractAddress)
+	if err != nil {
+		return nil, fmt.Errorf("error getting wards addresses: %w", err)
+	}
+	return wards.AddWardsKeys(mappings, addresses)
+}
+
+func (loader *keysLoader) addBidKeys(mappings map[common.Hash]types.ValueMetadata) (map[common.Hash]types.ValueMetadata, error) {
+	bidIDs, getBidsErr := loader.storageRepository.GetFlopBidIDs(loader.contractAddress)
+	if getBidsErr != nil {
+		return nil, fmt.Errorf("error getting flop bid IDs: %w", getBidsErr)
+	}
+	for _, bidID := range bidIDs {
+		hexBidID, convertErr := shared.ConvertIntStringToHex(bidID)
+		if convertErr != nil {
+			return nil, fmt.Errorf("error converting int string to hex: %w", convertErr)
+		}
+		mappings[getBidBidKey(hexBidID)] = getBidBidMetadata(bidID)
+		mappings[getBidLotKey(hexBidID)] = getBidLotMetadata(bidID)
+		mappings[getBidGuyTicEndKey(hexBidID)] = getBidGuyTicEndMetadata(bidID)
+	}
+	return mappings, nil
+}
+
+func getStaticMappings() map[common.Hash]types.ValueMetadata {
 	mappings := make(map[common.Hash]types.ValueMetadata)
 	mappings[VatKey] = VatMetadata
 	mappings[GemKey] = GemMetadata
 	mappings[BegKey] = BegMetadata
 	mappings[PadKey] = PadMetadata
-	mappings[TtlAndTauKey] = TtlAndTauMetadata
+	mappings[TTLAndTauKey] = TTLAndTauMetadata
 	mappings[KicksKey] = KicksMetadata
 	mappings[LiveKey] = LiveMetadata
 	mappings[VowKey] = VowMetadata
 	return mappings
 }
 
-func getBidBidKey(hexBidId string) common.Hash {
-	return vdbStorage.GetKeyForMapping(BidsIndex, hexBidId)
+func getBidBidKey(hexBidID string) common.Hash {
+	return vdbStorage.GetKeyForMapping(BidsIndex, hexBidID)
 }
 
-func getBidBidMetadata(bidId string) types.ValueMetadata {
-	keys := map[types.Key]string{constants.BidId: bidId}
+func getBidBidMetadata(bidID string) types.ValueMetadata {
+	keys := map[types.Key]string{constants.BidId: bidID}
 	return types.GetValueMetadata(mcdStorage.BidBid, keys, types.Uint256)
 }
 
-func getBidLotKey(hexBidId string) common.Hash {
-	return vdbStorage.GetIncrementedKey(getBidBidKey(hexBidId), 1)
+func getBidLotKey(hexBidID string) common.Hash {
+	return vdbStorage.GetIncrementedKey(getBidBidKey(hexBidID), 1)
 }
 
-func getBidLotMetadata(bidId string) types.ValueMetadata {
-	keys := map[types.Key]string{constants.BidId: bidId}
+func getBidLotMetadata(bidID string) types.ValueMetadata {
+	keys := map[types.Key]string{constants.BidId: bidID}
 	return types.GetValueMetadata(mcdStorage.BidLot, keys, types.Uint256)
 }
 
-func getBidGuyTicEndKey(hexBidId string) common.Hash {
-	return vdbStorage.GetIncrementedKey(getBidBidKey(hexBidId), 2)
+func getBidGuyTicEndKey(hexBidID string) common.Hash {
+	return vdbStorage.GetIncrementedKey(getBidBidKey(hexBidID), 2)
 }
 
-func getBidGuyTicEndMetadata(bidId string) types.ValueMetadata {
-	keys := map[types.Key]string{constants.BidId: bidId}
+func getBidGuyTicEndMetadata(bidID string) types.ValueMetadata {
+	keys := map[types.Key]string{constants.BidId: bidID}
 	packedTypes := map[int]types.ValueType{0: types.Address, 1: types.Uint48, 2: types.Uint48}
 	packedNames := map[int]string{0: mcdStorage.BidGuy, 1: mcdStorage.BidTic, 2: mcdStorage.BidEnd}
 	return types.GetValueMetadataForPackedSlot(mcdStorage.Packed, keys, types.PackedSlot, packedNames, packedTypes)

--- a/transformers/storage/flop/keys_loader_test.go
+++ b/transformers/storage/flop/keys_loader_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Flop storage keys loader", func() {
 		Expect(mappings[flop.GemKey]).To(Equal(flop.GemMetadata))
 		Expect(mappings[flop.BegKey]).To(Equal(flop.BegMetadata))
 		Expect(mappings[flop.PadKey]).To(Equal(flop.PadMetadata))
-		Expect(mappings[flop.TtlAndTauKey]).To(Equal(flop.TtlAndTauMetadata))
+		Expect(mappings[flop.TTLAndTauKey]).To(Equal(flop.TTLAndTauMetadata))
 		Expect(mappings[flop.KicksKey]).To(Equal(flop.KicksMetadata))
 		Expect(mappings[flop.LiveKey]).To(Equal(flop.LiveMetadata))
 		Expect(mappings[flop.VowKey]).To(Equal(flop.VowMetadata))
@@ -93,7 +93,7 @@ var _ = Describe("Flop storage keys loader", func() {
 	Describe("bid", func() {
 		Describe("when getting flop bid IDs fails", func() {
 			It("returns error", func() {
-				storageRepository.GetFlopBidIdsError = fakes.FakeError
+				storageRepository.GetFlopBidIDsError = fakes.FakeError
 
 				_, err := storageKeysLoader.LoadMappings()
 
@@ -104,19 +104,19 @@ var _ = Describe("Flop storage keys loader", func() {
 
 		Describe("when getting flop bid IDs succeeds", func() {
 			var (
-				fakeBidId string
+				fakeBidID string
 				bidBidKey common.Hash
 				mappings  map[common.Hash]types.ValueMetadata
 			)
 
 			BeforeEach(func() {
-				fakeBidId = "42"
-				fakeHexBidId, conversionErr := shared.ConvertIntStringToHex(fakeBidId)
+				fakeBidID = "42"
+				fakeHexBidID, conversionErr := shared.ConvertIntStringToHex(fakeBidID)
 
 				Expect(conversionErr).NotTo(HaveOccurred())
 
-				bidBidKey = common.BytesToHash(crypto.Keccak256(common.FromHex(fakeHexBidId + flop.BidsIndex)))
-				storageRepository.FlopBidIds = []string{fakeBidId}
+				bidBidKey = common.BytesToHash(crypto.Keccak256(common.FromHex(fakeHexBidID + flop.BidsIndex)))
+				storageRepository.FlopBidIDs = []string{fakeBidID}
 				var err error
 				mappings, err = storageKeysLoader.LoadMappings()
 				Expect(err).NotTo(HaveOccurred())
@@ -125,7 +125,7 @@ var _ = Describe("Flop storage keys loader", func() {
 			It("returns value metadata for bid bid", func() {
 				expectedMetadata := types.ValueMetadata{
 					Name: mcdStorage.BidBid,
-					Keys: map[types.Key]string{constants.BidId: fakeBidId},
+					Keys: map[types.Key]string{constants.BidId: fakeBidID},
 					Type: types.Uint256,
 				}
 
@@ -136,7 +136,7 @@ var _ = Describe("Flop storage keys loader", func() {
 				bidLotKey := vdbStorage.GetIncrementedKey(bidBidKey, 1)
 				expectedMetadata := types.ValueMetadata{
 					Name: mcdStorage.BidLot,
-					Keys: map[types.Key]string{constants.BidId: fakeBidId},
+					Keys: map[types.Key]string{constants.BidId: fakeBidID},
 					Type: types.Uint256,
 				}
 
@@ -147,7 +147,7 @@ var _ = Describe("Flop storage keys loader", func() {
 				bidGuyKey := vdbStorage.GetIncrementedKey(bidBidKey, 2)
 				expectedMetadata := types.ValueMetadata{
 					Name:        mcdStorage.Packed,
-					Keys:        map[types.Key]string{constants.BidId: fakeBidId},
+					Keys:        map[types.Key]string{constants.BidId: fakeBidID},
 					Type:        types.PackedSlot,
 					PackedTypes: map[int]types.ValueType{0: types.Address, 1: types.Uint48, 2: types.Uint48},
 					PackedNames: map[int]string{0: mcdStorage.BidGuy, 1: mcdStorage.BidTic, 2: mcdStorage.BidEnd},

--- a/transformers/storage/flop/repository.go
+++ b/transformers/storage/flop/repository.go
@@ -16,7 +16,7 @@ const (
 	insertFlopGemQuery   = `INSERT INTO maker.flop_gem (diff_id, header_id, address_id, gem) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
 	insertFlopBegQuery   = `INSERT INTO maker.flop_beg (diff_id, header_id, address_id, beg) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
 	insertFlopPadQuery   = `INSERT INTO maker.flop_pad (diff_id, header_id, address_id, pad) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
-	insertFlopTtlQuery   = `INSERT INTO maker.flop_ttl (diff_id, header_id, address_id, ttl) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
+	insertFlopTTLQuery   = `INSERT INTO maker.flop_ttl (diff_id, header_id, address_id, ttl) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
 	insertFlopTauQuery   = `INSERT INTO maker.flop_tau (diff_id, header_id, address_id, tau) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
 	InsertFlopKicksQuery = `INSERT INTO maker.flop_kicks (diff_id, header_id, address_id, kicks) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
 	insertFlopLiveQuery  = `INSERT INTO maker.flop_live (diff_id, header_id, address_id, live) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
@@ -29,12 +29,12 @@ const (
 	InsertFlopBidEndQuery = `INSERT INTO Maker.flop_bid_end (diff_id, header_id, address_id, bid_id, "end") VALUES ($1, $2, $3, $4, $5) ON CONFLICT DO NOTHING`
 )
 
-type FlopStorageRepository struct {
+type StorageRepository struct {
 	ContractAddress string
 	db              *postgres.DB
 }
 
-func (repository *FlopStorageRepository) Create(diffID, headerID int64, metadata types.ValueMetadata, value interface{}) error {
+func (repository *StorageRepository) Create(diffID, headerID int64, metadata types.ValueMetadata, value interface{}) error {
 	switch metadata.Name {
 	case storage.Vat:
 		return repository.insertVat(diffID, headerID, value.(string))
@@ -63,92 +63,153 @@ func (repository *FlopStorageRepository) Create(diffID, headerID int64, metadata
 	}
 }
 
-func (repository *FlopStorageRepository) SetDB(db *postgres.DB) {
+func (repository *StorageRepository) SetDB(db *postgres.DB) {
 	repository.db = db
 }
 
-func (repository *FlopStorageRepository) insertVat(diffID, headerID int64, vat string) error {
-	return shared.InsertRecordWithAddress(diffID, headerID, insertFlopVatQuery, vat, repository.ContractAddress, repository.db)
-}
-
-func (repository *FlopStorageRepository) insertGem(diffID, headerID int64, gem string) error {
-	return shared.InsertRecordWithAddress(diffID, headerID, insertFlopGemQuery, gem, repository.ContractAddress, repository.db)
-}
-
-func (repository *FlopStorageRepository) insertBeg(diffID, headerID int64, beg string) error {
-	return shared.InsertRecordWithAddress(diffID, headerID, insertFlopBegQuery, beg, repository.ContractAddress, repository.db)
-}
-
-func (repository *FlopStorageRepository) insertPad(diffID, headerID int64, pad string) error {
-	return shared.InsertRecordWithAddress(diffID, headerID, insertFlopPadQuery, pad, repository.ContractAddress, repository.db)
-}
-
-func (repository *FlopStorageRepository) insertTtl(diffID, headerID int64, ttl string) error {
-	return shared.InsertRecordWithAddress(diffID, headerID, insertFlopTtlQuery, ttl, repository.ContractAddress, repository.db)
-}
-
-func (repository *FlopStorageRepository) insertTau(diffID, headerID int64, tau string) error {
-	return shared.InsertRecordWithAddress(diffID, headerID, insertFlopTauQuery, tau, repository.ContractAddress, repository.db)
-}
-
-func (repository *FlopStorageRepository) insertKicks(diffID, headerID int64, kicks string) error {
-	return shared.InsertRecordWithAddress(diffID, headerID, InsertFlopKicksQuery, kicks, repository.ContractAddress, repository.db)
-}
-
-func (repository *FlopStorageRepository) insertLive(diffID, headerID int64, live string) error {
-	return shared.InsertRecordWithAddress(diffID, headerID, insertFlopLiveQuery, live, repository.ContractAddress, repository.db)
-}
-
-func (repository *FlopStorageRepository) insertVow(diffID, headerID int64, vow string) error {
-	return shared.InsertRecordWithAddress(diffID, headerID, insertFlopVowQuery, vow, repository.ContractAddress, repository.db)
-}
-
-func (repository *FlopStorageRepository) insertBidBid(diffID, headerID int64, metadata types.ValueMetadata, bid string) error {
-	bidId, err := getBidId(metadata.Keys)
+func (repository *StorageRepository) insertVat(diffID, headerID int64, vat string) error {
+	err := shared.InsertRecordWithAddress(diffID, headerID, insertFlopVatQuery, vat, repository.ContractAddress, repository.db)
 	if err != nil {
-		return err
+		return fmt.Errorf("error inserting flop vat %s from diff ID %d: %w", vat, diffID, err)
 	}
-	return shared.InsertRecordWithAddressAndBidId(diffID, headerID, InsertFlopBidBidQuery, bidId, bid, repository.ContractAddress, repository.db)
+	return nil
 }
 
-func (repository *FlopStorageRepository) insertBidLot(diffID, headerID int64, metadata types.ValueMetadata, lot string) error {
-	bidId, err := getBidId(metadata.Keys)
+func (repository *StorageRepository) insertGem(diffID, headerID int64, gem string) error {
+	err := shared.InsertRecordWithAddress(diffID, headerID, insertFlopGemQuery, gem, repository.ContractAddress, repository.db)
 	if err != nil {
-		return err
+		return fmt.Errorf("error inserting flop gem %s from diff ID %d: %w", gem, diffID, err)
 	}
-	return shared.InsertRecordWithAddressAndBidId(diffID, headerID, InsertFlopBidLotQuery, bidId, lot, repository.ContractAddress, repository.db)
+	return nil
 }
 
-func (repository *FlopStorageRepository) insertBidGuy(diffID, headerID int64, metadata types.ValueMetadata, guy string) error {
-	bidId, err := getBidId(metadata.Keys)
+func (repository *StorageRepository) insertBeg(diffID, headerID int64, beg string) error {
+	err := shared.InsertRecordWithAddress(diffID, headerID, insertFlopBegQuery, beg, repository.ContractAddress, repository.db)
 	if err != nil {
-		return err
+		return fmt.Errorf("error inserting flop beg %s from diff ID %d: %w", beg, diffID, err)
 	}
-	return shared.InsertRecordWithAddressAndBidId(diffID, headerID, InsertFlopBidGuyQuery, bidId, guy, repository.ContractAddress, repository.db)
+	return nil
 }
 
-func (repository *FlopStorageRepository) insertBidTic(diffID, headerID int64, metadata types.ValueMetadata, tic string) error {
-	bidId, err := getBidId(metadata.Keys)
+func (repository *StorageRepository) insertPad(diffID, headerID int64, pad string) error {
+	err := shared.InsertRecordWithAddress(diffID, headerID, insertFlopPadQuery, pad, repository.ContractAddress, repository.db)
 	if err != nil {
-		return err
+		return fmt.Errorf("error inserting flop pad %s from diff ID %d: %w", pad, diffID, err)
 	}
-	return shared.InsertRecordWithAddressAndBidId(diffID, headerID, InsertFlopBidTicQuery, bidId, tic, repository.ContractAddress, repository.db)
+	return nil
 }
 
-func (repository *FlopStorageRepository) insertBidEnd(diffID, headerID int64, metadata types.ValueMetadata, end string) error {
-	bidId, err := getBidId(metadata.Keys)
+func (repository *StorageRepository) insertTTL(diffID, headerID int64, ttl string) error {
+	err := shared.InsertRecordWithAddress(diffID, headerID, insertFlopTTLQuery, ttl, repository.ContractAddress, repository.db)
 	if err != nil {
-		return err
+		return fmt.Errorf("error inserting flop ttl %s from diff ID %d: %w", ttl, diffID, err)
 	}
-	return shared.InsertRecordWithAddressAndBidId(diffID, headerID, InsertFlopBidEndQuery, bidId, end, repository.ContractAddress, repository.db)
+	return nil
 }
 
-func (repository *FlopStorageRepository) insertPackedValueRecord(diffID, headerID int64, metadata types.ValueMetadata, packedValues map[int]string) error {
+func (repository *StorageRepository) insertTau(diffID, headerID int64, tau string) error {
+	err := shared.InsertRecordWithAddress(diffID, headerID, insertFlopTauQuery, tau, repository.ContractAddress, repository.db)
+	if err != nil {
+		return fmt.Errorf("error inserting flop tau %s from diff ID %d: %w", tau, diffID, err)
+	}
+	return nil
+}
+
+func (repository *StorageRepository) insertKicks(diffID, headerID int64, kicks string) error {
+	err := shared.InsertRecordWithAddress(diffID, headerID, InsertFlopKicksQuery, kicks, repository.ContractAddress, repository.db)
+	if err != nil {
+		return fmt.Errorf("error inserting flop kicks %s from diff ID %d: %w", kicks, diffID, err)
+	}
+	return nil
+}
+
+func (repository *StorageRepository) insertLive(diffID, headerID int64, live string) error {
+	err := shared.InsertRecordWithAddress(diffID, headerID, insertFlopLiveQuery, live, repository.ContractAddress, repository.db)
+	if err != nil {
+		return fmt.Errorf("error inserting flop live %s from diff ID %d: %w", live, diffID, err)
+	}
+	return nil
+}
+
+func (repository *StorageRepository) insertVow(diffID, headerID int64, vow string) error {
+	err := shared.InsertRecordWithAddress(diffID, headerID, insertFlopVowQuery, vow, repository.ContractAddress, repository.db)
+	if err != nil {
+		return fmt.Errorf("error inserting flop vow %s from diff ID %d: %w", vow, diffID, err)
+	}
+	return nil
+}
+
+func (repository *StorageRepository) insertBidBid(diffID, headerID int64, metadata types.ValueMetadata, bid string) error {
+	bidID, err := getBidID(metadata.Keys)
+	if err != nil {
+		return fmt.Errorf("error getting bid ID for bid bid: %w", err)
+	}
+	insertErr := shared.InsertRecordWithAddressAndBidID(diffID, headerID, InsertFlopBidBidQuery, bidID, bid, repository.ContractAddress, repository.db)
+	if insertErr != nil {
+		msg := fmt.Sprintf("error inserting flop bid %s bid %s from diff ID %d", bidID, bid, diffID)
+		return fmt.Errorf("%s: %w", msg, insertErr)
+	}
+	return nil
+}
+
+func (repository *StorageRepository) insertBidLot(diffID, headerID int64, metadata types.ValueMetadata, lot string) error {
+	bidID, err := getBidID(metadata.Keys)
+	if err != nil {
+		return fmt.Errorf("error getting bid ID for bid lot: %w", err)
+	}
+	insertErr := shared.InsertRecordWithAddressAndBidID(diffID, headerID, InsertFlopBidLotQuery, bidID, lot, repository.ContractAddress, repository.db)
+	if insertErr != nil {
+		msg := fmt.Sprintf("error inserting flop bid %s lot %s from diff ID %d", bidID, lot, diffID)
+		return fmt.Errorf("%s: %w", msg, insertErr)
+	}
+	return nil
+}
+
+func (repository *StorageRepository) insertBidGuy(diffID, headerID int64, metadata types.ValueMetadata, guy string) error {
+	bidID, err := getBidID(metadata.Keys)
+	if err != nil {
+		return fmt.Errorf("error getting bid ID for bid guy: %w", err)
+	}
+	insertErr := shared.InsertRecordWithAddressAndBidID(diffID, headerID, InsertFlopBidGuyQuery, bidID, guy, repository.ContractAddress, repository.db)
+	if insertErr != nil {
+		msg := fmt.Sprintf("error inserting flop bid %s guy %s from diff ID %d", bidID, guy, diffID)
+		return fmt.Errorf("%s: %w", msg, insertErr)
+	}
+	return nil
+}
+
+func (repository *StorageRepository) insertBidTic(diffID, headerID int64, metadata types.ValueMetadata, tic string) error {
+	bidID, err := getBidID(metadata.Keys)
+	if err != nil {
+		return fmt.Errorf("error getting bid ID for flop bid tic: %w", err)
+	}
+	insertErr := shared.InsertRecordWithAddressAndBidID(diffID, headerID, InsertFlopBidTicQuery, bidID, tic, repository.ContractAddress, repository.db)
+	if insertErr != nil {
+		msg := fmt.Sprintf("error inserting flop bid %s tic %s from diff ID %d", bidID, tic, diffID)
+		return fmt.Errorf("%s: %w", msg, insertErr)
+	}
+	return nil
+}
+
+func (repository *StorageRepository) insertBidEnd(diffID, headerID int64, metadata types.ValueMetadata, end string) error {
+	bidID, err := getBidID(metadata.Keys)
+	if err != nil {
+		return fmt.Errorf("error getting bid ID for flop bid end: %w", err)
+	}
+	insertErr := shared.InsertRecordWithAddressAndBidID(diffID, headerID, InsertFlopBidEndQuery, bidID, end, repository.ContractAddress, repository.db)
+	if insertErr != nil {
+		msg := fmt.Sprintf("error inserting flop bid %s end %s from diff ID %d", bidID, end, diffID)
+		return fmt.Errorf("%s: %w", msg, insertErr)
+	}
+	return nil
+}
+
+func (repository *StorageRepository) insertPackedValueRecord(diffID, headerID int64, metadata types.ValueMetadata, packedValues map[int]string) error {
 	var insertErr error
 	for order, value := range packedValues {
 		switch metadata.PackedNames[order] {
 		case storage.Ttl:
-			insertErr = repository.insertTtl(diffID, headerID, value)
+			insertErr = repository.insertTTL(diffID, headerID, value)
 		case storage.Tau:
 			insertErr = repository.insertTau(diffID, headerID, value)
 		case storage.BidGuy:
@@ -161,16 +222,16 @@ func (repository *FlopStorageRepository) insertPackedValueRecord(diffID, headerI
 			panic(fmt.Sprintf("unrecognized flop contract storage name in packed values: %s", metadata.Name))
 		}
 		if insertErr != nil {
-			return insertErr
+			return fmt.Errorf("error inserting flop packed value from diff ID %d: %w", diffID, insertErr)
 		}
 	}
 	return nil
 }
 
-func getBidId(keys map[types.Key]string) (string, error) {
-	bidId, ok := keys[constants.BidId]
+func getBidID(keys map[types.Key]string) (string, error) {
+	bidID, ok := keys[constants.BidId]
 	if !ok {
 		return "", types.ErrMetadataMalformed{MissingData: constants.BidId}
 	}
-	return bidId, nil
+	return bidID, nil
 }

--- a/transformers/storage/flop/repository.go
+++ b/transformers/storage/flop/repository.go
@@ -68,39 +68,39 @@ func (repository *FlopStorageRepository) SetDB(db *postgres.DB) {
 }
 
 func (repository *FlopStorageRepository) insertVat(diffID, headerID int64, vat string) error {
-	return repository.insertRecordWithAddress(diffID, headerID, insertFlopVatQuery, vat)
+	return shared.InsertRecordWithAddress(diffID, headerID, insertFlopVatQuery, vat, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlopStorageRepository) insertGem(diffID, headerID int64, gem string) error {
-	return repository.insertRecordWithAddress(diffID, headerID, insertFlopGemQuery, gem)
+	return shared.InsertRecordWithAddress(diffID, headerID, insertFlopGemQuery, gem, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlopStorageRepository) insertBeg(diffID, headerID int64, beg string) error {
-	return repository.insertRecordWithAddress(diffID, headerID, insertFlopBegQuery, beg)
+	return shared.InsertRecordWithAddress(diffID, headerID, insertFlopBegQuery, beg, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlopStorageRepository) insertPad(diffID, headerID int64, pad string) error {
-	return repository.insertRecordWithAddress(diffID, headerID, insertFlopPadQuery, pad)
+	return shared.InsertRecordWithAddress(diffID, headerID, insertFlopPadQuery, pad, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlopStorageRepository) insertTtl(diffID, headerID int64, ttl string) error {
-	return repository.insertRecordWithAddress(diffID, headerID, insertFlopTtlQuery, ttl)
+	return shared.InsertRecordWithAddress(diffID, headerID, insertFlopTtlQuery, ttl, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlopStorageRepository) insertTau(diffID, headerID int64, tau string) error {
-	return repository.insertRecordWithAddress(diffID, headerID, insertFlopTauQuery, tau)
+	return shared.InsertRecordWithAddress(diffID, headerID, insertFlopTauQuery, tau, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlopStorageRepository) insertKicks(diffID, headerID int64, kicks string) error {
-	return repository.insertRecordWithAddress(diffID, headerID, InsertFlopKicksQuery, kicks)
+	return shared.InsertRecordWithAddress(diffID, headerID, InsertFlopKicksQuery, kicks, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlopStorageRepository) insertLive(diffID, headerID int64, live string) error {
-	return repository.insertRecordWithAddress(diffID, headerID, insertFlopLiveQuery, live)
+	return shared.InsertRecordWithAddress(diffID, headerID, insertFlopLiveQuery, live, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlopStorageRepository) insertVow(diffID, headerID int64, vow string) error {
-	return repository.insertRecordWithAddress(diffID, headerID, insertFlopVowQuery, vow)
+	return shared.InsertRecordWithAddress(diffID, headerID, insertFlopVowQuery, vow, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlopStorageRepository) insertBidBid(diffID, headerID int64, metadata types.ValueMetadata, bid string) error {
@@ -108,7 +108,7 @@ func (repository *FlopStorageRepository) insertBidBid(diffID, headerID int64, me
 	if err != nil {
 		return err
 	}
-	return repository.insertRecordWithAddressAndBidId(diffID, headerID, InsertFlopBidBidQuery, bidId, bid)
+	return shared.InsertRecordWithAddressAndBidId(diffID, headerID, InsertFlopBidBidQuery, bidId, bid, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlopStorageRepository) insertBidLot(diffID, headerID int64, metadata types.ValueMetadata, lot string) error {
@@ -116,7 +116,7 @@ func (repository *FlopStorageRepository) insertBidLot(diffID, headerID int64, me
 	if err != nil {
 		return err
 	}
-	return repository.insertRecordWithAddressAndBidId(diffID, headerID, InsertFlopBidLotQuery, bidId, lot)
+	return shared.InsertRecordWithAddressAndBidId(diffID, headerID, InsertFlopBidLotQuery, bidId, lot, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlopStorageRepository) insertBidGuy(diffID, headerID int64, metadata types.ValueMetadata, guy string) error {
@@ -124,7 +124,7 @@ func (repository *FlopStorageRepository) insertBidGuy(diffID, headerID int64, me
 	if err != nil {
 		return err
 	}
-	return repository.insertRecordWithAddressAndBidId(diffID, headerID, InsertFlopBidGuyQuery, bidId, guy)
+	return shared.InsertRecordWithAddressAndBidId(diffID, headerID, InsertFlopBidGuyQuery, bidId, guy, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlopStorageRepository) insertBidTic(diffID, headerID int64, metadata types.ValueMetadata, tic string) error {
@@ -132,7 +132,7 @@ func (repository *FlopStorageRepository) insertBidTic(diffID, headerID int64, me
 	if err != nil {
 		return err
 	}
-	return repository.insertRecordWithAddressAndBidId(diffID, headerID, InsertFlopBidTicQuery, bidId, tic)
+	return shared.InsertRecordWithAddressAndBidId(diffID, headerID, InsertFlopBidTicQuery, bidId, tic, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlopStorageRepository) insertBidEnd(diffID, headerID int64, metadata types.ValueMetadata, end string) error {
@@ -140,7 +140,7 @@ func (repository *FlopStorageRepository) insertBidEnd(diffID, headerID int64, me
 	if err != nil {
 		return err
 	}
-	return repository.insertRecordWithAddressAndBidId(diffID, headerID, InsertFlopBidEndQuery, bidId, end)
+	return shared.InsertRecordWithAddressAndBidId(diffID, headerID, InsertFlopBidEndQuery, bidId, end, repository.ContractAddress, repository.db)
 }
 
 func (repository *FlopStorageRepository) insertPackedValueRecord(diffID, headerID int64, metadata types.ValueMetadata, packedValues map[int]string) error {
@@ -173,54 +173,4 @@ func getBidId(keys map[types.Key]string) (string, error) {
 		return "", types.ErrMetadataMalformed{MissingData: constants.BidId}
 	}
 	return bidId, nil
-}
-
-func (repository *FlopStorageRepository) insertRecordWithAddress(diffID, headerID int64, query, value string) error {
-	tx, txErr := repository.db.Beginx()
-	if txErr != nil {
-		return txErr
-	}
-	addressId, addressErr := shared.GetOrCreateAddress(repository.ContractAddress, repository.db)
-	if addressErr != nil {
-		rollbackErr := tx.Rollback()
-		if rollbackErr != nil {
-			return shared.FormatRollbackError("flop address", addressErr.Error())
-		}
-		return addressErr
-	}
-	_, insertErr := tx.Exec(query, diffID, headerID, addressId, value)
-	if insertErr != nil {
-		rollbackErr := tx.Rollback()
-		if rollbackErr != nil {
-			return shared.FormatRollbackError("flop field with address", insertErr.Error())
-		}
-		return insertErr
-	}
-
-	return tx.Commit()
-}
-
-func (repository *FlopStorageRepository) insertRecordWithAddressAndBidId(diffID, headerID int64, query, bidId, value string) error {
-	tx, txErr := repository.db.Beginx()
-	if txErr != nil {
-		return txErr
-	}
-	addressId, addressErr := shared.GetOrCreateAddress(repository.ContractAddress, repository.db)
-	if addressErr != nil {
-		rollbackErr := tx.Rollback()
-		if rollbackErr != nil {
-			return shared.FormatRollbackError("flop address", addressErr.Error())
-		}
-		return addressErr
-	}
-	_, insertErr := tx.Exec(query, diffID, headerID, addressId, bidId, value)
-	if insertErr != nil {
-		rollbackErr := tx.Rollback()
-		if rollbackErr != nil {
-			errorString := fmt.Sprintf("flop field with address for bid id %s", bidId)
-			return shared.FormatRollbackError(errorString, insertErr.Error())
-		}
-		return insertErr
-	}
-	return tx.Commit()
 }

--- a/transformers/storage/flop/repository_test.go
+++ b/transformers/storage/flop/repository_test.go
@@ -24,7 +24,7 @@ import (
 var _ = Describe("Flop storage repository", func() {
 	var (
 		db                   = test_config.NewTestDB(test_config.NewTestNode())
-		repo                 = &flop.FlopStorageRepository{ContractAddress: test_data.FlopAddress()}
+		repo                 = &flop.StorageRepository{ContractAddress: test_data.FlopAddress()}
 		blockNumber          int64
 		diffID, fakeHeaderID int64
 	)

--- a/transformers/storage/jug/initializer/initializer.go
+++ b/transformers/storage/jug/initializer/initializer.go
@@ -28,5 +28,5 @@ var jugAddress = constants.GetContractAddress("MCD_JUG")
 var StorageTransformerInitializer storage.TransformerInitializer = storage.Transformer{
 	Address:           common.HexToAddress(jugAddress),
 	StorageKeysLookup: storage.NewKeysLookup(jug.NewKeysLoader(&mcdStorage.MakerStorageRepository{}, jugAddress)),
-	Repository:        &jug.JugStorageRepository{ContractAddress: jugAddress},
+	Repository:        &jug.StorageRepository{ContractAddress: jugAddress},
 }.NewTransformer

--- a/transformers/storage/jug/repository_test.go
+++ b/transformers/storage/jug/repository_test.go
@@ -42,13 +42,13 @@ var _ = Describe("Jug storage repository", func() {
 		db                   = test_config.NewTestDB(test_config.NewTestNode())
 		fakeAddress          = "0x12345"
 		fakeUint256          = strconv.Itoa(rand.Intn(1000000))
-		repo                 jug.JugStorageRepository
+		repo                 jug.StorageRepository
 		diffID, fakeHeaderID int64
 	)
 
 	BeforeEach(func() {
 		test_config.CleanTestDB(db)
-		repo = jug.JugStorageRepository{ContractAddress: test_data.JugAddress()}
+		repo = jug.StorageRepository{ContractAddress: test_data.JugAddress()}
 		repo.SetDB(db)
 
 		headerRepository := repositories.NewHeaderRepository(db)

--- a/transformers/storage/pot/initializer/initializer.go
+++ b/transformers/storage/pot/initializer/initializer.go
@@ -12,5 +12,5 @@ var potAddress = constants.GetContractAddress("MCD_POT")
 var StorageTransformerInitializer storage.TransformerInitializer = storage.Transformer{
 	Address:           common.HexToAddress(constants.GetContractAddress("MCD_POT")),
 	StorageKeysLookup: storage.NewKeysLookup(pot.NewKeysLoader(&mcdStorage.MakerStorageRepository{}, potAddress)),
-	Repository:        &pot.PotStorageRepository{},
+	Repository:        &pot.StorageRepository{},
 }.NewTransformer

--- a/transformers/storage/pot/repository_test.go
+++ b/transformers/storage/pot/repository_test.go
@@ -23,7 +23,7 @@ import (
 var _ = Describe("Pot storage repository", func() {
 	var (
 		db                   = test_config.NewTestDB(test_config.NewTestNode())
-		repo                 pot.PotStorageRepository
+		repo                 pot.StorageRepository
 		fakeAddress          = "0x" + fakes.RandomString(40)
 		fakeUint256          = strconv.Itoa(rand.Intn(1000000))
 		diffID, fakeHeaderID int64
@@ -31,7 +31,7 @@ var _ = Describe("Pot storage repository", func() {
 
 	BeforeEach(func() {
 		test_config.CleanTestDB(db)
-		repo = pot.PotStorageRepository{ContractAddress: test_data.PotAddress()}
+		repo = pot.StorageRepository{ContractAddress: test_data.PotAddress()}
 		repo.SetDB(db)
 		headerRepository := repositories.NewHeaderRepository(db)
 		var insertHeaderErr error

--- a/transformers/storage/repository.go
+++ b/transformers/storage/repository.go
@@ -17,7 +17,6 @@
 package storage
 
 import (
-	"errors"
 	"strconv"
 
 	vdbRepository "github.com/makerdao/vulcanizedb/libraries/shared/repository"
@@ -29,14 +28,12 @@ type Urn struct {
 	Identifier string
 }
 
-var ErrNoFlips = errors.New("no flips exist in db")
-
 type IMakerStorageRepository interface {
 	GetCdpis() ([]string, error)
 	GetDaiKeys() ([]string, error)
-	GetFlapBidIds(string) ([]string, error)
-	GetFlipBidIds(contractAddress string) ([]string, error)
-	GetFlopBidIds(contractAddress string) ([]string, error)
+	GetFlapBidIDs(string) ([]string, error)
+	GetFlipBidIDs(contractAddress string) ([]string, error)
+	GetFlopBidIDs(contractAddress string) ([]string, error)
 	GetGemKeys() ([]Urn, error)
 	GetIlks() ([]string, error)
 	GetOwners() ([]string, error)
@@ -53,13 +50,13 @@ type MakerStorageRepository struct {
 	db *postgres.DB
 }
 
-func (repository *MakerStorageRepository) GetFlapBidIds(contractAddress string) ([]string, error) {
-	var bidIds []string
-	addressId, addressErr := repository.GetOrCreateAddress(contractAddress)
+func (repository *MakerStorageRepository) GetFlapBidIDs(contractAddress string) ([]string, error) {
+	var bidIDs []string
+	addressID, addressErr := repository.GetOrCreateAddress(contractAddress)
 	if addressErr != nil {
 		return []string{}, addressErr
 	}
-	err := repository.db.Select(&bidIds, `
+	err := repository.db.Select(&bidIDs, `
 		SELECT bid_id FROM maker.flap_kick WHERE address_id = $1
 		UNION
 		SELECT kicks FROM maker.flap_kicks WHERE address_id = $1
@@ -68,8 +65,8 @@ func (repository *MakerStorageRepository) GetFlapBidIds(contractAddress string) 
 		UNION
 		SELECT bid_id from maker.deal WHERE address_id = $1
 		UNION
-		SELECT bid_id from maker.yank WHERE address_id = $1`, addressId)
-	return bidIds, err
+		SELECT bid_id from maker.yank WHERE address_id = $1`, addressID)
+	return bidIDs, err
 }
 
 func (repository *MakerStorageRepository) GetDaiKeys() ([]string, error) {
@@ -192,13 +189,13 @@ func (repository *MakerStorageRepository) GetOwners() ([]string, error) {
 	return owners, err
 }
 
-func (repository *MakerStorageRepository) GetFlipBidIds(contractAddress string) ([]string, error) {
-	var bidIds []string
-	addressId, addressErr := repository.GetOrCreateAddress(contractAddress)
+func (repository *MakerStorageRepository) GetFlipBidIDs(contractAddress string) ([]string, error) {
+	var bidIDs []string
+	addressID, addressErr := repository.GetOrCreateAddress(contractAddress)
 	if addressErr != nil {
 		return []string{}, addressErr
 	}
-	err := repository.db.Select(&bidIds, `
+	err := repository.db.Select(&bidIDs, `
    		SELECT DISTINCT bid_id FROM maker.tick
 		WHERE address_id = $1
 		UNION
@@ -218,8 +215,8 @@ func (repository *MakerStorageRepository) GetFlipBidIds(contractAddress string) 
 		WHERE address_id = $1
 		UNION
 		SELECT DISTINCT kicks FROM maker.flip_kicks
-		WHERE address_id = $1`, addressId)
-	return bidIds, err
+		WHERE address_id = $1`, addressID)
+	return bidIDs, err
 }
 
 func (repository *MakerStorageRepository) GetPotPieUsers() ([]string, error) {
@@ -235,13 +232,13 @@ func (repository *MakerStorageRepository) GetPotPieUsers() ([]string, error) {
 	return userAddresses, err
 }
 
-func (repository *MakerStorageRepository) GetFlopBidIds(contractAddress string) ([]string, error) {
-	var bidIds []string
-	addressId, addressErr := repository.GetOrCreateAddress(contractAddress)
+func (repository *MakerStorageRepository) GetFlopBidIDs(contractAddress string) ([]string, error) {
+	var bidIDs []string
+	addressID, addressErr := repository.GetOrCreateAddress(contractAddress)
 	if addressErr != nil {
 		return []string{}, addressErr
 	}
-	err := repository.db.Select(&bidIds, `
+	err := repository.db.Select(&bidIDs, `
 		SELECT bid_id FROM maker.flop_kick
 		WHERE address_id = $1
 		UNION
@@ -255,8 +252,8 @@ func (repository *MakerStorageRepository) GetFlopBidIds(contractAddress string) 
 		WHERE address_id = $1
 		UNION
 		SELECT DISTINCT kicks FROM maker.flop_kicks
-		WHERE address_id = $1`, addressId)
-	return bidIds, err
+		WHERE address_id = $1`, addressID)
+	return bidIDs, err
 }
 
 func (repository *MakerStorageRepository) GetVatWardsAddresses() ([]string, error) {

--- a/transformers/storage/repository_test.go
+++ b/transformers/storage/repository_test.go
@@ -64,7 +64,7 @@ const (
 var _ = Describe("Maker storage repository", func() {
 	var (
 		address             = fakes.FakeAddress.Hex()
-		addressId           int64
+		addressID           int64
 		addressErr          error
 		db                  = test_config.NewTestDB(test_config.NewTestNode())
 		repository          storage.IMakerStorageRepository
@@ -87,70 +87,70 @@ var _ = Describe("Maker storage repository", func() {
 		test_config.CleanTestDB(db)
 		repository = &storage.MakerStorageRepository{}
 		repository.SetDB(db)
-		addressId, addressErr = shared.GetOrCreateAddress(address, db)
+		addressID, addressErr = shared.GetOrCreateAddress(address, db)
 		Expect(addressErr).NotTo(HaveOccurred())
 	})
 
 	Describe("getting flap bid ids", func() {
 		var (
-			bidId1, bidId2, bidId3, bidId4, bidId5, bidId6 string
+			bidID1, bidID2, bidID3, bidID4, bidID5, bidID6 string
 		)
 		BeforeEach(func() {
-			bidId1 = strconv.FormatInt(rand.Int63(), 10)
-			bidId2 = strconv.FormatInt(rand.Int63(), 10)
-			bidId3 = strconv.FormatInt(rand.Int63(), 10)
-			bidId4 = strconv.FormatInt(rand.Int63(), 10)
-			bidId5 = strconv.FormatInt(rand.Int63(), 10)
-			bidId6 = strconv.FormatInt(rand.Int63(), 10)
+			bidID1 = strconv.FormatInt(rand.Int63(), 10)
+			bidID2 = strconv.FormatInt(rand.Int63(), 10)
+			bidID3 = strconv.FormatInt(rand.Int63(), 10)
+			bidID4 = strconv.FormatInt(rand.Int63(), 10)
+			bidID5 = strconv.FormatInt(rand.Int63(), 10)
+			bidID6 = strconv.FormatInt(rand.Int63(), 10)
 		})
 
 		It("fetches unique bid ids from Flap methods", func() {
-			insertFlapKick(1, bidId1, addressId, db)
-			insertFlapKick(2, bidId1, addressId, db)
+			insertFlapKick(1, bidID1, addressID, db)
+			insertFlapKick(2, bidID1, addressID, db)
 
-			bidIds, err := repository.GetFlapBidIds(address)
+			bidIDs, err := repository.GetFlapBidIDs(address)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(bidIds)).To(Equal(1))
-			Expect(bidIds[0]).To(Equal(bidId1))
+			Expect(len(bidIDs)).To(Equal(1))
+			Expect(bidIDs[0]).To(Equal(bidID1))
 		})
 
 		It("fetches unique bid ids from flap_kick, tend, deal and yank", func() {
-			duplicateBidId := bidId1
-			insertFlapKick(1, bidId1, addressId, db)
-			insertFlapKicks(2, bidId2, addressId, db)
-			insertTend(3, bidId3, addressId, db)
-			insertDeal(4, bidId4, addressId, db)
-			insertYank(5, bidId5, addressId, db)
-			insertYank(6, duplicateBidId, addressId, db)
+			duplicateBidID := bidID1
+			insertFlapKick(1, bidID1, addressID, db)
+			insertFlapKicks(2, bidID2, addressID, db)
+			insertTend(3, bidID3, addressID, db)
+			insertDeal(4, bidID4, addressID, db)
+			insertYank(5, bidID5, addressID, db)
+			insertYank(6, duplicateBidID, addressID, db)
 
-			bidIds, err := repository.GetFlapBidIds(address)
+			bidIDs, err := repository.GetFlapBidIDs(address)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(bidIds)).To(Equal(5))
-			Expect(bidIds).To(ConsistOf(bidId1, bidId2, bidId3, bidId4, bidId5))
+			Expect(len(bidIDs)).To(Equal(5))
+			Expect(bidIDs).To(ConsistOf(bidID1, bidID2, bidID3, bidID4, bidID5))
 		})
 
 		It("fetches bid ids only for the given contract address", func() {
 			anotherAddress := address + "1"
-			anotherAddressId, addressErr := shared.GetOrCreateAddress(anotherAddress, db)
+			anotherAddressID, addressErr := shared.GetOrCreateAddress(anotherAddress, db)
 			Expect(addressErr).NotTo(HaveOccurred())
-			insertFlapKick(1, bidId1, addressId, db)
-			insertFlapKick(2, bidId2, addressId, db)
-			insertTend(3, bidId3, addressId, db)
-			insertDeal(4, bidId4, addressId, db)
-			insertYank(5, bidId5, addressId, db)
-			insertYank(6, bidId6, anotherAddressId, db)
+			insertFlapKick(1, bidID1, addressID, db)
+			insertFlapKick(2, bidID2, addressID, db)
+			insertTend(3, bidID3, addressID, db)
+			insertDeal(4, bidID4, addressID, db)
+			insertYank(5, bidID5, addressID, db)
+			insertYank(6, bidID6, anotherAddressID, db)
 
-			bidIds, err := repository.GetFlapBidIds(address)
+			bidIDs, err := repository.GetFlapBidIDs(address)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(bidIds)).To(Equal(5))
-			Expect(bidIds).To(ConsistOf(bidId1, bidId2, bidId3, bidId4, bidId5))
+			Expect(len(bidIDs)).To(Equal(5))
+			Expect(bidIDs).To(ConsistOf(bidID1, bidID2, bidID3, bidID4, bidID5))
 		})
 
 		It("does not return error if no matching rows", func() {
-			bidIds, err := repository.GetFlapBidIds(fakes.FakeAddress.Hex())
+			bidIDs, err := repository.GetFlapBidIDs(fakes.FakeAddress.Hex())
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(bidIds)).To(BeZero())
+			Expect(len(bidIDs)).To(BeZero())
 		})
 	})
 
@@ -504,121 +504,110 @@ var _ = Describe("Maker storage repository", func() {
 
 	Describe("getting flip bid ids", func() {
 		var (
-			bidId1  string
-			bidId2  string
-			bidId3  string
-			bidId4  string
-			bidId5  string
-			bidId6  string
-			bidId7  string
-			address = fakes.FakeAddress.Hex()
+			bidID1, bidID2, bidID3, bidID4, bidID5, bidID6, bidID7 string
+			address                                                = fakes.FakeAddress.Hex()
 		)
 
 		BeforeEach(func() {
-			bidId1 = strconv.FormatInt(rand.Int63(), 10)
-			bidId2 = strconv.FormatInt(rand.Int63(), 10)
-			bidId3 = strconv.FormatInt(rand.Int63(), 10)
-			bidId4 = strconv.FormatInt(rand.Int63(), 10)
-			bidId5 = strconv.FormatInt(rand.Int63(), 10)
-			bidId6 = strconv.FormatInt(rand.Int63(), 10)
-			bidId7 = strconv.FormatInt(rand.Int63(), 10)
+			bidID1 = strconv.FormatInt(rand.Int63(), 10)
+			bidID2 = strconv.FormatInt(rand.Int63(), 10)
+			bidID3 = strconv.FormatInt(rand.Int63(), 10)
+			bidID4 = strconv.FormatInt(rand.Int63(), 10)
+			bidID5 = strconv.FormatInt(rand.Int63(), 10)
+			bidID6 = strconv.FormatInt(rand.Int63(), 10)
+			bidID7 = strconv.FormatInt(rand.Int63(), 10)
 		})
 
 		It("fetches unique bid ids from flip methods", func() {
-			insertFlipKick(1, bidId1, addressId, db)
-			insertFlipKick(2, bidId1, addressId, db)
+			insertFlipKick(1, bidID1, addressID, db)
+			insertFlipKick(2, bidID1, addressID, db)
 
-			bidIds, err := repository.GetFlipBidIds(address)
+			bidIDs, err := repository.GetFlipBidIDs(address)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(bidIds)).To(Equal(1))
-			Expect(bidIds[0]).To(Equal(bidId1))
+			Expect(len(bidIDs)).To(Equal(1))
+			Expect(bidIDs[0]).To(Equal(bidID1))
 		})
 
 		It("fetches unique bid ids from tick, flip_kick, flip_kicks, tend, dent, deal and yank", func() {
-			duplicateBidId := bidId1
-			insertTick(1, bidId1, addressId, db)
-			insertFlipKick(2, bidId2, addressId, db)
-			insertFlipKicks(3, bidId3, addressId, db)
-			insertTend(4, bidId4, addressId, db)
-			insertDent(5, bidId5, addressId, db)
-			insertDeal(6, bidId6, addressId, db)
-			insertYank(7, bidId7, addressId, db)
-			insertYank(8, duplicateBidId, addressId, db)
+			duplicateBidID := bidID1
+			insertTick(1, bidID1, addressID, db)
+			insertFlipKick(2, bidID2, addressID, db)
+			insertFlipKicks(3, bidID3, addressID, db)
+			insertTend(4, bidID4, addressID, db)
+			insertDent(5, bidID5, addressID, db)
+			insertDeal(6, bidID6, addressID, db)
+			insertYank(7, bidID7, addressID, db)
+			insertYank(8, duplicateBidID, addressID, db)
 
-			bidIds, err := repository.GetFlipBidIds(address)
+			bidIDs, err := repository.GetFlipBidIDs(address)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(bidIds)).To(Equal(7))
-			Expect(bidIds).To(ConsistOf(bidId1, bidId2, bidId3, bidId4, bidId5, bidId6, bidId7))
+			Expect(len(bidIDs)).To(Equal(7))
+			Expect(bidIDs).To(ConsistOf(bidID1, bidID2, bidID3, bidID4, bidID5, bidID6, bidID7))
 		})
 	})
 
 	Describe("getting flop bid ids", func() {
 		var (
-			bidId1  string
-			bidId2  string
-			bidId3  string
-			bidId4  string
-			bidId5  string
-			bidId6  string
-			address = fakes.FakeAddress.Hex()
+			bidID1, bidID2, bidID3, bidID4, bidID5, bidID6 string
+			address                                        = fakes.FakeAddress.Hex()
 		)
 
 		BeforeEach(func() {
-			bidId1 = strconv.FormatInt(rand.Int63(), 10)
-			bidId2 = strconv.FormatInt(rand.Int63(), 10)
-			bidId3 = strconv.FormatInt(rand.Int63(), 10)
-			bidId4 = strconv.FormatInt(rand.Int63(), 10)
-			bidId5 = strconv.FormatInt(rand.Int63(), 10)
-			bidId6 = strconv.FormatInt(rand.Int63(), 10)
+			bidID1 = strconv.FormatInt(rand.Int63(), 10)
+			bidID2 = strconv.FormatInt(rand.Int63(), 10)
+			bidID3 = strconv.FormatInt(rand.Int63(), 10)
+			bidID4 = strconv.FormatInt(rand.Int63(), 10)
+			bidID5 = strconv.FormatInt(rand.Int63(), 10)
+			bidID6 = strconv.FormatInt(rand.Int63(), 10)
 		})
 
 		It("fetches unique flop bid ids from flop methods", func() {
-			insertFlopKick(1, bidId1, addressId, db)
-			insertFlopKick(2, bidId1, addressId, db)
+			insertFlopKick(1, bidID1, addressID, db)
+			insertFlopKick(2, bidID1, addressID, db)
 
-			bidIds, err := repository.GetFlopBidIds(address)
+			bidIDs, err := repository.GetFlopBidIDs(address)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(bidIds)).To(Equal(1))
-			Expect(bidIds[0]).To(Equal(bidId1))
+			Expect(len(bidIDs)).To(Equal(1))
+			Expect(bidIDs[0]).To(Equal(bidID1))
 		})
 
 		It("fetches unique bid ids from flop_kick, dent, deal, and yank", func() {
-			duplicateBidId := bidId1
-			insertFlopKick(1, bidId1, addressId, db)
-			insertFlopKicks(2, bidId2, addressId, db)
-			insertDent(3, bidId3, addressId, db)
-			insertDeal(4, bidId4, addressId, db)
-			insertYank(5, bidId5, addressId, db)
-			insertYank(6, duplicateBidId, addressId, db)
+			duplicateBidID := bidID1
+			insertFlopKick(1, bidID1, addressID, db)
+			insertFlopKicks(2, bidID2, addressID, db)
+			insertDent(3, bidID3, addressID, db)
+			insertDeal(4, bidID4, addressID, db)
+			insertYank(5, bidID5, addressID, db)
+			insertYank(6, duplicateBidID, addressID, db)
 
-			bidIds, err := repository.GetFlopBidIds(address)
+			bidIDs, err := repository.GetFlopBidIDs(address)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(bidIds)).To(Equal(5))
-			Expect(bidIds).To(ConsistOf(bidId1, bidId2, bidId3, bidId4, bidId5))
+			Expect(len(bidIDs)).To(Equal(5))
+			Expect(bidIDs).To(ConsistOf(bidID1, bidID2, bidID3, bidID4, bidID5))
 		})
 
 		It("fetches bid ids only for the given contract address", func() {
 			anotherAddress := address + "1"
-			anotherAddressId, addressErr := shared.GetOrCreateAddress(anotherAddress, db)
+			anotherAddressID, addressErr := shared.GetOrCreateAddress(anotherAddress, db)
 			Expect(addressErr).NotTo(HaveOccurred())
-			insertFlopKick(1, bidId1, addressId, db)
-			insertFlopKick(2, bidId2, addressId, db)
-			insertDent(3, bidId3, addressId, db)
-			insertDeal(4, bidId4, addressId, db)
-			insertYank(5, bidId5, addressId, db)
-			insertYank(6, bidId6, anotherAddressId, db)
+			insertFlopKick(1, bidID1, addressID, db)
+			insertFlopKick(2, bidID2, addressID, db)
+			insertDent(3, bidID3, addressID, db)
+			insertDeal(4, bidID4, addressID, db)
+			insertYank(5, bidID5, addressID, db)
+			insertYank(6, bidID6, anotherAddressID, db)
 
-			bidIds, err := repository.GetFlopBidIds(address)
+			bidIDs, err := repository.GetFlopBidIDs(address)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(bidIds)).To(Equal(5))
-			Expect(bidIds).To(ConsistOf(bidId1, bidId2, bidId3, bidId4, bidId5))
+			Expect(len(bidIDs)).To(Equal(5))
+			Expect(bidIDs).To(ConsistOf(bidID1, bidID2, bidID3, bidID4, bidID5))
 		})
 
 		It("does not return error if no matching rows", func() {
-			bidIds, err := repository.GetFlopBidIds(fakes.FakeAddress.Hex())
+			bidIDs, err := repository.GetFlopBidIDs(fakes.FakeAddress.Hex())
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(bidIds)).To(BeZero())
+			Expect(len(bidIDs)).To(BeZero())
 		})
 	})
 
@@ -693,110 +682,110 @@ var _ = Describe("Maker storage repository", func() {
 	})
 })
 
-func insertFlapKick(blockNumber int64, bidId string, contractAddressId int64, db *postgres.DB) {
+func insertFlapKick(blockNumber int64, bidID string, contractAddressID int64, db *postgres.DB) {
 	//inserting a flap kick log event record
 	headerID := insertHeader(db, blockNumber)
 
 	flapKickLog := test_data.CreateTestLog(headerID, db)
 	_, insertErr := db.Exec(insertFlapKickQuery,
-		headerID, bidId, 0, 0, contractAddressId, flapKickLog.ID,
+		headerID, bidID, 0, 0, contractAddressID, flapKickLog.ID,
 	)
 	Expect(insertErr).NotTo(HaveOccurred())
 }
 
-func insertFlapKicks(blockNumber int64, kicks string, contractAddressId int64, db *postgres.DB) {
+func insertFlapKicks(blockNumber int64, kicks string, contractAddressID int64, db *postgres.DB) {
 	//inserting a flap kicks storage record
 	headerID := insertHeader(db, blockNumber)
 	diffID := test_helpers.CreateFakeDiffRecord(db)
 	_, insertErr := db.Exec(flap.InsertKicksQuery,
-		diffID, headerID, contractAddressId, kicks,
+		diffID, headerID, contractAddressID, kicks,
 	)
 	Expect(insertErr).NotTo(HaveOccurred())
 }
 
-func insertTick(blockNumber int64, bidId string, contractAddressId int64, db *postgres.DB) {
+func insertTick(blockNumber int64, bidID string, contractAddressID int64, db *postgres.DB) {
 	// tick event record
 	headerID := insertHeader(db, blockNumber)
 	flapTickLog := test_data.CreateTestLog(headerID, db)
 	_, insertErr := db.Exec(`INSERT INTO maker.tick (header_id, bid_id, address_id, log_id)
 				VALUES($1, $2::NUMERIC, $3, $4)`,
-		headerID, bidId, contractAddressId, flapTickLog.ID,
+		headerID, bidID, contractAddressID, flapTickLog.ID,
 	)
 	Expect(insertErr).NotTo(HaveOccurred())
 }
 
-func insertFlipKick(blockNumber int64, bidId string, contractAddressId int64, db *postgres.DB) {
+func insertFlipKick(blockNumber int64, bidID string, contractAddressID int64, db *postgres.DB) {
 	// flip kick event record
 	headerID := insertHeader(db, blockNumber)
 	log := test_data.CreateTestLog(headerID, db)
 	_, insertErr := db.Exec(insertFlipKickQuery,
-		headerID, bidId, 0, 0, 0, "", "", contractAddressId, log.ID,
+		headerID, bidID, 0, 0, 0, "", "", contractAddressID, log.ID,
 	)
 	Expect(insertErr).NotTo(HaveOccurred())
 }
 
-func insertFlipKicks(blockNumber int64, kicks string, contractAddressId int64, db *postgres.DB) {
+func insertFlipKicks(blockNumber int64, kicks string, contractAddressID int64, db *postgres.DB) {
 	// flip kicks storage record
 	headerID := insertHeader(db, blockNumber)
 	diffID := test_helpers.CreateFakeDiffRecord(db)
 	_, insertErr := db.Exec(flip.InsertFlipKicksQuery,
-		diffID, headerID, contractAddressId, kicks,
+		diffID, headerID, contractAddressID, kicks,
 	)
 	Expect(insertErr).NotTo(HaveOccurred())
 }
 
-func insertFlopKick(blockNumber int64, bidId string, contractAddressId int64, db *postgres.DB) {
+func insertFlopKick(blockNumber int64, bidID string, contractAddressID int64, db *postgres.DB) {
 	// inserting a flop kick log event record
-	headerId := insertHeader(db, blockNumber)
-	flopKickLog := test_data.CreateTestLog(headerId, db)
-	_, insertErr := db.Exec(insertFlopKickQuery, headerId, bidId, contractAddressId, flopKickLog.ID)
+	headerID := insertHeader(db, blockNumber)
+	flopKickLog := test_data.CreateTestLog(headerID, db)
+	_, insertErr := db.Exec(insertFlopKickQuery, headerID, bidID, contractAddressID, flopKickLog.ID)
 	Expect(insertErr).NotTo(HaveOccurred())
 }
 
-func insertFlopKicks(blockNumber int64, kicks string, contractAddressId int64, db *postgres.DB) {
+func insertFlopKicks(blockNumber int64, kicks string, contractAddressID int64, db *postgres.DB) {
 	// inserting a flop kicks storage record
 	diffID := test_helpers.CreateFakeDiffRecord(db)
 	headerID := insertHeader(db, blockNumber)
-	_, insertErr := db.Exec(flop.InsertFlopKicksQuery, diffID, headerID, contractAddressId, kicks)
+	_, insertErr := db.Exec(flop.InsertFlopKicksQuery, diffID, headerID, contractAddressID, kicks)
 	Expect(insertErr).NotTo(HaveOccurred())
 }
 
-func insertTend(blockNumber int64, bidId string, contractAddressId int64, db *postgres.DB) {
+func insertTend(blockNumber int64, bidID string, contractAddressID int64, db *postgres.DB) {
 	headerID := insertHeader(db, blockNumber)
 	tendLog := test_data.CreateTestLog(headerID, db)
 	_, err := db.Exec(`INSERT into maker.tend (header_id, bid_id, lot, bid, address_id, log_id)
 		VALUES($1, $2::NUMERIC, $3::NUMERIC, $4::NUMERIC, $5, $6)`,
-		headerID, bidId, 0, 0, contractAddressId, tendLog.ID,
+		headerID, bidID, 0, 0, contractAddressID, tendLog.ID,
 	)
 	Expect(err).NotTo(HaveOccurred())
 }
 
-func insertDent(blockNumber int64, bidId string, contractAddressId int64, db *postgres.DB) {
+func insertDent(blockNumber int64, bidID string, contractAddressID int64, db *postgres.DB) {
 	headerID := insertHeader(db, blockNumber)
 	dentLog := test_data.CreateTestLog(headerID, db)
 	_, err := db.Exec(`INSERT into maker.dent (header_id, bid_id, lot, bid, address_id, log_id)
 		VALUES($1, $2::NUMERIC, $3::NUMERIC, $4::NUMERIC, $5, $6)`,
-		headerID, bidId, 0, 0, contractAddressId, dentLog.ID,
+		headerID, bidID, 0, 0, contractAddressID, dentLog.ID,
 	)
 	Expect(err).NotTo(HaveOccurred())
 }
 
-func insertDeal(blockNumber int64, bidId string, contractAddressId int64, db *postgres.DB) {
+func insertDeal(blockNumber int64, bidID string, contractAddressID int64, db *postgres.DB) {
 	headerID := insertHeader(db, blockNumber)
 	dealLog := test_data.CreateTestLog(headerID, db)
 	_, err := db.Exec(`INSERT into maker.deal (header_id, bid_id, address_id, log_id)
 		VALUES($1, $2::NUMERIC, $3, $4)`,
-		headerID, bidId, contractAddressId, dealLog.ID,
+		headerID, bidID, contractAddressID, dealLog.ID,
 	)
 	Expect(err).NotTo(HaveOccurred())
 }
 
-func insertYank(blockNumber int64, bidId string, contractAddressId int64, db *postgres.DB) {
+func insertYank(blockNumber int64, bidID string, contractAddressID int64, db *postgres.DB) {
 	headerID := insertHeader(db, blockNumber)
 	yankLog := test_data.CreateTestLog(headerID, db)
 	_, err := db.Exec(`INSERT into maker.yank (header_id, bid_id, address_id, log_id)
 		VALUES($1, $2::NUMERIC, $3, $4)`,
-		headerID, bidId, contractAddressId, yankLog.ID,
+		headerID, bidID, contractAddressID, yankLog.ID,
 	)
 	Expect(err).NotTo(HaveOccurred())
 }

--- a/transformers/storage/spot/initializer/initializer.go
+++ b/transformers/storage/spot/initializer/initializer.go
@@ -28,5 +28,5 @@ var spotAddress = constants.GetContractAddress("MCD_SPOT")
 var StorageTransformerInitializer storage.TransformerInitializer = storage.Transformer{
 	Address:           common.HexToAddress(spotAddress),
 	StorageKeysLookup: storage.NewKeysLookup(spot.NewKeysLoader(&mcdStorage.MakerStorageRepository{}, spotAddress)),
-	Repository:        &spot.SpotStorageRepository{ContractAddress: spotAddress},
+	Repository:        &spot.StorageRepository{ContractAddress: spotAddress},
 }.NewTransformer

--- a/transformers/storage/spot/repository.go
+++ b/transformers/storage/spot/repository.go
@@ -34,12 +34,12 @@ const (
 	insertSpotLiveQuery   = `INSERT INTO maker.spot_live (diff_id, header_id, live) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING`
 )
 
-type SpotStorageRepository struct {
+type StorageRepository struct {
 	db              *postgres.DB
 	ContractAddress string
 }
 
-func (repository SpotStorageRepository) Create(diffID, headerID int64, metadata types.ValueMetadata, value interface{}) error {
+func (repository StorageRepository) Create(diffID, headerID int64, metadata types.ValueMetadata, value interface{}) error {
 	switch metadata.Name {
 	case wards.Wards:
 		return wards.InsertWards(diffID, headerID, metadata, repository.ContractAddress, value.(string), repository.db)
@@ -59,40 +59,56 @@ func (repository SpotStorageRepository) Create(diffID, headerID int64, metadata 
 	}
 }
 
-func (repository *SpotStorageRepository) SetDB(db *postgres.DB) {
+func (repository *StorageRepository) SetDB(db *postgres.DB) {
 	repository.db = db
 }
 
-func (repository SpotStorageRepository) insertIlkPip(diffID, headerID int64, metadata types.ValueMetadata, pip string) error {
+func (repository StorageRepository) insertIlkPip(diffID, headerID int64, metadata types.ValueMetadata, pip string) error {
 	ilk, err := getIlk(metadata.Keys)
 	if err != nil {
-		return err
+		return fmt.Errorf("error getting ilk for ilk pip: %w", err)
 	}
-
-	return shared.InsertFieldWithIlk(diffID, headerID, ilk, IlkPip, InsertSpotIlkPipQuery, pip, repository.db)
+	insertErr := shared.InsertFieldWithIlk(diffID, headerID, ilk, IlkPip, InsertSpotIlkPipQuery, pip, repository.db)
+	if insertErr != nil {
+		return fmt.Errorf("error inserting ilk %s pip %s from diff ID %d: %w", ilk, pip, diffID, insertErr)
+	}
+	return nil
 }
 
-func (repository SpotStorageRepository) insertIlkMat(diffID, headerID int64, metadata types.ValueMetadata, mat string) error {
+func (repository StorageRepository) insertIlkMat(diffID, headerID int64, metadata types.ValueMetadata, mat string) error {
 	ilk, err := getIlk(metadata.Keys)
 	if err != nil {
-		return err
+		return fmt.Errorf("error getting ilk for ilk mat: %w", err)
 	}
-	return shared.InsertFieldWithIlk(diffID, headerID, ilk, IlkMat, InsertSpotIlkMatQuery, mat, repository.db)
+	insertErr := shared.InsertFieldWithIlk(diffID, headerID, ilk, IlkMat, InsertSpotIlkMatQuery, mat, repository.db)
+	if insertErr != nil {
+		return fmt.Errorf("error inserting ilk %s mat %s from diff ID %d: %w", ilk, mat, diffID, insertErr)
+	}
+	return nil
 }
 
-func (repository SpotStorageRepository) insertSpotVat(diffID, headerID int64, vat string) error {
+func (repository StorageRepository) insertSpotVat(diffID, headerID int64, vat string) error {
 	_, err := repository.db.Exec(insertSpotVatQuery, diffID, headerID, vat)
-	return err
+	if err != nil {
+		return fmt.Errorf("error inserting spot vat %s from diff ID %d: %w", vat, diffID, err)
+	}
+	return nil
 }
 
-func (repository SpotStorageRepository) insertSpotPar(diffID, headerID int64, par string) error {
+func (repository StorageRepository) insertSpotPar(diffID, headerID int64, par string) error {
 	_, err := repository.db.Exec(insertSpotParQuery, diffID, headerID, par)
-	return err
+	if err != nil {
+		return fmt.Errorf("error inserting spot par %s from diff ID %d: %w", par, diffID, err)
+	}
+	return nil
 }
 
-func (repository SpotStorageRepository) insertSpotLive(diffID, headerID int64, live string) error {
+func (repository StorageRepository) insertSpotLive(diffID, headerID int64, live string) error {
 	_, err := repository.db.Exec(insertSpotLiveQuery, diffID, headerID, live)
-	return err
+	if err != nil {
+		return fmt.Errorf("error inserting spot live %s from diff ID %d: %w", live, diffID, err)
+	}
+	return nil
 }
 
 func getIlk(keys map[types.Key]string) (string, error) {

--- a/transformers/storage/spot/repository_test.go
+++ b/transformers/storage/spot/repository_test.go
@@ -40,7 +40,7 @@ import (
 var _ = Describe("Spot storage repository", func() {
 	var (
 		db                   = test_config.NewTestDB(test_config.NewTestNode())
-		repo                 spot.SpotStorageRepository
+		repo                 spot.StorageRepository
 		fakeAddress          = "0x" + fakes.RandomString(20)
 		fakeUint256          = strconv.Itoa(rand.Intn(1000000))
 		diffID, fakeHeaderID int64
@@ -48,7 +48,7 @@ var _ = Describe("Spot storage repository", func() {
 
 	BeforeEach(func() {
 		test_config.CleanTestDB(db)
-		repo = spot.SpotStorageRepository{ContractAddress: test_data.SpotAddress()}
+		repo = spot.StorageRepository{ContractAddress: test_data.SpotAddress()}
 		repo.SetDB(db)
 		headerRepository := repositories.NewHeaderRepository(db)
 		var insertHeaderErr error

--- a/transformers/storage/test_helpers/maker_storage_repository.go
+++ b/transformers/storage/test_helpers/maker_storage_repository.go
@@ -9,9 +9,9 @@ import (
 type MockMakerStorageRepository struct {
 	Cdpis                   []string
 	DaiKeys                 []string
-	FlapBidIds              []string
-	FlipBidIds              []string
-	FlopBidIds              []string
+	FlapBidIDs              []string
+	FlipBidIDs              []string
+	FlopBidIDs              []string
 	GemKeys                 []storage.Urn
 	Ilks                    []string
 	Owners                  []string
@@ -24,12 +24,12 @@ type MockMakerStorageRepository struct {
 	GetCdpisError           error
 	GetDaiKeysCalled        bool
 	GetDaiKeysError         error
-	GetFlapBidIdsCalled     bool
-	GetFlapBidIdsError      error
-	GetFlipBidIdsCalledWith string
-	GetFlipBidIdsError      error
-	GetFlopBidIdsCalledWith string
-	GetFlopBidIdsError      error
+	GetFlapBidIDsCalled     bool
+	GetFlapBidIDsError      error
+	GetFlipBidIDsCalledWith string
+	GetFlipBidIDsError      error
+	GetFlopBidIDsCalledWith string
+	GetFlopBidIDsError      error
 	GetGemKeysCalled        bool
 	GetGemKeysError         error
 	GetIlksCalled           bool
@@ -60,19 +60,19 @@ func (repository *MockMakerStorageRepository) GetDaiKeys() ([]string, error) {
 	return repository.DaiKeys, repository.GetDaiKeysError
 }
 
-func (repository *MockMakerStorageRepository) GetFlapBidIds(string) ([]string, error) {
-	repository.GetFlapBidIdsCalled = true
-	return repository.FlapBidIds, repository.GetFlapBidIdsError
+func (repository *MockMakerStorageRepository) GetFlapBidIDs(string) ([]string, error) {
+	repository.GetFlapBidIDsCalled = true
+	return repository.FlapBidIDs, repository.GetFlapBidIDsError
 }
 
-func (repository *MockMakerStorageRepository) GetFlipBidIds(contractAddress string) ([]string, error) {
-	repository.GetFlipBidIdsCalledWith = contractAddress
-	return repository.FlipBidIds, repository.GetFlipBidIdsError
+func (repository *MockMakerStorageRepository) GetFlipBidIDs(contractAddress string) ([]string, error) {
+	repository.GetFlipBidIDsCalledWith = contractAddress
+	return repository.FlipBidIDs, repository.GetFlipBidIDsError
 }
 
-func (repository *MockMakerStorageRepository) GetFlopBidIds(contractAddress string) ([]string, error) {
-	repository.GetFlopBidIdsCalledWith = contractAddress
-	return repository.FlopBidIds, repository.GetFlopBidIdsError
+func (repository *MockMakerStorageRepository) GetFlopBidIDs(contractAddress string) ([]string, error) {
+	repository.GetFlopBidIDsCalledWith = contractAddress
+	return repository.FlopBidIDs, repository.GetFlopBidIDsError
 }
 
 func (repository *MockMakerStorageRepository) GetGemKeys() ([]storage.Urn, error) {

--- a/transformers/storage/utilities/wards/repository.go
+++ b/transformers/storage/utilities/wards/repository.go
@@ -24,7 +24,7 @@ func InsertWards(diffID, headerID int64, metadata types.ValueMetadata, contractA
 	if addressErr != nil {
 		rollbackErr := tx.Rollback()
 		if rollbackErr != nil {
-			return shared.FormatRollbackError("contract address", addressErr.Error())
+			return shared.FormatRollbackError("contract address", addressErr)
 		}
 		return addressErr
 	}
@@ -33,7 +33,7 @@ func InsertWards(diffID, headerID int64, metadata types.ValueMetadata, contractA
 	if userAddressErr != nil {
 		rollbackErr := tx.Rollback()
 		if rollbackErr != nil {
-			return shared.FormatRollbackError("wards user address", userAddressErr.Error())
+			return shared.FormatRollbackError("wards user address", userAddressErr)
 		}
 		return addressErr
 	}
@@ -42,7 +42,7 @@ func InsertWards(diffID, headerID int64, metadata types.ValueMetadata, contractA
 	if insertErr != nil {
 		rollbackErr := tx.Rollback()
 		if rollbackErr != nil {
-			return shared.FormatRollbackError("wards record with address", insertErr.Error())
+			return shared.FormatRollbackError("wards record with address", insertErr)
 		}
 		return insertErr
 	}

--- a/transformers/storage/vat/initializer/initializer.go
+++ b/transformers/storage/vat/initializer/initializer.go
@@ -27,5 +27,5 @@ import (
 var StorageTransformerInitializer storage.TransformerInitializer = storage.Transformer{
 	Address:           common.HexToAddress(constants.GetContractAddress("MCD_VAT")),
 	StorageKeysLookup: storage.NewKeysLookup(vat.NewKeysLoader(&mcdStorage.MakerStorageRepository{})),
-	Repository:        &vat.VatStorageRepository{},
+	Repository:        &vat.StorageRepository{},
 }.NewTransformer

--- a/transformers/storage/vat/keys_loader.go
+++ b/transformers/storage/vat/keys_loader.go
@@ -17,6 +17,8 @@
 package vat
 
 import (
+	"fmt"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	mcdStorage "github.com/makerdao/vdb-mcd-transformers/transformers/storage"
@@ -97,25 +99,29 @@ func (loader *keysLoader) LoadMappings() (map[common.Hash]types.ValueMetadata, e
 	mappings := loadStaticMappings()
 	mappings, wardsErr := loader.addWardsKeys(mappings)
 	if wardsErr != nil {
-		return nil, wardsErr
+		return nil, fmt.Errorf("error adding wards keys to vat keys loader: %w", wardsErr)
 	}
 	mappings, daiErr := loader.addDaiKeys(mappings)
 	if daiErr != nil {
-		return nil, daiErr
+		return nil, fmt.Errorf("error adding dai keys to vat keys loader: %w", daiErr)
 	}
 	mappings, gemErr := loader.addGemKeys(mappings)
 	if gemErr != nil {
-		return nil, gemErr
+		return nil, fmt.Errorf("error adding gem geys to vat keys loader: %w", gemErr)
 	}
 	mappings, ilkErr := loader.addIlkKeys(mappings)
 	if ilkErr != nil {
-		return nil, ilkErr
+		return nil, fmt.Errorf("error adding ilk keys to vat keys loader: %w", ilkErr)
 	}
 	mappings, sinErr := loader.addSinKeys(mappings)
 	if sinErr != nil {
-		return nil, sinErr
+		return nil, fmt.Errorf("error adding sin keys to vat keys loader: %w", sinErr)
 	}
-	return loader.addUrnKeys(mappings)
+	mappings, urnErr := loader.addUrnKeys(mappings)
+	if urnErr != nil {
+		return nil, fmt.Errorf("error adding urn keys to vat keys loader: %w", urnErr)
+	}
+	return mappings, nil
 }
 
 func loadStaticMappings() map[common.Hash]types.ValueMetadata {
@@ -130,7 +136,7 @@ func loadStaticMappings() map[common.Hash]types.ValueMetadata {
 func (loader *keysLoader) addWardsKeys(mappings map[common.Hash]types.ValueMetadata) (map[common.Hash]types.ValueMetadata, error) {
 	addresses, err := loader.storageRepository.GetVatWardsAddresses()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error getting wards addresses: %w", err)
 	}
 	return wards.AddWardsKeys(mappings, addresses)
 }
@@ -138,12 +144,12 @@ func (loader *keysLoader) addWardsKeys(mappings map[common.Hash]types.ValueMetad
 func (loader *keysLoader) addDaiKeys(mappings map[common.Hash]types.ValueMetadata) (map[common.Hash]types.ValueMetadata, error) {
 	daiKeys, err := loader.storageRepository.GetDaiKeys()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error getting dai keys: %w", err)
 	}
 	for _, d := range daiKeys {
 		paddedDai, padErr := utilities.PadAddress(d)
 		if padErr != nil {
-			return nil, padErr
+			return nil, fmt.Errorf("error padding address: %w", padErr)
 		}
 		mappings[getDaiKey(paddedDai)] = getDaiMetadata(d)
 	}
@@ -153,12 +159,12 @@ func (loader *keysLoader) addDaiKeys(mappings map[common.Hash]types.ValueMetadat
 func (loader *keysLoader) addGemKeys(mappings map[common.Hash]types.ValueMetadata) (map[common.Hash]types.ValueMetadata, error) {
 	gemKeys, err := loader.storageRepository.GetGemKeys()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error getting gem keys: %w", err)
 	}
 	for _, gem := range gemKeys {
 		paddedGem, padErr := utilities.PadAddress(gem.Identifier)
 		if padErr != nil {
-			return nil, padErr
+			return nil, fmt.Errorf("error padding address: %w", padErr)
 		}
 		mappings[getGemKey(gem.Ilk, paddedGem)] = getGemMetadata(gem.Ilk, gem.Identifier)
 	}
@@ -168,7 +174,7 @@ func (loader *keysLoader) addGemKeys(mappings map[common.Hash]types.ValueMetadat
 func (loader *keysLoader) addIlkKeys(mappings map[common.Hash]types.ValueMetadata) (map[common.Hash]types.ValueMetadata, error) {
 	ilks, err := loader.storageRepository.GetIlks()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error getting ilks: %w", err)
 	}
 	for _, ilk := range ilks {
 		mappings[GetIlkArtKey(ilk)] = getIlkArtMetadata(ilk)
@@ -183,12 +189,12 @@ func (loader *keysLoader) addIlkKeys(mappings map[common.Hash]types.ValueMetadat
 func (loader *keysLoader) addSinKeys(mappings map[common.Hash]types.ValueMetadata) (map[common.Hash]types.ValueMetadata, error) {
 	sinKeys, err := loader.storageRepository.GetVatSinKeys()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error getting vat sin keys: %w", err)
 	}
 	for _, s := range sinKeys {
 		paddedSin, padErr := utilities.PadAddress(s)
 		if padErr != nil {
-			return nil, padErr
+			return nil, fmt.Errorf("error padding address: %w", padErr)
 		}
 		mappings[getSinKey(paddedSin)] = getSinMetadata(s)
 	}
@@ -198,12 +204,12 @@ func (loader *keysLoader) addSinKeys(mappings map[common.Hash]types.ValueMetadat
 func (loader *keysLoader) addUrnKeys(mappings map[common.Hash]types.ValueMetadata) (map[common.Hash]types.ValueMetadata, error) {
 	urns, err := loader.storageRepository.GetUrns()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error getting urns: %w", err)
 	}
 	for _, urn := range urns {
 		paddedGuy, padErr := utilities.PadAddress(urn.Identifier)
 		if padErr != nil {
-			return nil, padErr
+			return nil, fmt.Errorf("error padding address: %w", padErr)
 		}
 		mappings[GetUrnArtKey(urn.Ilk, paddedGuy)] = getUrnArtMetadata(urn.Ilk, urn.Identifier)
 		mappings[GetUrnInkKey(urn.Ilk, paddedGuy)] = getUrnInkMetadata(urn.Ilk, urn.Identifier)

--- a/transformers/storage/vat/repository_test.go
+++ b/transformers/storage/vat/repository_test.go
@@ -43,7 +43,7 @@ import (
 var _ = Describe("Vat storage repository", func() {
 	var (
 		db                   = test_config.NewTestDB(test_config.NewTestNode())
-		repo                 vat.VatStorageRepository
+		repo                 vat.StorageRepository
 		fakeGuy              = "fake_urn"
 		fakeUint256          = "12345"
 		diffID, fakeHeaderID int64
@@ -51,7 +51,7 @@ var _ = Describe("Vat storage repository", func() {
 
 	BeforeEach(func() {
 		test_config.CleanTestDB(db)
-		repo = vat.VatStorageRepository{}
+		repo = vat.StorageRepository{}
 		repo.SetDB(db)
 		headerRepository := repositories.NewHeaderRepository(db)
 		var insertHeaderErr error

--- a/transformers/storage/vow/initializer/initializer.go
+++ b/transformers/storage/vow/initializer/initializer.go
@@ -28,5 +28,5 @@ var vowAddress = constants.GetContractAddress("MCD_VOW")
 var StorageTransformerInitializer storage.TransformerInitializer = storage.Transformer{
 	Address:           common.HexToAddress(vowAddress),
 	StorageKeysLookup: storage.NewKeysLookup(vow.NewKeysLoader(&mcdStorage.MakerStorageRepository{}, vowAddress)),
-	Repository:        &vow.VowStorageRepository{ContractAddress: vowAddress},
+	Repository:        &vow.StorageRepository{ContractAddress: vowAddress},
 }.NewTransformer

--- a/transformers/storage/vow/repository.go
+++ b/transformers/storage/vow/repository.go
@@ -40,16 +40,16 @@ const (
 	insertLiveQuery       = `INSERT INTO maker.vow_live (diff_id, header_id, live) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING`
 )
 
-type VowStorageRepository struct {
+type StorageRepository struct {
 	db              *postgres.DB
 	ContractAddress string
 }
 
-func (repository *VowStorageRepository) SetDB(db *postgres.DB) {
+func (repository *StorageRepository) SetDB(db *postgres.DB) {
 	repository.db = db
 }
 
-func (repository VowStorageRepository) Create(diffID, headerID int64, metadata types.ValueMetadata, value interface{}) error {
+func (repository StorageRepository) Create(diffID, headerID int64, metadata types.ValueMetadata, value interface{}) error {
 	switch metadata.Name {
 	case wards.Wards:
 		return wards.InsertWards(diffID, headerID, metadata, repository.ContractAddress, value.(string), repository.db)
@@ -82,80 +82,106 @@ func (repository VowStorageRepository) Create(diffID, headerID int64, metadata t
 	}
 }
 
-func (repository VowStorageRepository) insertVowVat(diffID, headerID int64, vat string) error {
+func (repository StorageRepository) insertVowVat(diffID, headerID int64, vat string) error {
 	_, err := repository.db.Exec(insertVatQuery, diffID, headerID, vat)
-
-	return err
+	if err != nil {
+		return fmt.Errorf("error inserting vow vat %s from diff ID %d: %w", vat, diffID, err)
+	}
+	return nil
 }
 
-func (repository VowStorageRepository) insertVowFlapper(diffID, headerID int64, flapper string) error {
+func (repository StorageRepository) insertVowFlapper(diffID, headerID int64, flapper string) error {
 	_, err := repository.db.Exec(insertFlapperQuery, diffID, headerID, flapper)
-
-	return err
+	if err != nil {
+		return fmt.Errorf("error inserting vow flapper %s from diff ID %d: %w", flapper, diffID, err)
+	}
+	return nil
 }
 
-func (repository VowStorageRepository) insertVowFlopper(diffID, headerID int64, flopper string) error {
+func (repository StorageRepository) insertVowFlopper(diffID, headerID int64, flopper string) error {
 	_, err := repository.db.Exec(insertFlopperQuery, diffID, headerID, flopper)
-
-	return err
+	if err != nil {
+		return fmt.Errorf("error inserting vow flopper %s from diff ID %d: %w", flopper, diffID, err)
+	}
+	return nil
 }
 
-func (repository VowStorageRepository) insertSinInteger(diffID, headerID int64, sin string) error {
+func (repository StorageRepository) insertSinInteger(diffID, headerID int64, sin string) error {
 	_, err := repository.db.Exec(insertSinIntegerQuery, diffID, headerID, sin)
-
-	return err
+	if err != nil {
+		return fmt.Errorf("error inserting vow sin integer %s, from diff ID %d: %w", sin, diffID, err)
+	}
+	return nil
 }
 
-func (repository VowStorageRepository) insertSinMapping(diffID, headerID int64, metadata types.ValueMetadata, sin string) error {
+func (repository StorageRepository) insertSinMapping(diffID, headerID int64, metadata types.ValueMetadata, sin string) error {
 	timestamp, err := getTimestamp(metadata.Keys)
 	if err != nil {
-		return err
+		return fmt.Errorf("error getting timestamp for vow sin mapping: %w", err)
 	}
-	_, writeErr := repository.db.Exec(insertSinMappingQuery, diffID, headerID, timestamp, sin)
-
-	return writeErr
+	_, insertErr := repository.db.Exec(insertSinMappingQuery, diffID, headerID, timestamp, sin)
+	if insertErr != nil {
+		msgToFormat := "error inserting vow sin mapping with timestamp %s and sin %s from diff ID %d"
+		msg := fmt.Sprintf(msgToFormat, timestamp, sin, diffID)
+		return fmt.Errorf("%s: %w", msg, insertErr)
+	}
+	return nil
 }
 
-func (repository VowStorageRepository) insertVowAsh(diffID, headerID int64, ash string) error {
+func (repository StorageRepository) insertVowAsh(diffID, headerID int64, ash string) error {
 	_, err := repository.db.Exec(insertAshQuery, diffID, headerID, ash)
-
-	return err
+	if err != nil {
+		return fmt.Errorf("error inserting vow ash %s from diff ID %d: %w", ash, diffID, err)
+	}
+	return nil
 }
 
-func (repository VowStorageRepository) insertVowWait(diffID, headerID int64, wait string) error {
+func (repository StorageRepository) insertVowWait(diffID, headerID int64, wait string) error {
 	_, err := repository.db.Exec(insertWaitQuery, diffID, headerID, wait)
-
-	return err
+	if err != nil {
+		return fmt.Errorf("error inserting vow wait %s from diff ID %d: %w", wait, diffID, err)
+	}
+	return nil
 }
 
-func (repository VowStorageRepository) insertVowDump(diffID, headerID int64, dump string) error {
+func (repository StorageRepository) insertVowDump(diffID, headerID int64, dump string) error {
 	_, err := repository.db.Exec(insertDumpQuery, diffID, headerID, dump)
-
-	return err
+	if err != nil {
+		return fmt.Errorf("error inserting vow dump %s from diff ID %d: %w", dump, diffID, err)
+	}
+	return nil
 }
 
-func (repository VowStorageRepository) insertVowSump(diffID, headerID int64, sump string) error {
+func (repository StorageRepository) insertVowSump(diffID, headerID int64, sump string) error {
 	_, err := repository.db.Exec(insertSumpQuery, diffID, headerID, sump)
-
-	return err
+	if err != nil {
+		return fmt.Errorf("error inserting vow sump %s from diff ID %d: %w", sump, diffID, err)
+	}
+	return nil
 }
 
-func (repository VowStorageRepository) insertVowBump(diffID, headerID int64, bump string) error {
+func (repository StorageRepository) insertVowBump(diffID, headerID int64, bump string) error {
 	_, err := repository.db.Exec(insertBumpQuery, diffID, headerID, bump)
-
-	return err
+	if err != nil {
+		return fmt.Errorf("error inserting vow bump %s from diff ID %d: %w", bump, diffID, err)
+	}
+	return nil
 }
 
-func (repository VowStorageRepository) insertVowHump(diffID, headerID int64, hump string) error {
+func (repository StorageRepository) insertVowHump(diffID, headerID int64, hump string) error {
 	_, err := repository.db.Exec(insertHumpQuery, diffID, headerID, hump)
-
-	return err
+	if err != nil {
+		return fmt.Errorf("error inserting vow hump %s from diff ID %d: %w", hump, diffID, err)
+	}
+	return nil
 }
 
-func (repository VowStorageRepository) insertVowLive(diffID, headerID int64, live string) error {
+func (repository StorageRepository) insertVowLive(diffID, headerID int64, live string) error {
 	_, err := repository.db.Exec(insertLiveQuery, diffID, headerID, live)
-
-	return err
+	if err != nil {
+		return fmt.Errorf("error inserting vow live %s from diff ID %d: %w", live, diffID, err)
+	}
+	return nil
 }
 
 func getTimestamp(keys map[types.Key]string) (string, error) {

--- a/transformers/storage/vow/repository_test.go
+++ b/transformers/storage/vow/repository_test.go
@@ -42,12 +42,12 @@ var _ = Describe("Vow storage repository test", func() {
 		diffID, fakeHeaderID int64
 		fakeAddress          = "0x" + fakes.RandomString(40)
 		fakeUint256          = strconv.Itoa(rand.Intn(1000000))
-		repo                 vow.VowStorageRepository
+		repo                 vow.StorageRepository
 	)
 
 	BeforeEach(func() {
 		test_config.CleanTestDB(db)
-		repo = vow.VowStorageRepository{}
+		repo = vow.StorageRepository{}
 		repo.SetDB(db)
 		headerRepository := repositories.NewHeaderRepository(db)
 		var insertHeaderErr error


### PR DESCRIPTION
The main purpose of this PR is to provide more detailed error messages when there's a failure in storage transformer execution. In general, all logs should now provide specific info about what data they're managing if there's an error.

I made a few quick changes to squash some complaints from the linter, though they did end up bloating the diff more than I would have hoped. These include:
- use [consistent case for initialisms/acronyms](https://github.com/golang/go/wiki/CodeReviewComments#initialisms)
- [don't repeat package name](https://github.com/golang/go/wiki/CodeReviewComments#package-names) in exported structs
- extract shared functions for duplicated code