### PR TITLE
(VDB-1350) Add health check to execute Dockerfile

### DIFF
--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -6,8 +6,8 @@ Builds an alpine image for running the vulcanizedb `execute` command against tra
 ### Build
 Build from the project root directory with: `docker build -f dockerfiles/execute/Dockerfile . -t execute:latest`.
 The following options are available at build time:
-- `VDB_VERSION` - target a specific vulcanizedb branch/release to generate the binary (ex: `docker build -f dockerfiles/execute/Dockerfile --build-arg VDB_VERSION=0.0.9 -t execute:latest`).
-- `CONFIG_FILE` - path to desired config file for this container (ex: `docker build -f dockerfiles/execute/Dockerfile --build-arg CONFIG_FILE=path -t execute:latest`).
+- `VDB_VERSION` - target a specific vulcanizedb branch/release to generate the binary (ex: `docker build -f dockerfiles/execute/Dockerfile --build-arg VDB_VERSION=v0.0.14-rc.1 . -t execute:latest`).
+- `CONFIG_FILE` - path to desired config file for this container (ex: `docker build -f dockerfiles/execute/Dockerfile --build-arg CONFIG_FILE=path . -t execute:latest`).
 
 ### Run
 Running the container requires an existing DB with which the container can interact.
@@ -26,7 +26,7 @@ The following arguments are required at runtime:
 With arguments correctly populated, the following command will run the container on OS X:
 
 ```
-docker run -e DATABASE_NAME=vulcanize_public -e DATABASE_HOSTNAME=host.docker.internal -e DATABASE_PORT=5432 -e DATABASE_USER=user -e DATABASE_PASSWORD=pw -e CLIENT_IPCPATH=https://kovan.infura.io/v3/token -it execute:latest
+docker run -e DATABASE_NAME=vulcanize_public -e DATABASE_HOSTNAME=host.docker.internal -e DATABASE_PORT=5432 -e DATABASE_USER=user -e DATABASE_PASSWORD=pw -e CLIENT_IPCPATH=https://mainnet.infura.io/v3/token -it execute:latest
 ```
 
 #### Explanation

--- a/dockerfiles/execute/Dockerfile
+++ b/dockerfiles/execute/Dockerfile
@@ -57,7 +57,7 @@ COPY --from=builder /go/src/github.com/makerdao/vdb-mcd-transformers/plugins/tra
 COPY --from=builder /go/src/github.com/makerdao/vdb-mcd-transformers/dockerfiles/wait-for-it.sh .
 COPY --from=builder /go/src/github.com/makerdao/vdb-mcd-transformers/dockerfiles/execute/run_migrations.sh .
 
-HEALTHCHECK CMD test -f /tmp/execute_health_check
+HEALTHCHECK CMD grep -q "event watcher starting" /tmp/execute_health_check && grep -q "storage watcher starting" /tmp/execute_health_check
 
 # need to execute with a shell to access env variables
 CMD ["./startup_script.sh"]

--- a/dockerfiles/execute/Dockerfile
+++ b/dockerfiles/execute/Dockerfile
@@ -57,5 +57,7 @@ COPY --from=builder /go/src/github.com/makerdao/vdb-mcd-transformers/plugins/tra
 COPY --from=builder /go/src/github.com/makerdao/vdb-mcd-transformers/dockerfiles/wait-for-it.sh .
 COPY --from=builder /go/src/github.com/makerdao/vdb-mcd-transformers/dockerfiles/execute/run_migrations.sh .
 
+HEALTHCHECK CMD test -f /tmp/execute_health_check
+
 # need to execute with a shell to access env variables
 CMD ["./startup_script.sh"]


### PR DESCRIPTION
Right now this only checks that the file exists, but we could also potentially check that it includes lines indicating that both the event and storage transformers are running