### PR TITLE
Fix abi parsing

### DIFF
--- a/transformers/shared/config.go
+++ b/transformers/shared/config.go
@@ -27,7 +27,7 @@ func GetEventTransformerConfig(transformerLabel, signature string) event.Transfo
 	return event.TransformerConfig{
 		TransformerName:     transformerLabel,
 		ContractAddresses:   constants.GetContractAddresses(contractNames),
-		ContractAbi:         constants.GetContractsABI(contractNames),
+		ContractAbi:         constants.GetFirstABI(contractNames),
 		Topic:               signature,
 		StartingBlockNumber: constants.GetMinDeploymentBlock(contractNames),
 		EndingBlockNumber:   -1, // TODO Generalise endingBlockNumber

--- a/transformers/shared/constants/external.go
+++ b/transformers/shared/constants/external.go
@@ -69,9 +69,9 @@ func GetTransformerContractNames(transformerLabel string) []string {
 	return contracts
 }
 
-// Get the ABI for multiple contracts from config
+// GetABIFromContractsWithMatchingABI gets the ABI for multiple contracts from config
 // Makes sure the ABI matches for all, since a single transformer may run against many contracts.
-func GetContractsABI(contractNames []string) string {
+func GetABIFromContractsWithMatchingABI(contractNames []string) string {
 	initConfig()
 	if len(contractNames) < 1 {
 		logrus.Fatalf("No contracts to get ABI for")
@@ -92,6 +92,15 @@ func GetContractsABI(contractNames []string) string {
 		}
 	}
 	return contractABI
+}
+
+// GetFirstABI returns the ABI from the first contract in a collection in config
+func GetFirstABI(contractNames []string) string {
+	initConfig()
+	if len(contractNames) < 1 {
+		logrus.Fatalf("No contracts to get ABI for")
+	}
+	return getContractABI(contractNames[0])
 }
 
 func getContractABI(contractName string) string {

--- a/transformers/shared/constants/external_test.go
+++ b/transformers/shared/constants/external_test.go
@@ -1,0 +1,35 @@
+package constants_test
+
+import (
+	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("External constants", func() {
+	var flipABI = `[{"inputs":[{"internalType":"address","name":"vat_","type":"address"},{"internalType":"bytes32","name":"ilk_","type":"bytes32"}],"payable":false,"stateMutability":"nonpayable","type":"constructor"},{"anonymous":false,"inputs":[{"indexed":false,"internalType":"uint256","name":"id","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"lot","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"bid","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"tab","type":"uint256"},{"indexed":true,"internalType":"address","name":"usr","type":"address"},{"indexed":true,"internalType":"address","name":"gal","type":"address"}],"name":"Kick","type":"event"},{"anonymous":true,"inputs":[{"indexed":true,"internalType":"bytes4","name":"sig","type":"bytes4"},{"indexed":true,"internalType":"address","name":"usr","type":"address"},{"indexed":true,"internalType":"bytes32","name":"arg1","type":"bytes32"},{"indexed":true,"internalType":"bytes32","name":"arg2","type":"bytes32"},{"indexed":false,"internalType":"bytes","name":"data","type":"bytes"}],"name":"LogNote","type":"event"},{"constant":true,"inputs":[],"name":"beg","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[{"internalType":"uint256","name":"","type":"uint256"}],"name":"bids","outputs":[{"internalType":"uint256","name":"bid","type":"uint256"},{"internalType":"uint256","name":"lot","type":"uint256"},{"internalType":"address","name":"guy","type":"address"},{"internalType":"uint48","name":"tic","type":"uint48"},{"internalType":"uint48","name":"end","type":"uint48"},{"internalType":"address","name":"usr","type":"address"},{"internalType":"address","name":"gal","type":"address"},{"internalType":"uint256","name":"tab","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"internalType":"uint256","name":"id","type":"uint256"}],"name":"deal","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[{"internalType":"uint256","name":"id","type":"uint256"},{"internalType":"uint256","name":"lot","type":"uint256"},{"internalType":"uint256","name":"bid","type":"uint256"}],"name":"dent","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[{"internalType":"address","name":"usr","type":"address"}],"name":"deny","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[{"internalType":"bytes32","name":"what","type":"bytes32"},{"internalType":"uint256","name":"data","type":"uint256"}],"name":"file","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"ilk","outputs":[{"internalType":"bytes32","name":"","type":"bytes32"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"internalType":"address","name":"usr","type":"address"},{"internalType":"address","name":"gal","type":"address"},{"internalType":"uint256","name":"tab","type":"uint256"},{"internalType":"uint256","name":"lot","type":"uint256"},{"internalType":"uint256","name":"bid","type":"uint256"}],"name":"kick","outputs":[{"internalType":"uint256","name":"id","type":"uint256"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"kicks","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"internalType":"address","name":"usr","type":"address"}],"name":"rely","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"tau","outputs":[{"internalType":"uint48","name":"","type":"uint48"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"internalType":"uint256","name":"id","type":"uint256"},{"internalType":"uint256","name":"lot","type":"uint256"},{"internalType":"uint256","name":"bid","type":"uint256"}],"name":"tend","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[{"internalType":"uint256","name":"id","type":"uint256"}],"name":"tick","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"ttl","outputs":[{"internalType":"uint48","name":"","type":"uint48"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"vat","outputs":[{"internalType":"contract VatLike","name":"","type":"address"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[{"internalType":"address","name":"","type":"address"}],"name":"wards","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"internalType":"uint256","name":"id","type":"uint256"}],"name":"yank","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}]`
+
+	Describe("GetABIFromContractsWithMatchingABI", func() {
+		It("returns parsed ABI for contract", func() {
+			abi := constants.GetABIFromContractsWithMatchingABI([]string{"MCD_FLIP_ETH_A", "MCD_FLIP_BAT_A"})
+
+			Expect(abi).To(Equal(flipABI))
+		})
+
+		It("panics of contract ABIs do not match", func() {
+			parseConflictingABIs := func() {
+				constants.GetABIFromContractsWithMatchingABI([]string{"MCD_FLIP_ETH_A", "MCD_JUG"})
+			}
+
+			Expect(parseConflictingABIs).To(Panic())
+		})
+	})
+
+	Describe("GetFirstABI", func() {
+		It("returns ABI for first passed contract", func() {
+			abi := constants.GetFirstABI([]string{"MCD_FLIP_ETH_A", "MCD_JUG"})
+
+			Expect(abi).To(Equal(flipABI))
+		})
+	})
+})

--- a/transformers/shared/constants/method.go
+++ b/transformers/shared/constants/method.go
@@ -42,7 +42,7 @@ func OasisABI() string {
 	return GetContractsABI([]string{"OASIS_MATCHING_MARKET_ONE", "OASIS_MATCHING_MARKET_TWO"})
 }
 func OsmABI() string {
-	return GetContractsABI([]string{"OSM_ETH", "OSM_BAT"})
+	return GetContractsABI([]string{"OSM_ETH", "OSM_BAT", "OSM_WBTC"})
 }
 func PotABI() string  { return getContractABI("MCD_POT") }
 func SpotABI() string { return getContractABI("MCD_SPOT") }

--- a/transformers/shared/constants/method.go
+++ b/transformers/shared/constants/method.go
@@ -21,7 +21,7 @@ func CatABI() string        { return getContractABI("MCD_CAT") }
 func CdpManagerABI() string { return getContractABI("CDP_MANAGER") }
 func FlapABI() string       { return getContractABI("MCD_FLAP") }
 func FlipABI() string {
-	return GetContractsABI([]string{
+	return GetABIFromContractsWithMatchingABI([]string{
 		"MCD_FLIP_BAT_A",
 		"MCD_FLIP_ETH_A",
 		"MCD_FLIP_SAI",
@@ -34,15 +34,15 @@ func FlipABI() string {
 func FlopABI() string { return getContractABI("MCD_FLOP") }
 func JugABI() string  { return getContractABI("MCD_JUG") }
 func MedianABI() string {
-	return GetContractsABI([]string{
+	return GetABIFromContractsWithMatchingABI([]string{
 		"MEDIAN_ETH", "MEDIAN_BAT",
 	})
 }
 func OasisABI() string {
-	return GetContractsABI([]string{"OASIS_MATCHING_MARKET_ONE", "OASIS_MATCHING_MARKET_TWO"})
+	return GetABIFromContractsWithMatchingABI([]string{"OASIS_MATCHING_MARKET_ONE", "OASIS_MATCHING_MARKET_TWO"})
 }
 func OsmABI() string {
-	return GetContractsABI([]string{"OSM_ETH", "OSM_BAT", "OSM_WBTC"})
+	return GetABIFromContractsWithMatchingABI([]string{"OSM_ETH", "OSM_BAT", "OSM_WBTC"})
 }
 func PotABI() string  { return getContractABI("MCD_POT") }
 func SpotABI() string { return getContractABI("MCD_SPOT") }


### PR DESCRIPTION
iterating through: `for _, contractName := range contractNames[:1]` means we only ever look at the first passed ABI. Fixing that led to failures where formatting differed, so we're now parsing the ABI before comparison. This required a custom function to do the comparison since equality comparisons aren't implemented on `abi.ABI`. Decided to panic if that fails so that we can see the error message (didn't happen with the old `log.Fatal` approach if the test suite was redirecting the logs to `ioutil.Discard`).