### PR TITLE
Further optimize allUrns query

### DIFF
--- a/db/migrations/20200701153647_update_all_urns_function_to_use_join_table.sql
+++ b/db/migrations/20200701153647_update_all_urns_function_to_use_join_table.sql
@@ -1,0 +1,34 @@
+-- +goose Up
+-- SQL in this section is executed when the migration is applied.
+CREATE OR REPLACE FUNCTION api.all_urns(block_height bigint DEFAULT api.max_block(), max_results integer DEFAULT NULL::integer, result_offset integer DEFAULT 0) RETURNS SETOF api.urn_snapshot
+    LANGUAGE sql STABLE
+    AS $$
+WITH distinct_urn_snapshots AS (SELECT urn_identifier, ilk_identifier, MAX(block_height) AS block_height
+                                FROM api.urn_snapshot
+                                WHERE block_height <= all_urns.block_height
+                                GROUP BY urn_identifier, ilk_identifier)
+SELECT us.urn_identifier, us.ilk_identifier, us.block_height, us.ink, coalesce(us.art, 0), us.created, us.updated
+    FROM api.urn_snapshot AS us, distinct_urn_snapshots AS dus
+    WHERE us.urn_identifier = dus.urn_identifier
+    AND us.ilk_identifier = dus.ilk_identifier
+    AND us.block_height = dus.block_height
+    LIMIT all_urns.max_results
+    OFFSET all_urns.result_offset
+$$;
+
+-- +goose Down
+-- SQL in this section is executed when the migration is rolled back.
+CREATE OR REPLACE FUNCTION api.all_urns(block_height bigint DEFAULT api.max_block(), max_results integer DEFAULT NULL::integer, result_offset integer DEFAULT 0) RETURNS SETOF api.urn_snapshot
+    LANGUAGE sql STABLE
+    AS $$
+WITH distinct_urn_snapshots AS (
+    SELECT DISTINCT ON (urn_identifier, ilk_identifier)
+        urn_identifier, ilk_identifier, block_height, ink, coalesce(art, 0), created, updated
+        FROM api.urn_snapshot
+        WHERE block_height <= all_urns.block_height
+        ORDER BY urn_identifier, ilk_identifier, updated DESC)
+SELECT *
+    FROM distinct_urn_snapshots
+    LIMIT all_urns.max_results
+    OFFSET all_urns.result_offset
+$$;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -957,14 +957,15 @@ CREATE TABLE api.urn_snapshot (
 CREATE FUNCTION api.all_urns(block_height bigint DEFAULT api.max_block(), max_results integer DEFAULT NULL::integer, result_offset integer DEFAULT 0) RETURNS SETOF api.urn_snapshot
     LANGUAGE sql STABLE
     AS $$
-WITH distinct_urn_snapshots AS (
-    SELECT DISTINCT ON (urn_identifier, ilk_identifier)
-        urn_identifier, ilk_identifier, block_height, ink, coalesce(art, 0), created, updated
-        FROM api.urn_snapshot
-        WHERE block_height <= all_urns.block_height
-        ORDER BY urn_identifier, ilk_identifier, updated DESC)
-SELECT *
-    FROM distinct_urn_snapshots
+WITH distinct_urn_snapshots AS (SELECT urn_identifier, ilk_identifier, MAX(block_height) AS block_height
+                                FROM api.urn_snapshot
+                                WHERE block_height <= all_urns.block_height
+                                GROUP BY urn_identifier, ilk_identifier)
+SELECT us.urn_identifier, us.ilk_identifier, us.block_height, us.ink, coalesce(us.art, 0), us.created, us.updated
+    FROM api.urn_snapshot AS us, distinct_urn_snapshots AS dus
+    WHERE us.urn_identifier = dus.urn_identifier
+    AND us.ilk_identifier = dus.ilk_identifier
+    AND us.block_height = dus.block_height
     LIMIT all_urns.max_results
     OFFSET all_urns.result_offset
 $$;


### PR DESCRIPTION
Replace DISTINCT with GROUP BY and inner join which reduces the time for me locally against staging. 

For the original query a recent run gives me:

```sql
WITH distinct_urn_snapshots AS (
    SELECT DISTINCT ON (urn_identifier, ilk_identifier)
        urn_identifier, ilk_identifier, block_height, ink, coalesce(art, 0), created, updated
        FROM api.urn_snapshot
        WHERE block_height <= api.max_block()
        ORDER BY urn_identifier, ilk_identifier, updated DESC)
SELECT *
    FROM distinct_urn_snapshots
    LIMIT NULL::integer
    OFFSET 0
```
```
Successfully run. Total query runtime: 895 msec.
8057 rows affected.
```

The new version: 
```sql
-- My database has been migrated
SELECT * from api.all_urns();
```
```
Successfully run. Total query runtime: 321 msec.
8057 rows affected.
```
