### PR TITLE
VDB-1425: Update VDB version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ethereum/go-ethereum v1.9.11
 	github.com/jmoiron/sqlx v0.0.0-20181024163419-82935fac6c1a
 	github.com/lib/pq v1.0.0
-	github.com/makerdao/vulcanizedb v0.0.14-rc.1.0.20200526232336-ac90e4306d86
+	github.com/makerdao/vulcanizedb v0.0.15-rc.1.0.20200805152253-f679fa949f58
 	github.com/onsi/ginkgo v1.10.1
 	github.com/onsi/gomega v1.10.0
 	github.com/sirupsen/logrus v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ethereum/go-ethereum v1.9.11
 	github.com/jmoiron/sqlx v0.0.0-20181024163419-82935fac6c1a
 	github.com/lib/pq v1.0.0
-	github.com/makerdao/vulcanizedb v0.0.15-rc.1.0.20200805152253-f679fa949f58
+	github.com/makerdao/vulcanizedb v0.0.15-rc.1.0.20200810204254-a9ae4957b1fb
 	github.com/onsi/ginkgo v1.10.1
 	github.com/onsi/gomega v1.10.0
 	github.com/sirupsen/logrus v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -188,6 +188,8 @@ github.com/makerdao/go-ethereum v1.9.11-rc2 h1:ZjxmFdkar8P43EkK17ni8y3vXxHHFZjOd
 github.com/makerdao/go-ethereum v1.9.11-rc2/go.mod h1:7oC0Ni6dosMv5pxMigm6s0hN8g4haJMBnqmmo0D9YfQ=
 github.com/makerdao/vulcanizedb v0.0.14-rc.1.0.20200526232336-ac90e4306d86 h1:BUMHD6b1MOjGS5GCv7TZpqusNCq5jfGuOBG+tXI64hc=
 github.com/makerdao/vulcanizedb v0.0.14-rc.1.0.20200526232336-ac90e4306d86/go.mod h1:YizhD/sv4ywwCOJAjJNMPW3zjsnvGMW3hAGmMftE870=
+github.com/makerdao/vulcanizedb v0.0.15-rc.1.0.20200805152253-f679fa949f58 h1:t/v5wFXdPSAwV1EUKt9evjtPUcUru+hdaf96Uu4aWUA=
+github.com/makerdao/vulcanizedb v0.0.15-rc.1.0.20200805152253-f679fa949f58/go.mod h1:YizhD/sv4ywwCOJAjJNMPW3zjsnvGMW3hAGmMftE870=
 github.com/mattn/go-colorable v0.1.0/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/go.sum
+++ b/go.sum
@@ -190,6 +190,10 @@ github.com/makerdao/vulcanizedb v0.0.14-rc.1.0.20200526232336-ac90e4306d86 h1:BU
 github.com/makerdao/vulcanizedb v0.0.14-rc.1.0.20200526232336-ac90e4306d86/go.mod h1:YizhD/sv4ywwCOJAjJNMPW3zjsnvGMW3hAGmMftE870=
 github.com/makerdao/vulcanizedb v0.0.15-rc.1.0.20200805152253-f679fa949f58 h1:t/v5wFXdPSAwV1EUKt9evjtPUcUru+hdaf96Uu4aWUA=
 github.com/makerdao/vulcanizedb v0.0.15-rc.1.0.20200805152253-f679fa949f58/go.mod h1:YizhD/sv4ywwCOJAjJNMPW3zjsnvGMW3hAGmMftE870=
+github.com/makerdao/vulcanizedb v0.0.15-rc.1.0.20200807184600-293f764929dd h1:snWJ063czxnhUcsqMQkYWkYgagPmrTpoSRVCJERMMU4=
+github.com/makerdao/vulcanizedb v0.0.15-rc.1.0.20200807184600-293f764929dd/go.mod h1:YizhD/sv4ywwCOJAjJNMPW3zjsnvGMW3hAGmMftE870=
+github.com/makerdao/vulcanizedb v0.0.15-rc.1.0.20200810204254-a9ae4957b1fb h1:82B1JFQgrMbFRlQWGZrwwk3NG0FmLK6HMJRGJbhqBv0=
+github.com/makerdao/vulcanizedb v0.0.15-rc.1.0.20200810204254-a9ae4957b1fb/go.mod h1:YizhD/sv4ywwCOJAjJNMPW3zjsnvGMW3hAGmMftE870=
 github.com/mattn/go-colorable v0.1.0/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/transformers/component_tests/vat/configured_transformer_test.go
+++ b/transformers/component_tests/vat/configured_transformer_test.go
@@ -193,24 +193,6 @@ var _ = Describe("Executing the transformer", func() {
 			test_helpers.AssertMapping(spotResult, ilkSpotDiff.ID, header.Id, strconv.FormatInt(ilkId, 10), "89550000000000000000000000000")
 		})
 
-		It("reads in a Vat ilk spot storage diff with a hashed storage key", func() {
-			anotherIlk := "0x474e542d41000000000000000000000000000000000000000000000000000000"
-			anotherIlkID, err := shared.GetOrCreateIlk(anotherIlk, db)
-			Expect(err).NotTo(HaveOccurred())
-
-			key := common.HexToHash("2165edb4e1c37b99b60fa510d84f939dd35d5cd1d1c8f299d6456ea09df65a76")
-			value := common.HexToHash("00000000000000000000000000000000000000008b1bb2b1a88f91522d765555")
-			ilkSpotDiff := test_helpers.CreateDiffRecord(db, header, keccakOfAddress, key, value)
-
-			err = transformer.Execute(ilkSpotDiff)
-			Expect(err).NotTo(HaveOccurred())
-
-			var spotResult test_helpers.MappingRes
-			err = db.Get(&spotResult, `SELECT diff_id, header_id, ilk_id AS key, spot AS value FROM maker.vat_ilk_spot`)
-			Expect(err).NotTo(HaveOccurred())
-			test_helpers.AssertMapping(spotResult, ilkSpotDiff.ID, header.Id, strconv.FormatInt(anotherIlkID, 10), "43051901220750297886077900117")
-		})
-
 		It("reads in a Vat ilk line storage diff row and persists it", func() {
 			key := common.HexToHash("5cd43a2b0a7e767504a508ed07c6f6d26130368a2a5ce573193b4c24eba603be")
 			value := common.HexToHash("00000000000000000000000000047bf19673df52e37f2410011d100000000000")


### PR DESCRIPTION
- Updates VDB to use https://github.com/makerdao/vulcanizedb/pull/120
- This is part of the story to remove hashed storage keys. I think all of the hashing is done in VDB, and the only change that is happening here is to update the plugin integration test. But would love another set of eyes on it!