### PR TITLE
Add ContractAddressID to cat storage tables

### DIFF
--- a/db/migrations/20190215160236_create_cat_storage_tables.sql
+++ b/db/migrations/20190215160236_create_cat_storage_tables.sql
@@ -31,15 +31,18 @@ CREATE INDEX cat_vat_address_id_index
 
 CREATE TABLE maker.cat_vow
 (
-    id        SERIAL PRIMARY KEY,
-    diff_id   BIGINT  NOT NULL REFERENCES storage_diff (id) ON DELETE CASCADE,
-    header_id INTEGER NOT NULL REFERENCES headers (id) ON DELETE CASCADE,
-    vow       TEXT,
+    id          SERIAL PRIMARY KEY,
+    diff_id     BIGINT  NOT NULL REFERENCES storage_diff (id) ON DELETE CASCADE,
+    header_id   INTEGER NOT NULL REFERENCES headers (id) ON DELETE CASCADE,
+    address_id  INTEGER NOT NULL REFERENCES public.addresses (id) ON DELETE CASCADE,
+    vow         TEXT,
     UNIQUE (diff_id, header_id, vow)
 );
 
 CREATE INDEX cat_vow_header_id_index
     ON maker.cat_vow (header_id);
+CREATE INDEX cat_vow_address_id_index
+    ON maker.cat_vow (address_id);
 
 CREATE TABLE maker.cat_ilk_flip
 (

--- a/db/migrations/20190215160236_create_cat_storage_tables.sql
+++ b/db/migrations/20190215160236_create_cat_storage_tables.sql
@@ -46,11 +46,12 @@ CREATE INDEX cat_vow_address_id_index
 
 CREATE TABLE maker.cat_ilk_flip
 (
-    id        SERIAL PRIMARY KEY,
-    diff_id   BIGINT  NOT NULL REFERENCES storage_diff (id) ON DELETE CASCADE,
-    header_id INTEGER NOT NULL REFERENCES headers (id) ON DELETE CASCADE,
-    ilk_id    INTEGER NOT NULL REFERENCES maker.ilks (id) ON DELETE CASCADE,
-    flip      TEXT,
+    id          SERIAL PRIMARY KEY,
+    diff_id     BIGINT  NOT NULL REFERENCES storage_diff (id) ON DELETE CASCADE,
+    header_id   INTEGER NOT NULL REFERENCES headers (id) ON DELETE CASCADE,
+    ilk_id      INTEGER NOT NULL REFERENCES maker.ilks (id) ON DELETE CASCADE,
+    address_id  INTEGER NOT NULL REFERENCES public.addresses (id) ON DELETE CASCADE,
+    flip        TEXT,
     UNIQUE (diff_id, header_id, ilk_id, flip)
 );
 
@@ -58,14 +59,17 @@ CREATE INDEX cat_ilk_flip_header_id_index
     ON maker.cat_ilk_flip (header_id);
 CREATE INDEX cat_ilk_flip_ilk_index
     ON maker.cat_ilk_flip (ilk_id);
+CREATE INDEX cat_ilk_flip_address_id_index
+    ON maker.cat_ilk_flip (address_id);
 
 CREATE TABLE maker.cat_ilk_chop
 (
-    id        SERIAL PRIMARY KEY,
-    diff_id   BIGINT  NOT NULL REFERENCES storage_diff (id) ON DELETE CASCADE,
-    header_id INTEGER NOT NULL REFERENCES headers (id) ON DELETE CASCADE,
-    ilk_id    INTEGER NOT NULL REFERENCES maker.ilks (id) ON DELETE CASCADE,
-    chop      NUMERIC NOT NULL,
+    id          SERIAL PRIMARY KEY,
+    diff_id     BIGINT  NOT NULL REFERENCES storage_diff (id) ON DELETE CASCADE,
+    header_id   INTEGER NOT NULL REFERENCES headers (id) ON DELETE CASCADE,
+    ilk_id      INTEGER NOT NULL REFERENCES maker.ilks (id) ON DELETE CASCADE,
+    address_id  INTEGER NOT NULL REFERENCES public.addresses (id) ON DELETE CASCADE,
+    chop        NUMERIC NOT NULL,
     UNIQUE (diff_id, header_id, ilk_id, chop)
 );
 
@@ -73,14 +77,17 @@ CREATE INDEX cat_ilk_chop_header_id_index
     ON maker.cat_ilk_chop (header_id);
 CREATE INDEX cat_ilk_chop_ilk_index
     ON maker.cat_ilk_chop (ilk_id);
+CREATE INDEX cat_ilk_chop_address_id_index
+    ON maker.cat_ilk_chop (address_id);
 
 CREATE TABLE maker.cat_ilk_lump
 (
-    id        SERIAL PRIMARY KEY,
-    diff_id   BIGINT  NOT NULL REFERENCES storage_diff (id) ON DELETE CASCADE,
-    header_id INTEGER NOT NULL REFERENCES headers (id) ON DELETE CASCADE,
-    ilk_id    INTEGER NOT NULL REFERENCES maker.ilks (id) ON DELETE CASCADE,
-    lump      NUMERIC NOT NULL,
+    id          SERIAL PRIMARY KEY,
+    diff_id     BIGINT  NOT NULL REFERENCES storage_diff (id) ON DELETE CASCADE,
+    header_id   INTEGER NOT NULL REFERENCES headers (id) ON DELETE CASCADE,
+    ilk_id      INTEGER NOT NULL REFERENCES maker.ilks (id) ON DELETE CASCADE,
+    address_id  INTEGER NOT NULL REFERENCES public.addresses (id) ON DELETE CASCADE,
+    lump        NUMERIC NOT NULL,
     UNIQUE (diff_id, header_id, ilk_id, lump)
 );
 
@@ -88,6 +95,8 @@ CREATE INDEX cat_ilk_lump_header_id_index
     ON maker.cat_ilk_lump (header_id);
 CREATE INDEX cat_ilk_lump_ilk_index
     ON maker.cat_ilk_lump (ilk_id);
+CREATE INDEX cat_ilk_lump_address_id_index
+    ON maker.cat_ilk_lump (address_id);
 
 -- +goose Down
 DROP INDEX maker.cat_live_header_id_index;

--- a/db/migrations/20190215160236_create_cat_storage_tables.sql
+++ b/db/migrations/20190215160236_create_cat_storage_tables.sql
@@ -1,15 +1,18 @@
 -- +goose Up
 CREATE TABLE maker.cat_live
 (
-    id        SERIAL PRIMARY KEY,
-    diff_id   BIGINT  NOT NULL REFERENCES storage_diff (id) ON DELETE CASCADE,
-    header_id INTEGER NOT NULL REFERENCES headers (id) ON DELETE CASCADE,
-    live      NUMERIC NOT NULL,
+    id          SERIAL PRIMARY KEY,
+    diff_id     BIGINT  NOT NULL REFERENCES storage_diff (id) ON DELETE CASCADE,
+    header_id   INTEGER NOT NULL REFERENCES headers (id) ON DELETE CASCADE,
+    address_id  INTEGER NOT NULL REFERENCES public.addresses (id) ON DELETE CASCADE,
+    live        NUMERIC NOT NULL,
     UNIQUE (diff_id, header_id, live)
 );
 
 CREATE INDEX cat_live_header_id_index
     ON maker.cat_live (header_id);
+CREATE INDEX cat_live_address_id_index
+    ON maker.cat_live (address_id);
 
 CREATE TABLE maker.cat_vat
 (

--- a/db/migrations/20190215160236_create_cat_storage_tables.sql
+++ b/db/migrations/20190215160236_create_cat_storage_tables.sql
@@ -16,15 +16,18 @@ CREATE INDEX cat_live_address_id_index
 
 CREATE TABLE maker.cat_vat
 (
-    id        SERIAL PRIMARY KEY,
-    diff_id   BIGINT  NOT NULL REFERENCES storage_diff (id) ON DELETE CASCADE,
-    header_id INTEGER NOT NULL REFERENCES headers (id) ON DELETE CASCADE,
-    vat       TEXT,
+    id          SERIAL PRIMARY KEY,
+    diff_id     BIGINT  NOT NULL REFERENCES storage_diff (id) ON DELETE CASCADE,
+    header_id   INTEGER NOT NULL REFERENCES headers (id) ON DELETE CASCADE,
+    address_id  INTEGER NOT NULL REFERENCES public.addresses (id) ON DELETE CASCADE,
+    vat         TEXT,
     UNIQUE (diff_id, header_id, vat)
 );
 
 CREATE INDEX cat_vat_header_id_index
     ON maker.cat_vat (header_id);
+CREATE INDEX cat_vat_address_id_index
+    ON maker.cat_vat (address_id);
 
 CREATE TABLE maker.cat_vow
 (

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -7873,6 +7873,7 @@ CREATE TABLE maker.cat_live (
     id integer NOT NULL,
     diff_id bigint NOT NULL,
     header_id integer NOT NULL,
+    address_id integer NOT NULL,
     live numeric NOT NULL
 );
 
@@ -18425,6 +18426,13 @@ CREATE INDEX cat_ilk_lump_ilk_index ON maker.cat_ilk_lump USING btree (ilk_id);
 
 
 --
+-- Name: cat_live_address_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX cat_live_address_id_index ON maker.cat_live USING btree (address_id);
+
+
+--
 -- Name: cat_live_header_id_index; Type: INDEX; Schema: maker; Owner: -
 --
 
@@ -22304,6 +22312,14 @@ ALTER TABLE ONLY maker.cat_ilk_lump
 
 ALTER TABLE ONLY maker.cat_ilk_lump
     ADD CONSTRAINT cat_ilk_lump_ilk_id_fkey FOREIGN KEY (ilk_id) REFERENCES maker.ilks(id) ON DELETE CASCADE;
+
+
+--
+-- Name: cat_live cat_live_address_id_fkey; Type: FK CONSTRAINT; Schema: maker; Owner: -
+--
+
+ALTER TABLE ONLY maker.cat_live
+    ADD CONSTRAINT cat_live_address_id_fkey FOREIGN KEY (address_id) REFERENCES public.addresses(id) ON DELETE CASCADE;
 
 
 --

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -2598,6 +2598,7 @@ CREATE TABLE maker.cat_ilk_chop (
     diff_id bigint NOT NULL,
     header_id integer NOT NULL,
     ilk_id integer NOT NULL,
+    address_id integer NOT NULL,
     chop numeric NOT NULL
 );
 
@@ -3044,6 +3045,7 @@ CREATE TABLE maker.cat_ilk_flip (
     diff_id bigint NOT NULL,
     header_id integer NOT NULL,
     ilk_id integer NOT NULL,
+    address_id integer NOT NULL,
     flip text
 );
 
@@ -3825,6 +3827,7 @@ CREATE TABLE maker.cat_ilk_lump (
     diff_id bigint NOT NULL,
     header_id integer NOT NULL,
     ilk_id integer NOT NULL,
+    address_id integer NOT NULL,
     lump numeric NOT NULL
 );
 
@@ -18386,6 +18389,13 @@ CREATE INDEX cat_file_vow_msg_sender ON maker.cat_file_vow USING btree (msg_send
 
 
 --
+-- Name: cat_ilk_chop_address_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX cat_ilk_chop_address_id_index ON maker.cat_ilk_chop USING btree (address_id);
+
+
+--
 -- Name: cat_ilk_chop_header_id_index; Type: INDEX; Schema: maker; Owner: -
 --
 
@@ -18400,6 +18410,13 @@ CREATE INDEX cat_ilk_chop_ilk_index ON maker.cat_ilk_chop USING btree (ilk_id);
 
 
 --
+-- Name: cat_ilk_flip_address_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX cat_ilk_flip_address_id_index ON maker.cat_ilk_flip USING btree (address_id);
+
+
+--
 -- Name: cat_ilk_flip_header_id_index; Type: INDEX; Schema: maker; Owner: -
 --
 
@@ -18411,6 +18428,13 @@ CREATE INDEX cat_ilk_flip_header_id_index ON maker.cat_ilk_flip USING btree (hea
 --
 
 CREATE INDEX cat_ilk_flip_ilk_index ON maker.cat_ilk_flip USING btree (ilk_id);
+
+
+--
+-- Name: cat_ilk_lump_address_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX cat_ilk_lump_address_id_index ON maker.cat_ilk_lump USING btree (address_id);
 
 
 --
@@ -22259,6 +22283,14 @@ ALTER TABLE ONLY maker.cat_file_vow
 
 
 --
+-- Name: cat_ilk_chop cat_ilk_chop_address_id_fkey; Type: FK CONSTRAINT; Schema: maker; Owner: -
+--
+
+ALTER TABLE ONLY maker.cat_ilk_chop
+    ADD CONSTRAINT cat_ilk_chop_address_id_fkey FOREIGN KEY (address_id) REFERENCES public.addresses(id) ON DELETE CASCADE;
+
+
+--
 -- Name: cat_ilk_chop cat_ilk_chop_diff_id_fkey; Type: FK CONSTRAINT; Schema: maker; Owner: -
 --
 
@@ -22283,6 +22315,14 @@ ALTER TABLE ONLY maker.cat_ilk_chop
 
 
 --
+-- Name: cat_ilk_flip cat_ilk_flip_address_id_fkey; Type: FK CONSTRAINT; Schema: maker; Owner: -
+--
+
+ALTER TABLE ONLY maker.cat_ilk_flip
+    ADD CONSTRAINT cat_ilk_flip_address_id_fkey FOREIGN KEY (address_id) REFERENCES public.addresses(id) ON DELETE CASCADE;
+
+
+--
 -- Name: cat_ilk_flip cat_ilk_flip_diff_id_fkey; Type: FK CONSTRAINT; Schema: maker; Owner: -
 --
 
@@ -22304,6 +22344,14 @@ ALTER TABLE ONLY maker.cat_ilk_flip
 
 ALTER TABLE ONLY maker.cat_ilk_flip
     ADD CONSTRAINT cat_ilk_flip_ilk_id_fkey FOREIGN KEY (ilk_id) REFERENCES maker.ilks(id) ON DELETE CASCADE;
+
+
+--
+-- Name: cat_ilk_lump cat_ilk_lump_address_id_fkey; Type: FK CONSTRAINT; Schema: maker; Owner: -
+--
+
+ALTER TABLE ONLY maker.cat_ilk_lump
+    ADD CONSTRAINT cat_ilk_lump_address_id_fkey FOREIGN KEY (address_id) REFERENCES public.addresses(id) ON DELETE CASCADE;
 
 
 --

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -7906,6 +7906,7 @@ CREATE TABLE maker.cat_vat (
     id integer NOT NULL,
     diff_id bigint NOT NULL,
     header_id integer NOT NULL,
+    address_id integer NOT NULL,
     vat text
 );
 
@@ -18440,6 +18441,13 @@ CREATE INDEX cat_live_header_id_index ON maker.cat_live USING btree (header_id);
 
 
 --
+-- Name: cat_vat_address_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX cat_vat_address_id_index ON maker.cat_vat USING btree (address_id);
+
+
+--
 -- Name: cat_vat_header_id_index; Type: INDEX; Schema: maker; Owner: -
 --
 
@@ -22336,6 +22344,14 @@ ALTER TABLE ONLY maker.cat_live
 
 ALTER TABLE ONLY maker.cat_live
     ADD CONSTRAINT cat_live_header_id_fkey FOREIGN KEY (header_id) REFERENCES public.headers(id) ON DELETE CASCADE;
+
+
+--
+-- Name: cat_vat cat_vat_address_id_fkey; Type: FK CONSTRAINT; Schema: maker; Owner: -
+--
+
+ALTER TABLE ONLY maker.cat_vat
+    ADD CONSTRAINT cat_vat_address_id_fkey FOREIGN KEY (address_id) REFERENCES public.addresses(id) ON DELETE CASCADE;
 
 
 --

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -7939,6 +7939,7 @@ CREATE TABLE maker.cat_vow (
     id integer NOT NULL,
     diff_id bigint NOT NULL,
     header_id integer NOT NULL,
+    address_id integer NOT NULL,
     vow text
 );
 
@@ -18455,6 +18456,13 @@ CREATE INDEX cat_vat_header_id_index ON maker.cat_vat USING btree (header_id);
 
 
 --
+-- Name: cat_vow_address_id_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX cat_vow_address_id_index ON maker.cat_vow USING btree (address_id);
+
+
+--
 -- Name: cat_vow_header_id_index; Type: INDEX; Schema: maker; Owner: -
 --
 
@@ -22368,6 +22376,14 @@ ALTER TABLE ONLY maker.cat_vat
 
 ALTER TABLE ONLY maker.cat_vat
     ADD CONSTRAINT cat_vat_header_id_fkey FOREIGN KEY (header_id) REFERENCES public.headers(id) ON DELETE CASCADE;
+
+
+--
+-- Name: cat_vow cat_vow_address_id_fkey; Type: FK CONSTRAINT; Schema: maker; Owner: -
+--
+
+ALTER TABLE ONLY maker.cat_vow
+    ADD CONSTRAINT cat_vow_address_id_fkey FOREIGN KEY (address_id) REFERENCES public.addresses(id) ON DELETE CASCADE;
 
 
 --

--- a/transformers/component_tests/cat/configured_transformer_test.go
+++ b/transformers/component_tests/cat/configured_transformer_test.go
@@ -38,20 +38,21 @@ import (
 
 var _ = Describe("Executing the transformer", func() {
 	var (
-		db                = test_config.NewTestDB(test_config.NewTestNode())
-		contractAddress   = test_data.CatAddress()
-		keccakOfAddress   = types.HexToKeccak256Hash(contractAddress)
-		repository        = cat.StorageRepository{ContractAddress: contractAddress}
-		storageKeysLookup = storage.NewKeysLookup(cat.NewKeysLoader(&mcdStorage.MakerStorageRepository{}, contractAddress))
-		transformer       = storage.Transformer{
+		db              = test_config.NewTestDB(test_config.NewTestNode())
+		contractAddress = test_data.CatAddress()
+		keccakOfAddress = types.HexToKeccak256Hash(contractAddress)
+		transformer     storage.Transformer
+		header          = fakes.FakeHeader
+	)
+
+	BeforeEach(func() {
+		storageKeysLookup := storage.NewKeysLookup(cat.NewKeysLoader(&mcdStorage.MakerStorageRepository{}, contractAddress))
+		repository := cat.StorageRepository{ContractAddress: contractAddress}
+		transformer = storage.Transformer{
 			Address:           common.HexToAddress(contractAddress),
 			StorageKeysLookup: storageKeysLookup,
 			Repository:        &repository,
 		}
-		header = fakes.FakeHeader
-	)
-
-	BeforeEach(func() {
 		test_config.CleanTestDB(db)
 		transformer.NewTransformer(db)
 		headerRepository := repositories.NewHeaderRepository(db)
@@ -152,15 +153,13 @@ var _ = Describe("Executing the transformer", func() {
 
 	Describe("ilk", func() {
 		var (
-			ilk                string
-			ilkID              int64
-			ilkErr             error
-			contractAddressID  int64
-			contractAddressErr error
+			ilkID             int64
+			contractAddressID int64
 		)
 
 		BeforeEach(func() {
-			ilk = "0x4554482d41000000000000000000000000000000000000000000000000000000"
+			var ilkErr, contractAddressErr error
+			ilk := "0x4554482d41000000000000000000000000000000000000000000000000000000"
 			ilkID, ilkErr = shared.GetOrCreateIlk(ilk, db)
 			Expect(ilkErr).NotTo(HaveOccurred())
 			contractAddressID, contractAddressErr = shared.GetOrCreateAddress(contractAddress, db)

--- a/transformers/component_tests/cat/configured_transformer_test.go
+++ b/transformers/component_tests/cat/configured_transformer_test.go
@@ -65,13 +65,16 @@ var _ = Describe("Executing the transformer", func() {
 		value := common.HexToHash("0000000000000000000000000000000000000000000000000000000000000001")
 		catLiveDiff := test_helpers.CreateDiffRecord(db, header, keccakOfAddress, key, value)
 
+		contractAddressID, contractAddressErr := shared.GetOrCreateAddress(contractAddress, db)
+		Expect(contractAddressErr).NotTo(HaveOccurred())
+
 		err := transformer.Execute(catLiveDiff)
 		Expect(err).NotTo(HaveOccurred())
 
-		var liveResult test_helpers.VariableRes
-		err = db.Get(&liveResult, `SELECT diff_id, header_id, live AS value FROM maker.cat_live`)
+		var liveResult test_helpers.VariableResWithAddress
+		err = db.Get(&liveResult, `SELECT diff_id, header_id, address_id, live AS value FROM maker.cat_live`)
 		Expect(err).NotTo(HaveOccurred())
-		test_helpers.AssertVariable(liveResult, catLiveDiff.ID, header.Id, "1")
+		test_helpers.AssertVariableWithAddress(liveResult, catLiveDiff.ID, header.Id, contractAddressID, "1")
 	})
 
 	It("reads in a Cat Vat storage diff row and persists it", func() {

--- a/transformers/component_tests/cat/configured_transformer_test.go
+++ b/transformers/component_tests/cat/configured_transformer_test.go
@@ -190,10 +190,11 @@ var _ = Describe("Executing the transformer", func() {
 			err := transformer.Execute(catIlkChopDiff)
 			Expect(err).NotTo(HaveOccurred())
 
-			var ilkChopResult test_helpers.MappingRes
-			err = db.Get(&ilkChopResult, `SELECT diff_id, header_id, ilk_id AS key, chop AS value FROM maker.cat_ilk_chop`)
+			var ilkChopResult test_helpers.MappingResWithAddress
+			err = db.Get(&ilkChopResult, `SELECT diff_id, header_id, address_id, ilk_id AS key, chop AS value FROM maker.cat_ilk_chop`)
 			Expect(err).NotTo(HaveOccurred())
-			test_helpers.AssertMapping(ilkChopResult, catIlkChopDiff.ID, header.Id, strconv.FormatInt(ilkID, 10), "1000000000000000000000000000")
+			test_helpers.AssertMapping(ilkChopResult.MappingRes, catIlkChopDiff.ID, header.Id, strconv.FormatInt(ilkID, 10), "1000000000000000000000000000")
+			Expect(ilkChopResult.AddressID).To(Equal(contractAddressID))
 		})
 
 		It("reads in a Cat Ilk Lump storage diff row and persists it", func() {
@@ -204,10 +205,11 @@ var _ = Describe("Executing the transformer", func() {
 			err := transformer.Execute(catIlkLumpDiff)
 			Expect(err).NotTo(HaveOccurred())
 
-			var ilkLumpResult test_helpers.MappingRes
-			err = db.Get(&ilkLumpResult, `SELECT diff_id, header_id, ilk_id AS key, lump AS value FROM maker.cat_ilk_lump`)
+			var ilkLumpResult test_helpers.MappingResWithAddress
+			err = db.Get(&ilkLumpResult, `SELECT diff_id, header_id, address_id, ilk_id AS key, lump AS value FROM maker.cat_ilk_lump`)
 			Expect(err).NotTo(HaveOccurred())
-			test_helpers.AssertMapping(ilkLumpResult, catIlkLumpDiff.ID, header.Id, strconv.FormatInt(ilkID, 10), "10000000000000000000000000000000000000000000000000")
+			test_helpers.AssertMapping(ilkLumpResult.MappingRes, catIlkLumpDiff.ID, header.Id, strconv.FormatInt(ilkID, 10), "10000000000000000000000000000000000000000000000000")
+			Expect(ilkLumpResult.AddressID).To(Equal(contractAddressID))
 		})
 	})
 })

--- a/transformers/component_tests/cat/configured_transformer_test.go
+++ b/transformers/component_tests/cat/configured_transformer_test.go
@@ -99,13 +99,16 @@ var _ = Describe("Executing the transformer", func() {
 		value := common.HexToHash("00000000000000000000000021444ac712ccd21ce82af24ea1aec64cf07361d2")
 		catVowDiff := test_helpers.CreateDiffRecord(db, header, keccakOfAddress, key, value)
 
+		contractAddressID, contractAddressErr := shared.GetOrCreateAddress(contractAddress, db)
+		Expect(contractAddressErr).NotTo(HaveOccurred())
+
 		err := transformer.Execute(catVowDiff)
 		Expect(err).NotTo(HaveOccurred())
 
-		var vowResult test_helpers.VariableRes
-		err = db.Get(&vowResult, `SELECT diff_id, header_id, vow AS value FROM maker.cat_vow`)
+		var vowResult test_helpers.VariableResWithAddress
+		err = db.Get(&vowResult, `SELECT diff_id, header_id, address_id, vow AS value FROM maker.cat_vow`)
 		Expect(err).NotTo(HaveOccurred())
-		test_helpers.AssertVariable(vowResult, catVowDiff.ID, header.Id, "0x21444AC712cCD21ce82AF24eA1aEc64Cf07361D2")
+		test_helpers.AssertVariableWithAddress(vowResult, catVowDiff.ID, header.Id, contractAddressID, "0x21444AC712cCD21ce82AF24eA1aEc64Cf07361D2")
 	})
 
 	Describe("wards", func() {

--- a/transformers/component_tests/cat/configured_transformer_test.go
+++ b/transformers/component_tests/cat/configured_transformer_test.go
@@ -82,13 +82,16 @@ var _ = Describe("Executing the transformer", func() {
 		value := common.HexToHash("000000000000000000000000acdd1ee0f74954ed8f0ac581b081b7b86bd6aad9")
 		catVatDiff := test_helpers.CreateDiffRecord(db, header, keccakOfAddress, key, value)
 
+		contractAddressID, contractAddressErr := shared.GetOrCreateAddress(contractAddress, db)
+		Expect(contractAddressErr).NotTo(HaveOccurred())
+
 		err := transformer.Execute(catVatDiff)
 		Expect(err).NotTo(HaveOccurred())
 
-		var vatResult test_helpers.VariableRes
-		err = db.Get(&vatResult, `SELECT diff_id, header_id, vat AS value FROM maker.cat_vat`)
+		var vatResult test_helpers.VariableResWithAddress
+		err = db.Get(&vatResult, `SELECT diff_id, header_id, address_id, vat AS value FROM maker.cat_vat`)
 		Expect(err).NotTo(HaveOccurred())
-		test_helpers.AssertVariable(vatResult, catVatDiff.ID, header.Id, "0xaCdd1ee0F74954Ed8F0aC581b081B7b86bD6aad9")
+		test_helpers.AssertVariableWithAddress(vatResult, catVatDiff.ID, header.Id, contractAddressID, "0xaCdd1ee0F74954Ed8F0aC581b081B7b86bD6aad9")
 	})
 
 	It("reads in a Cat Vow storage diff row and persists it", func() {

--- a/transformers/component_tests/cat/configured_transformer_test.go
+++ b/transformers/component_tests/cat/configured_transformer_test.go
@@ -146,8 +146,7 @@ var _ = Describe("Executing the transformer", func() {
 			var wardsResult test_helpers.MappingResWithAddress
 			err := db.Get(&wardsResult, `SELECT diff_id, header_id, address_id, usr AS key, wards.wards AS value FROM maker.wards`)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(wardsResult.AddressID).To(Equal(catAddressID))
-			test_helpers.AssertMapping(wardsResult.MappingRes, wardsDiff.ID, header.Id, strconv.FormatInt(userAddressID, 10), "1")
+			test_helpers.AssertMappingWithAddress(wardsResult, wardsDiff.ID, header.Id, catAddressID, strconv.FormatInt(userAddressID, 10), "1")
 		})
 	})
 
@@ -177,8 +176,7 @@ var _ = Describe("Executing the transformer", func() {
 			var ilkFlipResult test_helpers.MappingResWithAddress
 			err = db.Get(&ilkFlipResult, `SELECT diff_id, header_id, address_id, ilk_id AS key, flip AS value FROM maker.cat_ilk_flip`)
 			Expect(err).NotTo(HaveOccurred())
-			test_helpers.AssertMapping(ilkFlipResult.MappingRes, catIlkFlipDiff.ID, header.Id, strconv.FormatInt(ilkID, 10), "0xB88d2655abA486A06e638707FBEbD858D430AC6E")
-			Expect(ilkFlipResult.AddressID).To(Equal(contractAddressID))
+			test_helpers.AssertMappingWithAddress(ilkFlipResult, catIlkFlipDiff.ID, header.Id, contractAddressID, strconv.FormatInt(ilkID, 10), "0xB88d2655abA486A06e638707FBEbD858D430AC6E")
 		})
 
 		It("reads in a Cat Ilk Chop storage diff row and persists it", func() {
@@ -192,8 +190,7 @@ var _ = Describe("Executing the transformer", func() {
 			var ilkChopResult test_helpers.MappingResWithAddress
 			err = db.Get(&ilkChopResult, `SELECT diff_id, header_id, address_id, ilk_id AS key, chop AS value FROM maker.cat_ilk_chop`)
 			Expect(err).NotTo(HaveOccurred())
-			test_helpers.AssertMapping(ilkChopResult.MappingRes, catIlkChopDiff.ID, header.Id, strconv.FormatInt(ilkID, 10), "1000000000000000000000000000")
-			Expect(ilkChopResult.AddressID).To(Equal(contractAddressID))
+			test_helpers.AssertMappingWithAddress(ilkChopResult, catIlkChopDiff.ID, header.Id, contractAddressID, strconv.FormatInt(ilkID, 10), "1000000000000000000000000000")
 		})
 
 		It("reads in a Cat Ilk Lump storage diff row and persists it", func() {
@@ -207,8 +204,7 @@ var _ = Describe("Executing the transformer", func() {
 			var ilkLumpResult test_helpers.MappingResWithAddress
 			err = db.Get(&ilkLumpResult, `SELECT diff_id, header_id, address_id, ilk_id AS key, lump AS value FROM maker.cat_ilk_lump`)
 			Expect(err).NotTo(HaveOccurred())
-			test_helpers.AssertMapping(ilkLumpResult.MappingRes, catIlkLumpDiff.ID, header.Id, strconv.FormatInt(ilkID, 10), "10000000000000000000000000000000000000000000000000")
-			Expect(ilkLumpResult.AddressID).To(Equal(contractAddressID))
+			test_helpers.AssertMappingWithAddress(ilkLumpResult, catIlkLumpDiff.ID, header.Id, contractAddressID, strconv.FormatInt(ilkID, 10), "10000000000000000000000000000000000000000000000000")
 		})
 	})
 })

--- a/transformers/component_tests/flap/configured_transformer_test.go
+++ b/transformers/component_tests/flap/configured_transformer_test.go
@@ -189,7 +189,7 @@ var _ = Describe("Executing the flap transformer", func() {
 			var wardsResult test_helpers.MappingResWithAddress
 			err := db.Get(&wardsResult, `SELECT diff_id, header_id, address_id, usr AS key, wards.wards AS value FROM maker.wards`)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(wardsResult.AddressID).To(Equal(strconv.FormatInt(flapAddressID, 10)))
+			Expect(wardsResult.AddressID).To(Equal(flapAddressID))
 			test_helpers.AssertMapping(wardsResult.MappingRes, wardsDiff.ID, header.Id, strconv.FormatInt(userAddressID, 10), "1")
 		})
 	})

--- a/transformers/component_tests/flap/configured_transformer_test.go
+++ b/transformers/component_tests/flap/configured_transformer_test.go
@@ -189,8 +189,7 @@ var _ = Describe("Executing the flap transformer", func() {
 			var wardsResult test_helpers.MappingResWithAddress
 			err := db.Get(&wardsResult, `SELECT diff_id, header_id, address_id, usr AS key, wards.wards AS value FROM maker.wards`)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(wardsResult.AddressID).To(Equal(flapAddressID))
-			test_helpers.AssertMapping(wardsResult.MappingRes, wardsDiff.ID, header.Id, strconv.FormatInt(userAddressID, 10), "1")
+			test_helpers.AssertMappingWithAddress(wardsResult, wardsDiff.ID, header.Id, flapAddressID, strconv.FormatInt(userAddressID, 10), "1")
 		})
 	})
 

--- a/transformers/component_tests/flip/configured_transformer_test.go
+++ b/transformers/component_tests/flip/configured_transformer_test.go
@@ -177,8 +177,7 @@ var _ = Describe("Executing the flip transformer", func() {
 			var wardsResult test_helpers.MappingResWithAddress
 			err := db.Get(&wardsResult, `SELECT diff_id, header_id, address_id, usr AS key, wards.wards AS value FROM maker.wards`)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(wardsResult.AddressID).To(Equal(flipAddressID))
-			test_helpers.AssertMapping(wardsResult.MappingRes, wardsDiff.ID, header.Id, strconv.FormatInt(userAddressID, 10), "1")
+			test_helpers.AssertMappingWithAddress(wardsResult, wardsDiff.ID, header.Id, flipAddressID, strconv.FormatInt(userAddressID, 10), "1")
 		})
 	})
 

--- a/transformers/component_tests/flip/configured_transformer_test.go
+++ b/transformers/component_tests/flip/configured_transformer_test.go
@@ -177,7 +177,7 @@ var _ = Describe("Executing the flip transformer", func() {
 			var wardsResult test_helpers.MappingResWithAddress
 			err := db.Get(&wardsResult, `SELECT diff_id, header_id, address_id, usr AS key, wards.wards AS value FROM maker.wards`)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(wardsResult.AddressID).To(Equal(strconv.FormatInt(flipAddressID, 10)))
+			Expect(wardsResult.AddressID).To(Equal(flipAddressID))
 			test_helpers.AssertMapping(wardsResult.MappingRes, wardsDiff.ID, header.Id, strconv.FormatInt(userAddressID, 10), "1")
 		})
 	})

--- a/transformers/component_tests/flop/configured_transformer_test.go
+++ b/transformers/component_tests/flop/configured_transformer_test.go
@@ -212,7 +212,7 @@ var _ = Describe("Executing the flop transformer", func() {
 			var wardsResult test_helpers.MappingResWithAddress
 			err := db.Get(&wardsResult, `SELECT diff_id, header_id, address_id, usr AS key, wards.wards AS value FROM maker.wards`)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(wardsResult.AddressID).To(Equal(strconv.FormatInt(flopAddressID, 10)))
+			Expect(wardsResult.AddressID).To(Equal(flopAddressID))
 			test_helpers.AssertMapping(wardsResult.MappingRes, wardsDiff.ID, header.Id, strconv.FormatInt(userAddressID, 10), "1")
 		})
 	})

--- a/transformers/component_tests/flop/configured_transformer_test.go
+++ b/transformers/component_tests/flop/configured_transformer_test.go
@@ -212,8 +212,7 @@ var _ = Describe("Executing the flop transformer", func() {
 			var wardsResult test_helpers.MappingResWithAddress
 			err := db.Get(&wardsResult, `SELECT diff_id, header_id, address_id, usr AS key, wards.wards AS value FROM maker.wards`)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(wardsResult.AddressID).To(Equal(flopAddressID))
-			test_helpers.AssertMapping(wardsResult.MappingRes, wardsDiff.ID, header.Id, strconv.FormatInt(userAddressID, 10), "1")
+			test_helpers.AssertMappingWithAddress(wardsResult, wardsDiff.ID, header.Id, flopAddressID, strconv.FormatInt(userAddressID, 10), "1")
 		})
 	})
 

--- a/transformers/component_tests/jug/configured_transformer_test.go
+++ b/transformers/component_tests/jug/configured_transformer_test.go
@@ -126,7 +126,7 @@ var _ = Describe("Executing the transformer", func() {
 		var wardsResult test_helpers.MappingResWithAddress
 		err := db.Get(&wardsResult, `SELECT diff_id, header_id, address_id, usr AS key, wards.wards AS value FROM maker.wards`)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(wardsResult.AddressID).To(Equal(strconv.FormatInt(jugAddressID, 10)))
+		Expect(wardsResult.AddressID).To(Equal(jugAddressID))
 		test_helpers.AssertMapping(wardsResult.MappingRes, wardsDiff.ID, header.Id, strconv.FormatInt(userAddressID, 10), "1")
 	})
 

--- a/transformers/component_tests/jug/configured_transformer_test.go
+++ b/transformers/component_tests/jug/configured_transformer_test.go
@@ -126,8 +126,7 @@ var _ = Describe("Executing the transformer", func() {
 		var wardsResult test_helpers.MappingResWithAddress
 		err := db.Get(&wardsResult, `SELECT diff_id, header_id, address_id, usr AS key, wards.wards AS value FROM maker.wards`)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(wardsResult.AddressID).To(Equal(jugAddressID))
-		test_helpers.AssertMapping(wardsResult.MappingRes, wardsDiff.ID, header.Id, strconv.FormatInt(userAddressID, 10), "1")
+		test_helpers.AssertMappingWithAddress(wardsResult, wardsDiff.ID, header.Id, jugAddressID, strconv.FormatInt(userAddressID, 10), "1")
 	})
 
 	It("reads in a Jug Ilk Duty storage diff row and persists it", func() {

--- a/transformers/component_tests/median/configured_transformer_test.go
+++ b/transformers/component_tests/median/configured_transformer_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Executing the median transformer", func() {
 			var wardsResult test_helpers.MappingResWithAddress
 			err := db.Get(&wardsResult, `SELECT diff_id, header_id, address_id, usr AS key, wards.wards AS value FROM maker.wards`)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(wardsResult.AddressID).To(Equal(strconv.FormatInt(medianAddressID, 10)))
+			Expect(wardsResult.AddressID).To(Equal(medianAddressID))
 			test_helpers.AssertMapping(wardsResult.MappingRes, wardsDiff.ID, header.Id, strconv.FormatInt(userAddressID, 10), "1")
 		})
 	})
@@ -119,7 +119,7 @@ var _ = Describe("Executing the median transformer", func() {
 			var budResult test_helpers.MappingResWithAddress
 			err := db.Get(&budResult, `SELECT diff_id, header_id, address_id, a AS key, bud AS value FROM maker.median_bud`)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(budResult.AddressID).To(Equal(strconv.FormatInt(medianAddressID, 10)))
+			Expect(budResult.AddressID).To(Equal(medianAddressID))
 			test_helpers.AssertMapping(budResult.MappingRes, wardsDiff.ID, header.Id, strconv.FormatInt(aAddressID, 10), "1")
 		})
 	})
@@ -158,7 +158,7 @@ var _ = Describe("Executing the median transformer", func() {
 			var orclResult test_helpers.MappingResWithAddress
 			err := db.Get(&orclResult, `SELECT diff_id, header_id, address_id, a AS key, orcl AS value from maker.median_orcl`)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(orclResult.AddressID).To(Equal(strconv.FormatInt(medianAddressID, 10)))
+			Expect(orclResult.AddressID).To(Equal(medianAddressID))
 			test_helpers.AssertMapping(orclResult.MappingRes, liftDiff.ID, header.Id, strconv.FormatInt(aAddressID, 10), "1")
 		})
 	})
@@ -200,7 +200,7 @@ var _ = Describe("Executing the median transformer", func() {
 			Expect(err).NotTo(HaveOccurred())
 			slotValueAddressID, slotErr := shared.GetOrCreateAddress(value.String(), db)
 			Expect(slotErr).NotTo(HaveOccurred())
-			Expect(slotResult.AddressID).To(Equal(strconv.FormatInt(medianAddressID, 10)))
+			Expect(slotResult.AddressID).To(Equal(medianAddressID))
 			solidityKey := "172"
 			test_helpers.AssertMapping(slotResult.MappingRes, liftDiff.ID, header.Id, solidityKey, strconv.FormatInt(slotValueAddressID, 10))
 		})

--- a/transformers/component_tests/median/configured_transformer_test.go
+++ b/transformers/component_tests/median/configured_transformer_test.go
@@ -80,8 +80,7 @@ var _ = Describe("Executing the median transformer", func() {
 			var wardsResult test_helpers.MappingResWithAddress
 			err := db.Get(&wardsResult, `SELECT diff_id, header_id, address_id, usr AS key, wards.wards AS value FROM maker.wards`)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(wardsResult.AddressID).To(Equal(medianAddressID))
-			test_helpers.AssertMapping(wardsResult.MappingRes, wardsDiff.ID, header.Id, strconv.FormatInt(userAddressID, 10), "1")
+			test_helpers.AssertMappingWithAddress(wardsResult, wardsDiff.ID, header.Id, medianAddressID, strconv.FormatInt(userAddressID, 10), "1")
 		})
 	})
 
@@ -119,8 +118,7 @@ var _ = Describe("Executing the median transformer", func() {
 			var budResult test_helpers.MappingResWithAddress
 			err := db.Get(&budResult, `SELECT diff_id, header_id, address_id, a AS key, bud AS value FROM maker.median_bud`)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(budResult.AddressID).To(Equal(medianAddressID))
-			test_helpers.AssertMapping(budResult.MappingRes, wardsDiff.ID, header.Id, strconv.FormatInt(aAddressID, 10), "1")
+			test_helpers.AssertMappingWithAddress(budResult, wardsDiff.ID, header.Id, medianAddressID, strconv.FormatInt(aAddressID, 10), "1")
 		})
 	})
 
@@ -158,8 +156,7 @@ var _ = Describe("Executing the median transformer", func() {
 			var orclResult test_helpers.MappingResWithAddress
 			err := db.Get(&orclResult, `SELECT diff_id, header_id, address_id, a AS key, orcl AS value from maker.median_orcl`)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(orclResult.AddressID).To(Equal(medianAddressID))
-			test_helpers.AssertMapping(orclResult.MappingRes, liftDiff.ID, header.Id, strconv.FormatInt(aAddressID, 10), "1")
+			test_helpers.AssertMappingWithAddress(orclResult, liftDiff.ID, header.Id, medianAddressID, strconv.FormatInt(aAddressID, 10), "1")
 		})
 	})
 
@@ -200,9 +197,8 @@ var _ = Describe("Executing the median transformer", func() {
 			Expect(err).NotTo(HaveOccurred())
 			slotValueAddressID, slotErr := shared.GetOrCreateAddress(value.String(), db)
 			Expect(slotErr).NotTo(HaveOccurred())
-			Expect(slotResult.AddressID).To(Equal(medianAddressID))
 			solidityKey := "172"
-			test_helpers.AssertMapping(slotResult.MappingRes, liftDiff.ID, header.Id, solidityKey, strconv.FormatInt(slotValueAddressID, 10))
+			test_helpers.AssertMappingWithAddress(slotResult, liftDiff.ID, header.Id, medianAddressID, solidityKey, strconv.FormatInt(slotValueAddressID, 10))
 		})
 	})
 })

--- a/transformers/component_tests/pot/configured_transformer_test.go
+++ b/transformers/component_tests/pot/configured_transformer_test.go
@@ -192,8 +192,7 @@ var _ = Describe("Executing the transformer", func() {
 			var wardsResult test_helpers.MappingResWithAddress
 			err := db.Get(&wardsResult, `SELECT diff_id, header_id, address_id, usr AS key, wards.wards AS value FROM maker.wards`)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(wardsResult.AddressID).To(Equal(potAddressID))
-			test_helpers.AssertMapping(wardsResult.MappingRes, wardsDiff.ID, header.Id, strconv.FormatInt(userAddressID, 10), "1")
+			test_helpers.AssertMappingWithAddress(wardsResult, wardsDiff.ID, header.Id, potAddressID, strconv.FormatInt(userAddressID, 10), "1")
 		})
 	})
 

--- a/transformers/component_tests/pot/configured_transformer_test.go
+++ b/transformers/component_tests/pot/configured_transformer_test.go
@@ -192,7 +192,7 @@ var _ = Describe("Executing the transformer", func() {
 			var wardsResult test_helpers.MappingResWithAddress
 			err := db.Get(&wardsResult, `SELECT diff_id, header_id, address_id, usr AS key, wards.wards AS value FROM maker.wards`)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(wardsResult.AddressID).To(Equal(strconv.FormatInt(potAddressID, 10)))
+			Expect(wardsResult.AddressID).To(Equal(potAddressID))
 			test_helpers.AssertMapping(wardsResult.MappingRes, wardsDiff.ID, header.Id, strconv.FormatInt(userAddressID, 10), "1")
 		})
 	})

--- a/transformers/component_tests/spot/configured_transformer_test.go
+++ b/transformers/component_tests/spot/configured_transformer_test.go
@@ -136,7 +136,7 @@ var _ = Describe("Executing the transformer", func() {
 			var wardsResult test_helpers.MappingResWithAddress
 			err := db.Get(&wardsResult, `SELECT diff_id, header_id, address_id, usr AS key, wards.wards AS value FROM maker.wards`)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(wardsResult.AddressID).To(Equal(strconv.FormatInt(spotAddressID, 10)))
+			Expect(wardsResult.AddressID).To(Equal(spotAddressID))
 			test_helpers.AssertMapping(wardsResult.MappingRes, wardsDiff.ID, header.Id, strconv.FormatInt(userAddressID, 10), "1")
 		})
 	})

--- a/transformers/component_tests/spot/configured_transformer_test.go
+++ b/transformers/component_tests/spot/configured_transformer_test.go
@@ -136,8 +136,7 @@ var _ = Describe("Executing the transformer", func() {
 			var wardsResult test_helpers.MappingResWithAddress
 			err := db.Get(&wardsResult, `SELECT diff_id, header_id, address_id, usr AS key, wards.wards AS value FROM maker.wards`)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(wardsResult.AddressID).To(Equal(spotAddressID))
-			test_helpers.AssertMapping(wardsResult.MappingRes, wardsDiff.ID, header.Id, strconv.FormatInt(userAddressID, 10), "1")
+			test_helpers.AssertMappingWithAddress(wardsResult, wardsDiff.ID, header.Id, spotAddressID, strconv.FormatInt(userAddressID, 10), "1")
 		})
 	})
 

--- a/transformers/component_tests/vat/configured_transformer_test.go
+++ b/transformers/component_tests/vat/configured_transformer_test.go
@@ -93,8 +93,7 @@ var _ = Describe("Executing the transformer", func() {
 		var wardsResult test_helpers.MappingResWithAddress
 		err := db.Get(&wardsResult, `SELECT diff_id, header_id, address_id, usr AS key, wards.wards AS value FROM maker.wards`)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(wardsResult.AddressID).To(Equal(vatAddressID))
-		test_helpers.AssertMapping(wardsResult.MappingRes, wardsDiff.ID, header.Id, strconv.FormatInt(userAddressID, 10), "1")
+		test_helpers.AssertMappingWithAddress(wardsResult, wardsDiff.ID, header.Id, vatAddressID, strconv.FormatInt(userAddressID, 10), "1")
 	})
 
 	It("reads in a Vat debt storage diff row and persists it", func() {

--- a/transformers/component_tests/vat/configured_transformer_test.go
+++ b/transformers/component_tests/vat/configured_transformer_test.go
@@ -93,7 +93,7 @@ var _ = Describe("Executing the transformer", func() {
 		var wardsResult test_helpers.MappingResWithAddress
 		err := db.Get(&wardsResult, `SELECT diff_id, header_id, address_id, usr AS key, wards.wards AS value FROM maker.wards`)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(wardsResult.AddressID).To(Equal(strconv.FormatInt(vatAddressID, 10)))
+		Expect(wardsResult.AddressID).To(Equal(vatAddressID))
 		test_helpers.AssertMapping(wardsResult.MappingRes, wardsDiff.ID, header.Id, strconv.FormatInt(userAddressID, 10), "1")
 	})
 

--- a/transformers/component_tests/vow/configured_transformer_test.go
+++ b/transformers/component_tests/vow/configured_transformer_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Executing the transformer", func() {
 			var wardsResult test_helpers.MappingResWithAddress
 			err := db.Get(&wardsResult, `SELECT diff_id, header_id, address_id, usr AS key, wards.wards AS value FROM maker.wards`)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(wardsResult.AddressID).To(Equal(strconv.FormatInt(vowAddressID, 10)))
+			Expect(wardsResult.AddressID).To(Equal(vowAddressID))
 			test_helpers.AssertMapping(wardsResult.MappingRes, wardsDiff.ID, header.Id, strconv.FormatInt(userAddressID, 10), "1")
 		})
 	})

--- a/transformers/component_tests/vow/configured_transformer_test.go
+++ b/transformers/component_tests/vow/configured_transformer_test.go
@@ -94,8 +94,7 @@ var _ = Describe("Executing the transformer", func() {
 			var wardsResult test_helpers.MappingResWithAddress
 			err := db.Get(&wardsResult, `SELECT diff_id, header_id, address_id, usr AS key, wards.wards AS value FROM maker.wards`)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(wardsResult.AddressID).To(Equal(vowAddressID))
-			test_helpers.AssertMapping(wardsResult.MappingRes, wardsDiff.ID, header.Id, strconv.FormatInt(userAddressID, 10), "1")
+			test_helpers.AssertMappingWithAddress(wardsResult, wardsDiff.ID, header.Id, vowAddressID, strconv.FormatInt(userAddressID, 10), "1")
 		})
 	})
 

--- a/transformers/shared/utilities.go
+++ b/transformers/shared/utilities.go
@@ -124,15 +124,10 @@ func InsertFieldWithIlk(diffID, headerID int64, ilk, variableName, query, value 
 	return tx.Commit()
 }
 
-func InsertFieldWithIlkAndAddress(diffID, headerID int64, address, ilk, variableName, query, value string, db *postgres.DB) error {
+func InsertFieldWithIlkAndAddress(diffID, headerID, addressID int64, ilk, variableName, query, value string, db *postgres.DB) error {
 	tx, txErr := db.Beginx()
 	if txErr != nil {
 		return fmt.Errorf("error beginning transaction: %w", txErr)
-	}
-
-	addressID, addressErr := GetOrCreateAddress(address, db)
-	if addressErr != nil {
-		return fmt.Errorf("Could not retrieve address id for %s, error: %w", address, addressErr)
 	}
 
 	ilkID, ilkErr := GetOrCreateIlkInTransaction(ilk, tx)

--- a/transformers/storage/cat/repository.go
+++ b/transformers/storage/cat/repository.go
@@ -16,7 +16,7 @@ const (
 	InsertCatIlkLumpQuery = `INSERT INTO maker.cat_ilk_lump (diff_id, header_id, ilk_id, lump) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
 
 	insertCatLiveQuery = `INSERT INTO maker.cat_live (diff_id, header_id, address_id, live) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
-	insertCatVatQuery  = `INSERT INTO maker.cat_vat (diff_id, header_id, vat) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING`
+	insertCatVatQuery  = `INSERT INTO maker.cat_vat (diff_id, header_id, address_id, vat) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
 	insertCatVowQuery  = `INSERT INTO maker.cat_vow (diff_id, header_id, vow) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING`
 )
 
@@ -36,7 +36,7 @@ func (repository *StorageRepository) Create(diffID, headerID int64, metadata typ
 	case Live:
 		return repository.insertLive(diffID, headerID, addressID, value.(string))
 	case Vat:
-		return repository.insertVat(diffID, headerID, value.(string))
+		return repository.insertVat(diffID, headerID, addressID, value.(string))
 	case Vow:
 		return repository.insertVow(diffID, headerID, value.(string))
 	case wards.Wards:
@@ -56,7 +56,7 @@ func (repository *StorageRepository) SetDB(db *postgres.DB) {
 	repository.db = db
 }
 
-func (repository *StorageRepository) insertLive(diffID, headerID int64, addressID int64, live string) error {
+func (repository *StorageRepository) insertLive(diffID, headerID, addressID int64, live string) error {
 	_, err := repository.db.Exec(insertCatLiveQuery, diffID, headerID, addressID, live)
 	if err != nil {
 		return fmt.Errorf("error inserting cat live %s from diff ID %d: %w", live, diffID, err)
@@ -64,8 +64,8 @@ func (repository *StorageRepository) insertLive(diffID, headerID int64, addressI
 	return nil
 }
 
-func (repository *StorageRepository) insertVat(diffID, headerID int64, vat string) error {
-	_, err := repository.db.Exec(insertCatVatQuery, diffID, headerID, vat)
+func (repository *StorageRepository) insertVat(diffID, headerID, addressID int64, vat string) error {
+	_, err := repository.db.Exec(insertCatVatQuery, diffID, headerID, addressID, vat)
 	if err != nil {
 		return fmt.Errorf("error inserting cat vat %s from diff ID %d: %w", vat, diffID, err)
 	}

--- a/transformers/storage/cat/repository.go
+++ b/transformers/storage/cat/repository.go
@@ -17,7 +17,7 @@ const (
 
 	insertCatLiveQuery = `INSERT INTO maker.cat_live (diff_id, header_id, address_id, live) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
 	insertCatVatQuery  = `INSERT INTO maker.cat_vat (diff_id, header_id, address_id, vat) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
-	insertCatVowQuery  = `INSERT INTO maker.cat_vow (diff_id, header_id, vow) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING`
+	insertCatVowQuery  = `INSERT INTO maker.cat_vow (diff_id, header_id, address_id, vow) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
 )
 
 type StorageRepository struct {
@@ -38,7 +38,7 @@ func (repository *StorageRepository) Create(diffID, headerID int64, metadata typ
 	case Vat:
 		return repository.insertVat(diffID, headerID, addressID, value.(string))
 	case Vow:
-		return repository.insertVow(diffID, headerID, value.(string))
+		return repository.insertVow(diffID, headerID, addressID, value.(string))
 	case wards.Wards:
 		return wards.InsertWards(diffID, headerID, metadata, repository.ContractAddress, value.(string), repository.db)
 	case IlkChop:
@@ -72,8 +72,8 @@ func (repository *StorageRepository) insertVat(diffID, headerID, addressID int64
 	return nil
 }
 
-func (repository *StorageRepository) insertVow(diffID, headerID int64, vow string) error {
-	_, err := repository.db.Exec(insertCatVowQuery, diffID, headerID, vow)
+func (repository *StorageRepository) insertVow(diffID, headerID, addressID int64, vow string) error {
+	_, err := repository.db.Exec(insertCatVowQuery, diffID, headerID, addressID, vow)
 	if err != nil {
 		return fmt.Errorf("error inserting cat vow %s from diff ID %d: %w", vow, diffID, err)
 	}

--- a/transformers/storage/cat/repository_test.go
+++ b/transformers/storage/cat/repository_test.go
@@ -70,12 +70,13 @@ var _ = Describe("Cat storage repository", func() {
 		Describe("Vat", func() {
 			vatMetadata := types.GetValueMetadata(cat.Vat, nil, types.Address)
 			inputs := shared_behaviors.StorageBehaviorInputs{
-				ValueFieldName: cat.Vat,
-				Value:          fakeAddress,
-				Schema:         constants.MakerSchema,
-				TableName:      constants.CatVatTable,
-				Repository:     &repo,
-				Metadata:       vatMetadata,
+				ValueFieldName:  cat.Vat,
+				Value:           fakeAddress,
+				Schema:          constants.MakerSchema,
+				TableName:       constants.CatVatTable,
+				Repository:      &repo,
+				ContractAddress: test_data.CatAddress(),
+				Metadata:        vatMetadata,
 			}
 
 			shared_behaviors.SharedStorageRepositoryBehaviors(&inputs)

--- a/transformers/storage/cat/repository_test.go
+++ b/transformers/storage/cat/repository_test.go
@@ -122,7 +122,7 @@ var _ = Describe("Cat storage repository", func() {
 			Expect(contractAddressErr).NotTo(HaveOccurred())
 			userAddressID, userAddressErr := shared.GetOrCreateAddress(fakeUserAddress, db)
 			Expect(userAddressErr).NotTo(HaveOccurred())
-			Expect(result.AddressID).To(Equal(strconv.FormatInt(contractAddressID, 10)))
+			Expect(result.AddressID).To(Equal(contractAddressID))
 			AssertMapping(result.MappingRes, diffID, fakeHeaderID, strconv.FormatInt(userAddressID, 10), fakeUint256)
 		})
 
@@ -166,13 +166,16 @@ var _ = Describe("Cat storage repository", func() {
 				err := repo.Create(diffID, fakeHeaderID, ilkFlipMetadata, fakeAddress)
 				Expect(err).NotTo(HaveOccurred())
 
-				var result MappingRes
-				query := fmt.Sprintf(`SELECT diff_id, header_id, ilk_id AS key, flip AS value FROM %s`, shared.GetFullTableName(constants.MakerSchema, constants.CatIlkFlipTable))
+				var result MappingResWithAddress
+				query := fmt.Sprintf(`SELECT diff_id, header_id, address_id, ilk_id AS key, flip AS value FROM %s`, shared.GetFullTableName(constants.MakerSchema, constants.CatIlkFlipTable))
 				err = db.Get(&result, query)
 				Expect(err).NotTo(HaveOccurred())
 				ilkID, err := shared.GetOrCreateIlk(test_helpers.FakeIlk.Hex, db)
 				Expect(err).NotTo(HaveOccurred())
-				AssertMapping(result, diffID, fakeHeaderID, strconv.FormatInt(ilkID, 10), fakeAddress)
+				contractAddressID, contractAddressErr := shared.GetOrCreateAddress(repo.ContractAddress, db)
+				Expect(contractAddressErr).NotTo(HaveOccurred())
+				Expect(result.AddressID).To(Equal(contractAddressID))
+				AssertMapping(result.MappingRes, diffID, fakeHeaderID, strconv.FormatInt(ilkID, 10), fakeAddress)
 			})
 
 			It("does not duplicate row", func() {

--- a/transformers/storage/cat/repository_test.go
+++ b/transformers/storage/cat/repository_test.go
@@ -85,12 +85,13 @@ var _ = Describe("Cat storage repository", func() {
 		Describe("Vow", func() {
 			vowMetadata := types.GetValueMetadata(cat.Vow, nil, types.Address)
 			inputs := shared_behaviors.StorageBehaviorInputs{
-				ValueFieldName: cat.Vow,
-				Value:          fakeAddress,
-				Schema:         constants.MakerSchema,
-				TableName:      constants.CatVowTable,
-				Repository:     &repo,
-				Metadata:       vowMetadata,
+				ValueFieldName:  cat.Vow,
+				Value:           fakeAddress,
+				Schema:          constants.MakerSchema,
+				TableName:       constants.CatVowTable,
+				Repository:      &repo,
+				ContractAddress: test_data.CatAddress(),
+				Metadata:        vowMetadata,
 			}
 
 			shared_behaviors.SharedStorageRepositoryBehaviors(&inputs)

--- a/transformers/storage/cat/repository_test.go
+++ b/transformers/storage/cat/repository_test.go
@@ -217,13 +217,16 @@ var _ = Describe("Cat storage repository", func() {
 				err := repo.Create(diffID, fakeHeaderID, ilkChopMetadata, fakeUint256)
 				Expect(err).NotTo(HaveOccurred())
 
-				var result MappingRes
-				query := fmt.Sprintf(`SELECT diff_id, header_id, ilk_id AS key, chop AS value FROM %s`, shared.GetFullTableName(constants.MakerSchema, constants.CatIlkChopTable))
+				var result MappingResWithAddress
+				query := fmt.Sprintf(`SELECT diff_id, header_id, address_id, ilk_id AS key, chop AS value FROM %s`, shared.GetFullTableName(constants.MakerSchema, constants.CatIlkChopTable))
 				err = db.Get(&result, query)
 				Expect(err).NotTo(HaveOccurred())
 				ilkID, err := shared.GetOrCreateIlk(test_helpers.FakeIlk.Hex, db)
+				contractAddressID, contractAddressErr := shared.GetOrCreateAddress(repo.ContractAddress, db)
+				Expect(contractAddressErr).NotTo(HaveOccurred())
 				Expect(err).NotTo(HaveOccurred())
-				AssertMapping(result, diffID, fakeHeaderID, strconv.FormatInt(ilkID, 10), fakeUint256)
+				AssertMapping(result.MappingRes, diffID, fakeHeaderID, strconv.FormatInt(ilkID, 10), fakeUint256)
+				Expect(result.AddressID).To(Equal(contractAddressID))
 			})
 
 			It("does not duplicate row", func() {
@@ -265,13 +268,17 @@ var _ = Describe("Cat storage repository", func() {
 				err := repo.Create(diffID, fakeHeaderID, ilkLumpMetadata, fakeUint256)
 				Expect(err).NotTo(HaveOccurred())
 
-				var result MappingRes
+				var result MappingResWithAddress
 				query := fmt.Sprintf(`SELECT diff_id, header_id, ilk_id AS key, lump AS value FROM %s`, shared.GetFullTableName(constants.MakerSchema, constants.CatIlkLumpTable))
 				err = db.Get(&result, query)
 				Expect(err).NotTo(HaveOccurred())
 				ilkID, err := shared.GetOrCreateIlk(test_helpers.FakeIlk.Hex, db)
 				Expect(err).NotTo(HaveOccurred())
-				AssertMapping(result, diffID, fakeHeaderID, strconv.FormatInt(ilkID, 10), fakeUint256)
+				contractAddressID, contractAddressErr := shared.GetOrCreateAddress(repo.ContractAddress, db)
+				Expect(contractAddressErr).NotTo(HaveOccurred())
+				AssertMapping(result.MappingRes, diffID, fakeHeaderID, strconv.FormatInt(ilkID, 10), fakeUint256)
+				Expect(contractAddressID).To(Equal(contractAddressID))
+
 			})
 
 			It("does not duplicate row", func() {

--- a/transformers/storage/cat/repository_test.go
+++ b/transformers/storage/cat/repository_test.go
@@ -122,8 +122,7 @@ var _ = Describe("Cat storage repository", func() {
 			Expect(contractAddressErr).NotTo(HaveOccurred())
 			userAddressID, userAddressErr := shared.GetOrCreateAddress(fakeUserAddress, db)
 			Expect(userAddressErr).NotTo(HaveOccurred())
-			Expect(result.AddressID).To(Equal(contractAddressID))
-			AssertMapping(result.MappingRes, diffID, fakeHeaderID, strconv.FormatInt(userAddressID, 10), fakeUint256)
+			AssertMappingWithAddress(result, diffID, fakeHeaderID, contractAddressID, strconv.FormatInt(userAddressID, 10), fakeUint256)
 		})
 
 		It("does not duplicate row", func() {
@@ -174,8 +173,7 @@ var _ = Describe("Cat storage repository", func() {
 				Expect(err).NotTo(HaveOccurred())
 				contractAddressID, contractAddressErr := shared.GetOrCreateAddress(repo.ContractAddress, db)
 				Expect(contractAddressErr).NotTo(HaveOccurred())
-				Expect(result.AddressID).To(Equal(contractAddressID))
-				AssertMapping(result.MappingRes, diffID, fakeHeaderID, strconv.FormatInt(ilkID, 10), fakeAddress)
+				AssertMappingWithAddress(result, diffID, fakeHeaderID, contractAddressID, strconv.FormatInt(ilkID, 10), fakeAddress)
 			})
 
 			It("does not duplicate row", func() {
@@ -225,8 +223,7 @@ var _ = Describe("Cat storage repository", func() {
 				contractAddressID, contractAddressErr := shared.GetOrCreateAddress(repo.ContractAddress, db)
 				Expect(contractAddressErr).NotTo(HaveOccurred())
 				Expect(err).NotTo(HaveOccurred())
-				AssertMapping(result.MappingRes, diffID, fakeHeaderID, strconv.FormatInt(ilkID, 10), fakeUint256)
-				Expect(result.AddressID).To(Equal(contractAddressID))
+				AssertMappingWithAddress(result, diffID, fakeHeaderID, contractAddressID, strconv.FormatInt(ilkID, 10), fakeUint256)
 			})
 
 			It("does not duplicate row", func() {
@@ -269,16 +266,14 @@ var _ = Describe("Cat storage repository", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				var result MappingResWithAddress
-				query := fmt.Sprintf(`SELECT diff_id, header_id, ilk_id AS key, lump AS value FROM %s`, shared.GetFullTableName(constants.MakerSchema, constants.CatIlkLumpTable))
+				query := fmt.Sprintf(`SELECT diff_id, header_id, address_id, ilk_id AS key, lump AS value FROM %s`, shared.GetFullTableName(constants.MakerSchema, constants.CatIlkLumpTable))
 				err = db.Get(&result, query)
 				Expect(err).NotTo(HaveOccurred())
 				ilkID, err := shared.GetOrCreateIlk(test_helpers.FakeIlk.Hex, db)
 				Expect(err).NotTo(HaveOccurred())
 				contractAddressID, contractAddressErr := shared.GetOrCreateAddress(repo.ContractAddress, db)
 				Expect(contractAddressErr).NotTo(HaveOccurred())
-				AssertMapping(result.MappingRes, diffID, fakeHeaderID, strconv.FormatInt(ilkID, 10), fakeUint256)
-				Expect(contractAddressID).To(Equal(contractAddressID))
-
+				AssertMappingWithAddress(result, diffID, fakeHeaderID, contractAddressID, strconv.FormatInt(ilkID, 10), fakeUint256)
 			})
 
 			It("does not duplicate row", func() {

--- a/transformers/storage/cat/repository_test.go
+++ b/transformers/storage/cat/repository_test.go
@@ -55,12 +55,13 @@ var _ = Describe("Cat storage repository", func() {
 		Describe("Live", func() {
 			liveMetadata := types.GetValueMetadata(cat.Live, nil, types.Uint256)
 			inputs := shared_behaviors.StorageBehaviorInputs{
-				ValueFieldName: cat.Live,
-				Value:          fakeUint256,
-				Schema:         constants.MakerSchema,
-				TableName:      constants.CatLiveTable,
-				Repository:     &repo,
-				Metadata:       liveMetadata,
+				ValueFieldName:  cat.Live,
+				Value:           fakeUint256,
+				Schema:          constants.MakerSchema,
+				TableName:       constants.CatLiveTable,
+				Repository:      &repo,
+				ContractAddress: test_data.CatAddress(),
+				Metadata:        liveMetadata,
 			}
 
 			shared_behaviors.SharedStorageRepositoryBehaviors(&inputs)

--- a/transformers/storage/flap/repository_test.go
+++ b/transformers/storage/flap/repository_test.go
@@ -112,8 +112,7 @@ var _ = Describe("Flap storage repository", func() {
 			Expect(contractAddressErr).NotTo(HaveOccurred())
 			userAddressID, userAddressErr := shared.GetOrCreateAddress(fakeUserAddress, db)
 			Expect(userAddressErr).NotTo(HaveOccurred())
-			Expect(result.AddressID).To(Equal(contractAddressID))
-			AssertMapping(result.MappingRes, diffID, fakeHeaderID, strconv.FormatInt(userAddressID, 10), fakeUint256)
+			AssertMappingWithAddress(result, diffID, fakeHeaderID, contractAddressID, strconv.FormatInt(userAddressID, 10), fakeUint256)
 		})
 
 		It("does not duplicate row", func() {

--- a/transformers/storage/flap/repository_test.go
+++ b/transformers/storage/flap/repository_test.go
@@ -112,7 +112,7 @@ var _ = Describe("Flap storage repository", func() {
 			Expect(contractAddressErr).NotTo(HaveOccurred())
 			userAddressID, userAddressErr := shared.GetOrCreateAddress(fakeUserAddress, db)
 			Expect(userAddressErr).NotTo(HaveOccurred())
-			Expect(result.AddressID).To(Equal(strconv.FormatInt(contractAddressID, 10)))
+			Expect(result.AddressID).To(Equal(contractAddressID))
 			AssertMapping(result.MappingRes, diffID, fakeHeaderID, strconv.FormatInt(userAddressID, 10), fakeUint256)
 		})
 

--- a/transformers/storage/flip/repository_test.go
+++ b/transformers/storage/flip/repository_test.go
@@ -92,8 +92,7 @@ var _ = Describe("Flip storage repository", func() {
 				Expect(contractAddressErr).NotTo(HaveOccurred())
 				userAddressID, userAddressErr := shared.GetOrCreateAddress(fakeUserAddress, db)
 				Expect(userAddressErr).NotTo(HaveOccurred())
-				Expect(result.AddressID).To(Equal(contractAddressID))
-				AssertMapping(result.MappingRes, diffID, fakeHeaderID, strconv.FormatInt(userAddressID, 10), fakeUint256)
+				AssertMappingWithAddress(result, diffID, fakeHeaderID, contractAddressID, strconv.FormatInt(userAddressID, 10), fakeUint256)
 			})
 
 			It("does not duplicate row", func() {

--- a/transformers/storage/flip/repository_test.go
+++ b/transformers/storage/flip/repository_test.go
@@ -92,7 +92,7 @@ var _ = Describe("Flip storage repository", func() {
 				Expect(contractAddressErr).NotTo(HaveOccurred())
 				userAddressID, userAddressErr := shared.GetOrCreateAddress(fakeUserAddress, db)
 				Expect(userAddressErr).NotTo(HaveOccurred())
-				Expect(result.AddressID).To(Equal(strconv.FormatInt(contractAddressID, 10)))
+				Expect(result.AddressID).To(Equal(contractAddressID))
 				AssertMapping(result.MappingRes, diffID, fakeHeaderID, strconv.FormatInt(userAddressID, 10), fakeUint256)
 			})
 

--- a/transformers/storage/flop/repository_test.go
+++ b/transformers/storage/flop/repository_test.go
@@ -246,7 +246,7 @@ var _ = Describe("Flop storage repository", func() {
 			Expect(contractAddressErr).NotTo(HaveOccurred())
 			userAddressID, userAddressErr := shared.GetOrCreateAddress(fakeUserAddress, db)
 			Expect(userAddressErr).NotTo(HaveOccurred())
-			Expect(result.AddressID).To(Equal(strconv.FormatInt(contractAddressID, 10)))
+			Expect(result.AddressID).To(Equal(contractAddressID))
 			AssertMapping(result.MappingRes, diffID, fakeHeaderID, strconv.FormatInt(userAddressID, 10), fakeUint256)
 		})
 

--- a/transformers/storage/flop/repository_test.go
+++ b/transformers/storage/flop/repository_test.go
@@ -246,8 +246,7 @@ var _ = Describe("Flop storage repository", func() {
 			Expect(contractAddressErr).NotTo(HaveOccurred())
 			userAddressID, userAddressErr := shared.GetOrCreateAddress(fakeUserAddress, db)
 			Expect(userAddressErr).NotTo(HaveOccurred())
-			Expect(result.AddressID).To(Equal(contractAddressID))
-			AssertMapping(result.MappingRes, diffID, fakeHeaderID, strconv.FormatInt(userAddressID, 10), fakeUint256)
+			AssertMappingWithAddress(result, diffID, fakeHeaderID, contractAddressID, strconv.FormatInt(userAddressID, 10), fakeUint256)
 		})
 
 		It("does not duplicate row", func() {

--- a/transformers/storage/jug/repository.go
+++ b/transformers/storage/jug/repository.go
@@ -68,6 +68,7 @@ func (repository StorageRepository) insertIlkRho(diffID, headerID int64, metadat
 	if err != nil {
 		return fmt.Errorf("error getting ilk for ilk rho: %w", err)
 	}
+
 	insertErr := shared.InsertFieldWithIlk(diffID, headerID, ilk, IlkRho, InsertJugIlkRhoQuery, rho, repository.db)
 	if insertErr != nil {
 		return fmt.Errorf("error inserting ilk %s rho %s from diff ID %d: %w", ilk, rho, diffID, insertErr)
@@ -80,6 +81,7 @@ func (repository StorageRepository) insertIlkDuty(diffID, headerID int64, metada
 	if err != nil {
 		return fmt.Errorf("error getting ilk for ilk duty: %w", err)
 	}
+
 	insertErr := shared.InsertFieldWithIlk(diffID, headerID, ilk, IlkDuty, InsertJugIlkDutyQuery, duty, repository.db)
 	if insertErr != nil {
 		return fmt.Errorf("error inserting ilk %s duty %s from diff ID %d: %w", ilk, duty, diffID, insertErr)

--- a/transformers/storage/jug/repository_test.go
+++ b/transformers/storage/jug/repository_test.go
@@ -75,8 +75,7 @@ var _ = Describe("Jug storage repository", func() {
 			Expect(contractAddressErr).NotTo(HaveOccurred())
 			userAddressID, userAddressErr := shared.GetOrCreateAddress(fakeUserAddress, db)
 			Expect(userAddressErr).NotTo(HaveOccurred())
-			Expect(result.AddressID).To(Equal(contractAddressID))
-			AssertMapping(result.MappingRes, diffID, fakeHeaderID, strconv.FormatInt(userAddressID, 10), fakeUint256)
+			AssertMappingWithAddress(result, diffID, fakeHeaderID, contractAddressID, strconv.FormatInt(userAddressID, 10), fakeUint256)
 		})
 
 		It("does not duplicate row", func() {

--- a/transformers/storage/jug/repository_test.go
+++ b/transformers/storage/jug/repository_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Jug storage repository", func() {
 			Expect(contractAddressErr).NotTo(HaveOccurred())
 			userAddressID, userAddressErr := shared.GetOrCreateAddress(fakeUserAddress, db)
 			Expect(userAddressErr).NotTo(HaveOccurred())
-			Expect(result.AddressID).To(Equal(strconv.FormatInt(contractAddressID, 10)))
+			Expect(result.AddressID).To(Equal(contractAddressID))
 			AssertMapping(result.MappingRes, diffID, fakeHeaderID, strconv.FormatInt(userAddressID, 10), fakeUint256)
 		})
 

--- a/transformers/storage/median/repository_test.go
+++ b/transformers/storage/median/repository_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Median Storage Repository", func() {
 			Expect(contractAddressErr).NotTo(HaveOccurred())
 			userAddressID, userAddressErr := shared.GetOrCreateAddress(fakeUserAddress, db)
 			Expect(userAddressErr).NotTo(HaveOccurred())
-			Expect(result.AddressID).To(Equal(strconv.FormatInt(contractAddressID, 10)))
+			Expect(result.AddressID).To(Equal(contractAddressID))
 			AssertMapping(result.MappingRes, diffID, fakeHeaderID, strconv.FormatInt(userAddressID, 10), fakeUint256)
 		})
 
@@ -184,7 +184,7 @@ var _ = Describe("Median Storage Repository", func() {
 			Expect(contractAddressErr).NotTo(HaveOccurred())
 			budAddressID, budAddressErr := shared.GetOrCreateAddress(fakeBudAddress, db)
 			Expect(budAddressErr).NotTo(HaveOccurred())
-			Expect(result.AddressID).To(Equal(strconv.FormatInt(contractAddressID, 10)))
+			Expect(result.AddressID).To(Equal(contractAddressID))
 			AssertMapping(result.MappingRes, diffID, fakeHeaderID, strconv.FormatInt(budAddressID, 10), fakeUint256)
 		})
 
@@ -230,7 +230,7 @@ var _ = Describe("Median Storage Repository", func() {
 			Expect(contractAddressErr).NotTo(HaveOccurred())
 			orclAddressID, orclAddressErr := shared.GetOrCreateAddress(fakeOrclAddress, db)
 			Expect(orclAddressErr).NotTo(HaveOccurred())
-			Expect(result.AddressID).To(Equal(strconv.FormatInt(contractAddressID, 10)))
+			Expect(result.AddressID).To(Equal(contractAddressID))
 			AssertMapping(result.MappingRes, diffID, fakeHeaderID, strconv.FormatInt(orclAddressID, 10), fakeUint256)
 		})
 
@@ -275,7 +275,7 @@ var _ = Describe("Median Storage Repository", func() {
 			Expect(contractAddressErr).NotTo(HaveOccurred())
 			slotAddressID, slotAddressErr := shared.GetOrCreateAddress(fakeSlotAddress, db)
 			Expect(slotAddressErr).NotTo(HaveOccurred())
-			Expect(result.AddressID).To(Equal(strconv.FormatInt(contractAddressID, 10)))
+			Expect(result.AddressID).To(Equal(contractAddressID))
 			AssertMapping(result.MappingRes, diffID, fakeHeaderID, fakeUint8, strconv.FormatInt(slotAddressID, 10))
 		})
 

--- a/transformers/storage/median/repository_test.go
+++ b/transformers/storage/median/repository_test.go
@@ -70,8 +70,7 @@ var _ = Describe("Median Storage Repository", func() {
 			Expect(contractAddressErr).NotTo(HaveOccurred())
 			userAddressID, userAddressErr := shared.GetOrCreateAddress(fakeUserAddress, db)
 			Expect(userAddressErr).NotTo(HaveOccurred())
-			Expect(result.AddressID).To(Equal(contractAddressID))
-			AssertMapping(result.MappingRes, diffID, fakeHeaderID, strconv.FormatInt(userAddressID, 10), fakeUint256)
+			AssertMappingWithAddress(result, diffID, fakeHeaderID, contractAddressID, strconv.FormatInt(userAddressID, 10), fakeUint256)
 		})
 
 		It("does not duplicate row", func() {
@@ -184,8 +183,7 @@ var _ = Describe("Median Storage Repository", func() {
 			Expect(contractAddressErr).NotTo(HaveOccurred())
 			budAddressID, budAddressErr := shared.GetOrCreateAddress(fakeBudAddress, db)
 			Expect(budAddressErr).NotTo(HaveOccurred())
-			Expect(result.AddressID).To(Equal(contractAddressID))
-			AssertMapping(result.MappingRes, diffID, fakeHeaderID, strconv.FormatInt(budAddressID, 10), fakeUint256)
+			AssertMappingWithAddress(result, diffID, fakeHeaderID, contractAddressID, strconv.FormatInt(budAddressID, 10), fakeUint256)
 		})
 
 		It("does not duplicate row", func() {
@@ -230,8 +228,7 @@ var _ = Describe("Median Storage Repository", func() {
 			Expect(contractAddressErr).NotTo(HaveOccurred())
 			orclAddressID, orclAddressErr := shared.GetOrCreateAddress(fakeOrclAddress, db)
 			Expect(orclAddressErr).NotTo(HaveOccurred())
-			Expect(result.AddressID).To(Equal(contractAddressID))
-			AssertMapping(result.MappingRes, diffID, fakeHeaderID, strconv.FormatInt(orclAddressID, 10), fakeUint256)
+			AssertMappingWithAddress(result, diffID, fakeHeaderID, contractAddressID, strconv.FormatInt(orclAddressID, 10), fakeUint256)
 		})
 
 		It("does not duplicate row", func() {
@@ -275,8 +272,7 @@ var _ = Describe("Median Storage Repository", func() {
 			Expect(contractAddressErr).NotTo(HaveOccurred())
 			slotAddressID, slotAddressErr := shared.GetOrCreateAddress(fakeSlotAddress, db)
 			Expect(slotAddressErr).NotTo(HaveOccurred())
-			Expect(result.AddressID).To(Equal(contractAddressID))
-			AssertMapping(result.MappingRes, diffID, fakeHeaderID, fakeUint8, strconv.FormatInt(slotAddressID, 10))
+			AssertMappingWithAddress(result, diffID, fakeHeaderID, contractAddressID, fakeUint8, strconv.FormatInt(slotAddressID, 10))
 		})
 
 		It("returns an error if metadata missing slotID", func() {

--- a/transformers/storage/pot/repository_test.go
+++ b/transformers/storage/pot/repository_test.go
@@ -226,7 +226,7 @@ var _ = Describe("Pot storage repository", func() {
 			Expect(contractAddressErr).NotTo(HaveOccurred())
 			userAddressID, userAddressErr := shared.GetOrCreateAddress(fakeUserAddress, db)
 			Expect(userAddressErr).NotTo(HaveOccurred())
-			Expect(result.AddressID).To(Equal(strconv.FormatInt(contractAddressID, 10)))
+			Expect(result.AddressID).To(Equal(contractAddressID))
 			AssertMapping(result.MappingRes, diffID, fakeHeaderID, strconv.FormatInt(userAddressID, 10), fakeUint256)
 		})
 

--- a/transformers/storage/pot/repository_test.go
+++ b/transformers/storage/pot/repository_test.go
@@ -226,8 +226,7 @@ var _ = Describe("Pot storage repository", func() {
 			Expect(contractAddressErr).NotTo(HaveOccurred())
 			userAddressID, userAddressErr := shared.GetOrCreateAddress(fakeUserAddress, db)
 			Expect(userAddressErr).NotTo(HaveOccurred())
-			Expect(result.AddressID).To(Equal(contractAddressID))
-			AssertMapping(result.MappingRes, diffID, fakeHeaderID, strconv.FormatInt(userAddressID, 10), fakeUint256)
+			AssertMappingWithAddress(result, diffID, fakeHeaderID, contractAddressID, strconv.FormatInt(userAddressID, 10), fakeUint256)
 		})
 
 		It("does not duplicate row", func() {

--- a/transformers/storage/spot/repository.go
+++ b/transformers/storage/spot/repository.go
@@ -68,6 +68,7 @@ func (repository StorageRepository) insertIlkPip(diffID, headerID int64, metadat
 	if err != nil {
 		return fmt.Errorf("error getting ilk for ilk pip: %w", err)
 	}
+
 	insertErr := shared.InsertFieldWithIlk(diffID, headerID, ilk, IlkPip, InsertSpotIlkPipQuery, pip, repository.db)
 	if insertErr != nil {
 		return fmt.Errorf("error inserting ilk %s pip %s from diff ID %d: %w", ilk, pip, diffID, insertErr)
@@ -80,6 +81,7 @@ func (repository StorageRepository) insertIlkMat(diffID, headerID int64, metadat
 	if err != nil {
 		return fmt.Errorf("error getting ilk for ilk mat: %w", err)
 	}
+
 	insertErr := shared.InsertFieldWithIlk(diffID, headerID, ilk, IlkMat, InsertSpotIlkMatQuery, mat, repository.db)
 	if insertErr != nil {
 		return fmt.Errorf("error inserting ilk %s mat %s from diff ID %d: %w", ilk, mat, diffID, insertErr)

--- a/transformers/storage/spot/repository_test.go
+++ b/transformers/storage/spot/repository_test.go
@@ -74,8 +74,7 @@ var _ = Describe("Spot storage repository", func() {
 			Expect(contractAddressErr).NotTo(HaveOccurred())
 			userAddressID, userAddressErr := shared.GetOrCreateAddress(fakeUserAddress, db)
 			Expect(userAddressErr).NotTo(HaveOccurred())
-			Expect(result.AddressID).To(Equal(contractAddressID))
-			AssertMapping(result.MappingRes, diffID, fakeHeaderID, strconv.FormatInt(userAddressID, 10), fakeUint256)
+			AssertMappingWithAddress(result, diffID, fakeHeaderID, contractAddressID, strconv.FormatInt(userAddressID, 10), fakeUint256)
 		})
 
 		It("does not duplicate row", func() {

--- a/transformers/storage/spot/repository_test.go
+++ b/transformers/storage/spot/repository_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Spot storage repository", func() {
 			Expect(contractAddressErr).NotTo(HaveOccurred())
 			userAddressID, userAddressErr := shared.GetOrCreateAddress(fakeUserAddress, db)
 			Expect(userAddressErr).NotTo(HaveOccurred())
-			Expect(result.AddressID).To(Equal(strconv.FormatInt(contractAddressID, 10)))
+			Expect(result.AddressID).To(Equal(contractAddressID))
 			AssertMapping(result.MappingRes, diffID, fakeHeaderID, strconv.FormatInt(userAddressID, 10), fakeUint256)
 		})
 

--- a/transformers/storage/test_helpers/datatypes.go
+++ b/transformers/storage/test_helpers/datatypes.go
@@ -36,7 +36,7 @@ type DoubleMappingRes struct {
 
 type MappingResWithAddress struct {
 	MappingRes
-	AddressID string `db:"address_id"`
+	AddressID int64 `db:"address_id"`
 }
 
 type FlapRes struct {

--- a/transformers/storage/test_helpers/datatypes.go
+++ b/transformers/storage/test_helpers/datatypes.go
@@ -18,6 +18,11 @@ type VariableRes struct {
 	DiffMetadata
 }
 
+type VariableResWithAddress struct {
+	VariableRes
+	AddressID int64 `db:"address_id"`
+}
+
 type MappingRes struct {
 	DiffMetadata
 	Key string
@@ -63,6 +68,13 @@ type FlopRes struct {
 func AssertVariable(res VariableRes, diffID, headerID int64, value string) {
 	Expect(res.DiffID).To(Equal(diffID))
 	Expect(res.HeaderID).To(Equal(headerID))
+	Expect(res.Value).To(Equal(value))
+}
+
+func AssertVariableWithAddress(res VariableResWithAddress, diffID, headerID, addressID int64, value string) {
+	Expect(res.DiffID).To(Equal(diffID))
+	Expect(res.HeaderID).To(Equal(headerID))
+	Expect(res.AddressID).To(Equal(addressID))
 	Expect(res.Value).To(Equal(value))
 }
 

--- a/transformers/storage/test_helpers/datatypes.go
+++ b/transformers/storage/test_helpers/datatypes.go
@@ -72,10 +72,8 @@ func AssertVariable(res VariableRes, diffID, headerID int64, value string) {
 }
 
 func AssertVariableWithAddress(res VariableResWithAddress, diffID, headerID, addressID int64, value string) {
-	Expect(res.DiffID).To(Equal(diffID))
-	Expect(res.HeaderID).To(Equal(headerID))
+	AssertVariable(res.VariableRes, diffID, headerID, value)
 	Expect(res.AddressID).To(Equal(addressID))
-	Expect(res.Value).To(Equal(value))
 }
 
 func AssertMapping(res MappingRes, diffID, headerID int64, key, value string) {
@@ -83,6 +81,12 @@ func AssertMapping(res MappingRes, diffID, headerID int64, key, value string) {
 	Expect(res.HeaderID).To(Equal(headerID))
 	Expect(res.Key).To(Equal(key))
 	Expect(res.Value).To(Equal(value))
+}
+
+func AssertMappingWithAddress(res MappingResWithAddress, diffID, headerID, addressID int64, key, value string) {
+	AssertMapping(res.MappingRes, diffID, headerID, key, value)
+	Expect(res.AddressID).To(Equal(addressID))
+
 }
 
 func AssertDoubleMapping(res DoubleMappingRes, diffID, headerID int64, keyOne, keyTwo, value string) {

--- a/transformers/storage/vat/repository_test.go
+++ b/transformers/storage/vat/repository_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Vat storage repository", func() {
 			Expect(contractAddressErr).NotTo(HaveOccurred())
 			userAddressID, userAddressErr := shared.GetOrCreateAddress(fakeUserAddress, db)
 			Expect(userAddressErr).NotTo(HaveOccurred())
-			Expect(result.AddressID).To(Equal(strconv.FormatInt(contractAddressID, 10)))
+			Expect(result.AddressID).To(Equal(contractAddressID))
 			AssertMapping(result.MappingRes, diffID, fakeHeaderID, strconv.FormatInt(userAddressID, 10), fakeUint256)
 		})
 

--- a/transformers/storage/vat/repository_test.go
+++ b/transformers/storage/vat/repository_test.go
@@ -76,8 +76,7 @@ var _ = Describe("Vat storage repository", func() {
 			Expect(contractAddressErr).NotTo(HaveOccurred())
 			userAddressID, userAddressErr := shared.GetOrCreateAddress(fakeUserAddress, db)
 			Expect(userAddressErr).NotTo(HaveOccurred())
-			Expect(result.AddressID).To(Equal(contractAddressID))
-			AssertMapping(result.MappingRes, diffID, fakeHeaderID, strconv.FormatInt(userAddressID, 10), fakeUint256)
+			AssertMappingWithAddress(result, diffID, fakeHeaderID, contractAddressID, strconv.FormatInt(userAddressID, 10), fakeUint256)
 		})
 
 		It("does not duplicate row", func() {

--- a/transformers/storage/vow/repository_test.go
+++ b/transformers/storage/vow/repository_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Vow storage repository test", func() {
 			Expect(contractAddressErr).NotTo(HaveOccurred())
 			userAddressID, userAddressErr := shared.GetOrCreateAddress(fakeUserAddress, db)
 			Expect(userAddressErr).NotTo(HaveOccurred())
-			Expect(result.AddressID).To(Equal(strconv.FormatInt(contractAddressID, 10)))
+			Expect(result.AddressID).To(Equal(contractAddressID))
 			AssertMapping(result.MappingRes, diffID, fakeHeaderID, strconv.FormatInt(userAddressID, 10), fakeUint256)
 		})
 

--- a/transformers/storage/vow/repository_test.go
+++ b/transformers/storage/vow/repository_test.go
@@ -72,8 +72,7 @@ var _ = Describe("Vow storage repository test", func() {
 			Expect(contractAddressErr).NotTo(HaveOccurred())
 			userAddressID, userAddressErr := shared.GetOrCreateAddress(fakeUserAddress, db)
 			Expect(userAddressErr).NotTo(HaveOccurred())
-			Expect(result.AddressID).To(Equal(contractAddressID))
-			AssertMapping(result.MappingRes, diffID, fakeHeaderID, strconv.FormatInt(userAddressID, 10), fakeUint256)
+			AssertMappingWithAddress(result, diffID, fakeHeaderID, contractAddressID, strconv.FormatInt(userAddressID, 10), fakeUint256)
 		})
 
 		It("does not duplicate row", func() {


### PR DESCRIPTION
A few things that make this larger than might be expected.

* The data_generator needed a hack because CatIlkChop and CatIlkLump now require an addressID, but the rest of the ilk tables don't.
* InsertFieldWithIlkAndAddress was added to shared/utlities, because not every InsertFieldWithIlk needs an address
* I changed MappingResWithAddress to take an int64. Since this is just in test code, it should be fine, but it caused a large number of cascading changes I didn't anticipate.