### PR TITLE
Add eth_node_id to storage_diffs_table

### DIFF
--- a/backfill/repository/storage_repository.go
+++ b/backfill/repository/storage_repository.go
@@ -46,9 +46,9 @@ func (repo storageRepository) GetUrnByID(id int64) (Urn, error) {
 
 func (repo storageRepository) InsertDiff(diff types.RawDiff) error {
 	_, err := repo.db.Exec(`INSERT INTO public.storage_diff (block_height, block_hash, hashed_address, storage_key,
-                storage_value, from_backfill) VALUES ($1, $2, $3, $4, $5, true) ON CONFLICT DO NOTHING;`,
+                storage_value, from_backfill, eth_node_id) VALUES ($1, $2, $3, $4, $5, true, $6) ON CONFLICT DO NOTHING;`,
 		diff.BlockHeight, diff.BlockHash.Bytes(), diff.HashedAddress.Bytes(), diff.StorageKey.Bytes(),
-		diff.StorageValue.Bytes())
+		diff.StorageValue.Bytes(), repo.db.NodeID)
 	return err
 }
 

--- a/db/migrations/00005_create_storage_diffs_table.sql
+++ b/db/migrations/00005_create_storage_diffs_table.sql
@@ -7,6 +7,7 @@ CREATE TABLE public.storage_diff
     hashed_address BYTEA,
     storage_key    BYTEA,
     storage_value  BYTEA,
+    eth_node_id    INTEGER NOT NULL REFERENCES public.eth_nodes (id) ON DELETE CASCADE,
     checked        BOOLEAN NOT NULL DEFAULT FALSE,
     from_backfill  BOOLEAN NOT NULL DEFAULT FALSE,
     UNIQUE (block_height, block_hash, hashed_address, storage_key, storage_value)
@@ -14,6 +15,8 @@ CREATE TABLE public.storage_diff
 
 CREATE INDEX storage_diff_checked_index
     ON public.storage_diff (checked) WHERE checked = false;
+CREATE INDEX storage_diff_eth_node
+    ON public.storage_diff (eth_node_id);
 
 -- +goose Down
 DROP TABLE public.storage_diff;

--- a/db/migrations/00011_create_create_back_filled_diff_function.sql
+++ b/db/migrations/00011_create_create_back_filled_diff_function.sql
@@ -1,7 +1,7 @@
 -- +goose Up
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION public.create_back_filled_diff(block_height BIGINT, block_hash BYTEA, hashed_address BYTEA,
-                                                          storage_key BYTEA, storage_value BYTEA) RETURNS VOID AS
+                                                          storage_key BYTEA, storage_value BYTEA, eth_node_id INTEGER) RETURNS VOID AS
 $$
 DECLARE
     last_storage_value  BYTEA := (
@@ -26,10 +26,10 @@ BEGIN
     END IF;
 
     INSERT INTO public.storage_diff (block_height, block_hash, hashed_address, storage_key, storage_value,
-                                     from_backfill)
+                                     eth_node_id, from_backfill)
     VALUES (create_back_filled_diff.block_height, create_back_filled_diff.block_hash,
             create_back_filled_diff.hashed_address, create_back_filled_diff.storage_key,
-            create_back_filled_diff.storage_value, true)
+            create_back_filled_diff.storage_value, create_back_filled_diff.eth_node_id, true)
     ON CONFLICT DO NOTHING;
 
     RETURN;
@@ -38,8 +38,8 @@ $$
     LANGUAGE plpgsql;
 -- +goose StatementEnd
 
-COMMENT ON FUNCTION public.create_back_filled_diff(block_height BIGINT, block_hash BYTEA, hashed_address BYTEA, storage_key BYTEA, storage_value BYTEA)
+COMMENT ON FUNCTION public.create_back_filled_diff(block_height BIGINT, block_hash BYTEA, hashed_address BYTEA, storage_key BYTEA, storage_value BYTEA, eth_node_id INTEGER)
     IS E'@omit';
 
 -- +goose Down
-DROP FUNCTION public.create_back_filled_diff(block_height BIGINT, block_hash BYTEA, hashed_address BYTEA, storage_key BYTEA, storage_value BYTEA);
+DROP FUNCTION public.create_back_filled_diff(block_height BIGINT, block_hash BYTEA, hashed_address BYTEA, storage_key BYTEA, storage_value BYTEA, eth_node_id INTEGER);

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/jmoiron/sqlx v0.0.0-20181024163419-82935fac6c1a
 	github.com/lib/pq v1.0.0
-	github.com/makerdao/vulcanizedb v0.0.15-rc.1.0.20200811182937-89a4c0b00a08
+	github.com/makerdao/vulcanizedb v0.0.15-rc.1.0.20200813201755-ded0808a0c6b
 	github.com/onsi/ginkgo v1.10.1
 	github.com/onsi/gomega v1.10.0
 	github.com/sirupsen/logrus v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -205,6 +205,8 @@ github.com/makerdao/vulcanizedb v0.0.15-rc.1.0.20200810204254-a9ae4957b1fb h1:82
 github.com/makerdao/vulcanizedb v0.0.15-rc.1.0.20200810204254-a9ae4957b1fb/go.mod h1:YizhD/sv4ywwCOJAjJNMPW3zjsnvGMW3hAGmMftE870=
 github.com/makerdao/vulcanizedb v0.0.15-rc.1.0.20200811182937-89a4c0b00a08 h1:fmh0uN6V9lt9sFHr4DmNr0vfygGUNb2tW15v5VQkRqQ=
 github.com/makerdao/vulcanizedb v0.0.15-rc.1.0.20200811182937-89a4c0b00a08/go.mod h1:uHEp22Kbjtb3HPSifRchqh/A6M73UCt/+glptjoO8GQ=
+github.com/makerdao/vulcanizedb v0.0.15-rc.1.0.20200813201755-ded0808a0c6b h1:Cv9TE9G7809IcYbVr32K3+bW3CBESxfhRPQnSvExc+E=
+github.com/makerdao/vulcanizedb v0.0.15-rc.1.0.20200813201755-ded0808a0c6b/go.mod h1:uHEp22Kbjtb3HPSifRchqh/A6M73UCt/+glptjoO8GQ=
 github.com/mattn/go-colorable v0.1.0/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=


### PR DESCRIPTION
Synchronize with vulcanizedb. 

This meant pointing to the staging version of vulcanizedb so that PersistedDiff would have the EthNodeID. 