### PR TITLE
Use cat_file_chop_lump as transformer label

### DIFF
--- a/environments/docker.toml
+++ b/environments/docker.toml
@@ -58,7 +58,7 @@
         "bite",
         "cat_claw",
         "cat_file_box",
-        "cat_file_chop_lump_dunk",
+        "cat_file_chop_lump",
         "cat_file_flip",
         "cat_file_vow",
         "deal",
@@ -486,8 +486,8 @@
         migrations = "db/migrations"
         contracts = ["MCD_CAT_1.1.0"]
         rank = "0"
-    [exporter.cat_file_chop_lump_dunk]
-        path = "transformers/events/cat_file/chop_lump_dunk/initializer"
+    [exporter.cat_file_chop_lump]
+        path = "transformers/events/cat_file/chop_lump/initializer"
         type = "eth_event"
         repository = "github.com/makerdao/vdb-mcd-transformers"
         migrations = "db/migrations"

--- a/environments/mcdTransformers.toml
+++ b/environments/mcdTransformers.toml
@@ -71,7 +71,7 @@
         "bite",
         "cat_claw",
         "cat_file_box",
-        "cat_file_chop_lump_dunk",
+        "cat_file_chop_lump",
         "cat_file_flip",
         "cat_file_vow",
         "deal",
@@ -499,8 +499,8 @@
         migrations = "db/migrations"
         contracts = ["MCD_CAT_1.1.0"]
         rank = "0"
-    [exporter.cat_file_chop_lump_dunk]
-        path = "transformers/events/cat_file/chop_lump_dunk/initializer"
+    [exporter.cat_file_chop_lump]
+        path = "transformers/events/cat_file/chop_lump/initializer"
         type = "eth_event"
         repository = "github.com/makerdao/vdb-mcd-transformers"
         migrations = "db/migrations"

--- a/environments/testing.toml
+++ b/environments/testing.toml
@@ -71,7 +71,7 @@
         "bite",
         "cat_claw",
         "cat_file_box",
-        "cat_file_chop_lump_dunk",
+        "cat_file_chop_lump",
         "cat_file_flip",
         "cat_file_vow",
         "deal",
@@ -499,8 +499,8 @@
         migrations = "db/migrations"
         contracts = ["MCD_CAT_1.1.0"]
         rank = "0"
-    [exporter.cat_file_chop_lump_dunk]
-        path = "transformers/events/cat_file/chop_lump_dunk/initializer"
+    [exporter.cat_file_chop_lump]
+        path = "transformers/events/cat_file/chop_lump/initializer"
         type = "eth_event"
         repository = "github.com/makerdao/vdb-mcd-transformers"
         migrations = "db/migrations"

--- a/plugins/execute/transformerExporter.go
+++ b/plugins/execute/transformerExporter.go
@@ -9,7 +9,7 @@ import (
 	bite "github.com/makerdao/vdb-mcd-transformers/transformers/events/bite/initializer"
 	cat_claw "github.com/makerdao/vdb-mcd-transformers/transformers/events/cat_claw/initializer"
 	cat_file_box "github.com/makerdao/vdb-mcd-transformers/transformers/events/cat_file/box/initializer"
-	cat_file_chop_lump_dunk "github.com/makerdao/vdb-mcd-transformers/transformers/events/cat_file/chop_lump_dunk/initializer"
+	cat_file_chop_lump "github.com/makerdao/vdb-mcd-transformers/transformers/events/cat_file/chop_lump/initializer"
 	cat_file_flip "github.com/makerdao/vdb-mcd-transformers/transformers/events/cat_file/flip/initializer"
 	cat_file_vow "github.com/makerdao/vdb-mcd-transformers/transformers/events/cat_file/vow/initializer"
 	deal "github.com/makerdao/vdb-mcd-transformers/transformers/events/deal/initializer"
@@ -143,7 +143,7 @@ func (e exporter) Export() ([]event.TransformerInitializer, []storage.Transforme
 			bite.EventTransformerInitializer,
 			cat_claw.EventTransformerInitializer,
 			cat_file_box.EventTransformerInitializer,
-			cat_file_chop_lump_dunk.EventTransformerInitializer,
+			cat_file_chop_lump.EventTransformerInitializer,
 			cat_file_flip.EventTransformerInitializer,
 			cat_file_vow.EventTransformerInitializer,
 			deal.EventTransformerInitializer,

--- a/transformers/events/cat_file/chop_lump/chop_lump_suite_test.go
+++ b/transformers/events/cat_file/chop_lump/chop_lump_suite_test.go
@@ -14,16 +14,16 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package initializer
+package chop_lump_test
 
 import (
-	"github.com/makerdao/vdb-mcd-transformers/transformers/events/cat_file/chop_lump_dunk"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
-	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
-var EventTransformerInitializer event.TransformerInitializer = event.ConfiguredTransformer{
-	Config:      shared.GetEventTransformerConfig(constants.CatFileChopLumpTable, constants.CatFileChopLumpSignature()),
-	Transformer: chop_lump_dunk.Transformer{},
-}.NewTransformer
+func TestChopLump(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CatFileChopLump Event Transformer Suite")
+}

--- a/transformers/events/cat_file/chop_lump/initializer/initializer.go
+++ b/transformers/events/cat_file/chop_lump/initializer/initializer.go
@@ -14,16 +14,16 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package chop_lump_dunk_test
+package initializer
 
 import (
-	"testing"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/makerdao/vdb-mcd-transformers/transformers/events/cat_file/chop_lump"
+	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
+	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
+	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 )
 
-func TestChopLump(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "CatFileChopLump Event Transformer Suite")
-}
+var EventTransformerInitializer event.TransformerInitializer = event.ConfiguredTransformer{
+	Config:      shared.GetEventTransformerConfig(constants.CatFileChopLumpTable, constants.CatFileChopLumpSignature()),
+	Transformer: chop_lump.Transformer{},
+}.NewTransformer

--- a/transformers/events/cat_file/chop_lump/transformer.go
+++ b/transformers/events/cat_file/chop_lump/transformer.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package chop_lump_dunk
+package chop_lump
 
 import (
 	"github.com/ethereum/go-ethereum/common/hexutil"

--- a/transformers/events/cat_file/chop_lump/transformer_test.go
+++ b/transformers/events/cat_file/chop_lump/transformer_test.go
@@ -14,13 +14,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package chop_lump_dunk_test
+package chop_lump_test
 
 import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/events/cat_file/chop_lump_dunk"
+	"github.com/makerdao/vdb-mcd-transformers/transformers/events/cat_file/chop_lump"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
@@ -32,7 +32,7 @@ import (
 
 var _ = Describe("Cat file chop lump transformer", func() {
 	var (
-		transformer = chop_lump_dunk.Transformer{}
+		transformer = chop_lump.Transformer{}
 		db          = test_config.NewTestDB(test_config.NewTestNode())
 	)
 

--- a/transformers/integration_tests/cat_file_test.go
+++ b/transformers/integration_tests/cat_file_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/cat_file/box"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/events/cat_file/chop_lump_dunk"
+	"github.com/makerdao/vdb-mcd-transformers/transformers/events/cat_file/chop_lump"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/cat_file/flip"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/cat_file/vow"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
@@ -59,7 +59,7 @@ var _ = Describe("Cat File transformer", func() {
 
 			initializer := event.ConfiguredTransformer{
 				Config:      catFileConfig,
-				Transformer: chop_lump_dunk.Transformer{},
+				Transformer: chop_lump.Transformer{},
 			}
 			transformer := initializer.NewTransformer(db)
 
@@ -96,7 +96,7 @@ var _ = Describe("Cat File transformer", func() {
 
 			initializer := event.ConfiguredTransformer{
 				Config:      catFileConfig,
-				Transformer: chop_lump_dunk.Transformer{},
+				Transformer: chop_lump.Transformer{},
 			}
 			transformer := initializer.NewTransformer(db)
 
@@ -255,7 +255,7 @@ var _ = Describe("Cat File transformer", func() {
 
 			initializer := event.ConfiguredTransformer{
 				Config:      catFileConfig,
-				Transformer: chop_lump_dunk.Transformer{},
+				Transformer: chop_lump.Transformer{},
 			}
 			transformer := initializer.NewTransformer(db)
 


### PR DESCRIPTION
- in initializer
- currently, the table name and transformer label are overloaded.
  If the table name doesn't match the transformer label (as it did
  not in this case, where the table was cat_file_chop_lump and the
  label was cat_file_chop_lump_dunk), then the initializer does not
  find addresses associated with the _table_ name.
- temporarily setting up transformer label to match table name, but
  it would be good to circle back and decouple these things.
- also would be nice to start execute in CI to verify config works.