### PR TITLE
Rename references to execute vdb-mcd-execute

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Note that, as with other commands, executing this requires either a config file 
 **NOTE** The database must be migrated once before running the `headerSync` command, otherwise the database will not be able to properly create its schema. Assuming you are not using the `docker-compose` setup above you can migrate the database once using:
 
 ```
-docker run -e DATABASE_USER=<user> -e DATABASE_PASSWORD=<pw> -e DATABASE_HOSTNAME=<host> -e DATABASE_PORT=<port> -e DATABASE_NAME=<name> -e CLIENT_IPCPATH=<path> makerdao/vdb-execute:latest ./run_migrations.sh
+docker run -e DATABASE_USER=<user> -e DATABASE_PASSWORD=<pw> -e DATABASE_HOSTNAME=<host> -e DATABASE_PORT=<port> -e DATABASE_NAME=<name> -e CLIENT_IPCPATH=<path> makerdao/vdb-mcd-execute:latest ./run_migrations.sh
 ```
 
 #### Running `headerSync`
@@ -103,7 +103,7 @@ docker run -e DATABASE_USER=<user> -e DATABASE_PASSWORD=<pw> -e DATABASE_HOSTNAM
   - when running on MacOSX use `host.docker.internal` as the `DATABASE_HOSTNAME` and as the host in the `CLIENT_IPCPATH`
 
 #### Running `execute`
-`execute` Docker images are located in the [MakerDao Dockerhub organization](https://hub.docker.com/repository/docker/makerdao/vdb-execute). See the [Docker README](./dockerfiles/README.md) for further information.
+`execute` Docker images are located in the [MakerDao Dockerhub organization](https://hub.docker.com/repository/docker/makerdao/vdb-mcd-execute). See the [Docker README](./dockerfiles/README.md) for further information.
 
 ### With the CLI
 

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -4,10 +4,12 @@
 Builds an alpine image for running the vulcanizedb `execute` command against transformers in this repo.
 
 ### Build
-Build from the project root directory with: `docker build -f dockerfiles/execute/Dockerfile . -t execute:latest`.
+Build from the project root directory with: `docker build -f dockerfiles/execute/Dockerfile . -t vdb-mcd-execute:latest`.
 The following options are available at build time:
-- `VDB_VERSION` - target a specific vulcanizedb branch/release to generate the binary (ex: `docker build -f dockerfiles/execute/Dockerfile --build-arg VDB_VERSION=v0.0.14-rc.1 . -t execute:latest`).
-- `CONFIG_FILE` - path to desired config file for this container (ex: `docker build -f dockerfiles/execute/Dockerfile --build-arg CONFIG_FILE=path . -t execute:latest`).
+- `VDB_VERSION` - target a specific vulcanizedb branch/release to generate the binary (ex: `docker build -f dockerfiles/execute/Dockerfile --build-arg VDB_VERSION=v0.0.14-rc.1 . -t vdb-mcd-execute:latest`).
+- `CONFIG_FILE` - path to desired config file for this container (ex: `docker build -f dockerfiles/execute/Dockerfile --build-arg CONFIG_FILE=path . -t vdb-mcd-execute:latest`).
+
+There is a `make` task as well named `dockerbuild` which can quickly build the image with `make dockerbuild IMAGE=execute`, but that is not suitable for a production build.
 
 ### Run
 Running the container requires an existing DB with which the container can interact.
@@ -26,7 +28,7 @@ The following arguments are required at runtime:
 With arguments correctly populated, the following command will run the container on OS X:
 
 ```
-docker run -e DATABASE_NAME=vulcanize_public -e DATABASE_HOSTNAME=host.docker.internal -e DATABASE_PORT=5432 -e DATABASE_USER=user -e DATABASE_PASSWORD=pw -e CLIENT_IPCPATH=https://mainnet.infura.io/v3/token -it execute:latest
+docker run -e DATABASE_NAME=vulcanize_public -e DATABASE_HOSTNAME=host.docker.internal -e DATABASE_PORT=5432 -e DATABASE_USER=user -e DATABASE_PASSWORD=pw -e CLIENT_IPCPATH=https://mainnet.infura.io/v3/token -it vdb-mcd-execute:latest
 ```
 
 #### Explanation

--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -51,7 +51,7 @@ services:
     command: ["./wait-for-it.sh", "db:5432", "--strict", "--", "./startup_script.sh"]
 
   execute:
-    image: makerdao/vdb-execute:latest # (needs wait-for-it.sh)
+    image: makerdao/vdb-mcd-execute:latest # (needs wait-for-it.sh)
     environment:
       - CLIENT_IPCPATH=ws://geth-statediffing:8546
       - DATABASE_NAME=vdb


### PR DESCRIPTION
I didn't rename all references since the process is still named execute, it's just the docker image that is namespaced.

This is part of VDB-1630 to get Oasis ready for deploy.