### PR TITLE
Make sure busybox is on execute image

### DIFF
--- a/dockerfiles/execute/Dockerfile
+++ b/dockerfiles/execute/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update \
         && apt-get install -y \
         ca-certificates \
         bash \
+        busybox \
         postgresql-client \
         && update-ca-certificates 2>/dev/null || true
 


### PR DESCRIPTION
Busybox is used by the wait-for-it script and was already present on alpine, so the execute container needs it.