### PR TITLE
Remove shared functions inserting addresses

### DIFF
--- a/data_generator/data_generator.go
+++ b/data_generator/data_generator.go
@@ -11,12 +11,12 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/jmoiron/sqlx"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/storage/cat"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/storage/jug"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/storage/test_helpers"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/storage/vat"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/libraries/shared/storage"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
@@ -398,7 +398,7 @@ func (state *GeneratorState) insertInitialIlkData(ilkId int64) error {
 		cat.InsertCatIlkLumpQuery,
 	}
 
-	contractAddressID, contractAddressErr := shared.GetOrCreateAddress(getRandomAddress(), state.db)
+	contractAddressID, contractAddressErr := repository.GetOrCreateAddress(state.db, getRandomAddress())
 	if contractAddressErr != nil {
 		return fmt.Errorf("error inserting random contract address: %w", contractAddressErr)
 	}

--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,6 @@ github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDe
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/makerdao/go-ethereum v1.9.21-rc1 h1:izuLZxMHei6UX89Q2Ld1v5PYcuYEhw34/Ncf/e/WPW8=
 github.com/makerdao/go-ethereum v1.9.21-rc1/go.mod h1:RXAVzbGrSGmDkDnHymruTAIEjUR3E4TX0EOpaj702sI=
-github.com/makerdao/vulcanizedb v0.0.15-rc.1.0.20200929194143-7adef1042ead h1:azwmqedVoxpfybMB38d4wQnr3rfot91wxm0EYPqf+ds=
-github.com/makerdao/vulcanizedb v0.0.15-rc.1.0.20200929194143-7adef1042ead/go.mod h1:VXiGa8YKMzA2aiKanFNA2vtMS4n7dP2fVxCUt4Bar4w=
 github.com/makerdao/vulcanizedb v0.1.0 h1:CPNLVGaw6R3+tHnUlBiDULr3lsKziFa0UM8Nc/JsYnw=
 github.com/makerdao/vulcanizedb v0.1.0/go.mod h1:VXiGa8YKMzA2aiKanFNA2vtMS4n7dP2fVxCUt4Bar4w=
 github.com/mattn/go-colorable v0.1.0 h1:v2XXALHHh6zHfYTJ+cSkwtyffnaOyR1MXaA91mTrb8o=

--- a/transformers/component_tests/cat/configured_transformer_test.go
+++ b/transformers/component_tests/cat/configured_transformer_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/storage"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
 	"github.com/makerdao/vulcanizedb/pkg/fakes"
 	. "github.com/onsi/ginkgo"
@@ -65,7 +66,7 @@ var _ = Describe("Executing the transformer", func() {
 		value := common.HexToHash("0000000000000000000000000000000000000000000000000000000000000001")
 		catLiveDiff := test_helpers.CreateDiffRecord(db, header, contractAddress, key, value)
 
-		contractAddressID, contractAddressErr := shared.GetOrCreateAddress(contractAddress.Hex(), db)
+		contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, contractAddress.Hex())
 		Expect(contractAddressErr).NotTo(HaveOccurred())
 
 		err := transformer.Execute(catLiveDiff)
@@ -82,7 +83,7 @@ var _ = Describe("Executing the transformer", func() {
 		value := common.HexToHash("000000000000000000000000acdd1ee0f74954ed8f0ac581b081b7b86bd6aad9")
 		catVatDiff := test_helpers.CreateDiffRecord(db, header, contractAddress, key, value)
 
-		contractAddressID, contractAddressErr := shared.GetOrCreateAddress(contractAddress.Hex(), db)
+		contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, contractAddress.Hex())
 		Expect(contractAddressErr).NotTo(HaveOccurred())
 
 		err := transformer.Execute(catVatDiff)
@@ -99,7 +100,7 @@ var _ = Describe("Executing the transformer", func() {
 		value := common.HexToHash("00000000000000000000000021444ac712ccd21ce82af24ea1aec64cf07361d2")
 		catVowDiff := test_helpers.CreateDiffRecord(db, header, contractAddress, key, value)
 
-		contractAddressID, contractAddressErr := shared.GetOrCreateAddress(contractAddress.Hex(), db)
+		contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, contractAddress.Hex())
 		Expect(contractAddressErr).NotTo(HaveOccurred())
 
 		err := transformer.Execute(catVowDiff)
@@ -116,15 +117,15 @@ var _ = Describe("Executing the transformer", func() {
 			denyLog := test_data.CreateTestLog(header.Id, db)
 			denyModel := test_data.DenyModel()
 
-			catAddressID, catAddressErr := shared.GetOrCreateAddress(contractAddress.Hex(), db)
+			catAddressID, catAddressErr := repository.GetOrCreateAddress(db, contractAddress.Hex())
 			Expect(catAddressErr).NotTo(HaveOccurred())
 
 			userAddress := "0x39ad5d336a4c08fac74879f796e1ea0af26c1521"
-			userAddressID, userAddressErr := shared.GetOrCreateAddress(userAddress, db)
+			userAddressID, userAddressErr := repository.GetOrCreateAddress(db, userAddress)
 			Expect(userAddressErr).NotTo(HaveOccurred())
 
 			msgSenderAddress := "0x" + fakes.RandomString(40)
-			msgSenderAddressID, msgSenderAddressErr := shared.GetOrCreateAddress(msgSenderAddress, db)
+			msgSenderAddressID, msgSenderAddressErr := repository.GetOrCreateAddress(db, msgSenderAddress)
 			Expect(msgSenderAddressErr).NotTo(HaveOccurred())
 
 			denyModel.ColumnValues[event.HeaderFK] = header.Id
@@ -160,7 +161,7 @@ var _ = Describe("Executing the transformer", func() {
 			ilk := "0x4554482d41000000000000000000000000000000000000000000000000000000"
 			ilkID, ilkErr = shared.GetOrCreateIlk(ilk, db)
 			Expect(ilkErr).NotTo(HaveOccurred())
-			contractAddressID, contractAddressErr = shared.GetOrCreateAddress(contractAddress.Hex(), db)
+			contractAddressID, contractAddressErr = repository.GetOrCreateAddress(db, contractAddress.Hex())
 			Expect(contractAddressErr).NotTo(HaveOccurred())
 		})
 

--- a/transformers/component_tests/jug/configured_transformer_test.go
+++ b/transformers/component_tests/jug/configured_transformer_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/storage"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
 	"github.com/makerdao/vulcanizedb/pkg/fakes"
 	. "github.com/onsi/ginkgo"
@@ -40,11 +41,11 @@ var _ = Describe("Executing the transformer", func() {
 		db                = test_config.NewTestDB(test_config.NewTestNode())
 		contractAddress   = common.HexToAddress(test_data.JugAddress())
 		storageKeysLookup = storage.NewKeysLookup(jug.NewKeysLoader(&mcdStorage.MakerStorageRepository{}, contractAddress.Hex()))
-		repository        = jug.StorageRepository{ContractAddress: contractAddress.Hex()}
+		repo              = jug.StorageRepository{ContractAddress: contractAddress.Hex()}
 		transformer       = storage.Transformer{
 			Address:           contractAddress,
 			StorageKeysLookup: storageKeysLookup,
-			Repository:        &repository,
+			Repository:        &repo,
 		}
 		header = fakes.FakeHeader
 		ilkID  int64
@@ -95,15 +96,15 @@ var _ = Describe("Executing the transformer", func() {
 		denyLog := test_data.CreateTestLog(header.Id, db)
 		denyModel := test_data.DenyModel()
 
-		jugAddressID, jugAddressErr := shared.GetOrCreateAddress(contractAddress.Hex(), db)
+		jugAddressID, jugAddressErr := repository.GetOrCreateAddress(db, contractAddress.Hex())
 		Expect(jugAddressErr).NotTo(HaveOccurred())
 
 		userAddress := "0x13141b8a5e4a82ebc6b636849dd6a515185d6236"
-		userAddressID, userAddressErr := shared.GetOrCreateAddress(userAddress, db)
+		userAddressID, userAddressErr := repository.GetOrCreateAddress(db, userAddress)
 		Expect(userAddressErr).NotTo(HaveOccurred())
 
 		msgSenderAddress := "0x" + fakes.RandomString(40)
-		msgSenderAddressID, msgSenderAddressErr := shared.GetOrCreateAddress(msgSenderAddress, db)
+		msgSenderAddressID, msgSenderAddressErr := repository.GetOrCreateAddress(db, msgSenderAddress)
 		Expect(msgSenderAddressErr).NotTo(HaveOccurred())
 
 		denyModel.ColumnValues[event.HeaderFK] = header.Id

--- a/transformers/component_tests/median/configured_transformer_test.go
+++ b/transformers/component_tests/median/configured_transformer_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/lib/pq"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	mcdStorage "github.com/makerdao/vdb-mcd-transformers/transformers/storage"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/storage/median"
@@ -14,6 +13,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/storage"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
 	"github.com/makerdao/vulcanizedb/pkg/fakes"
 	. "github.com/onsi/ginkgo"
@@ -31,11 +31,11 @@ var _ = Describe("Executing the median transformer", func() {
 
 	BeforeEach(func() {
 		test_config.CleanTestDB(db)
-		var repository = median.MedianStorageRepository{ContractAddress: contractAddress.Hex()}
+		repo := median.MedianStorageRepository{ContractAddress: contractAddress.Hex()}
 		transformer = storage.Transformer{
 			Address:           contractAddress,
 			StorageKeysLookup: storageKeysLookup,
-			Repository:        &repository,
+			Repository:        &repo,
 		}
 		transformer.NewTransformer(db)
 		headerRepository := repositories.NewHeaderRepository(db)
@@ -49,15 +49,15 @@ var _ = Describe("Executing the median transformer", func() {
 			denyLog := test_data.CreateTestLog(header.Id, db)
 			denyModel := test_data.DenyModel()
 
-			medianAddressID, medianAddressErr := shared.GetOrCreateAddress(contractAddress.Hex(), db)
+			medianAddressID, medianAddressErr := repository.GetOrCreateAddress(db, contractAddress.Hex())
 			Expect(medianAddressErr).NotTo(HaveOccurred())
 
 			userAddress := "0xffb0382ca7cfdc4fc4d5cc8913af1393d7ee1ef1"
-			userAddressID, userAddressErr := shared.GetOrCreateAddress(userAddress, db)
+			userAddressID, userAddressErr := repository.GetOrCreateAddress(db, userAddress)
 			Expect(userAddressErr).NotTo(HaveOccurred())
 
 			msgSenderAddress := "0x" + fakes.RandomString(40)
-			msgSenderAddressID, msgSenderAddressErr := shared.GetOrCreateAddress(msgSenderAddress, db)
+			msgSenderAddressID, msgSenderAddressErr := repository.GetOrCreateAddress(db, msgSenderAddress)
 			Expect(msgSenderAddressErr).NotTo(HaveOccurred())
 
 			denyModel.ColumnValues[event.HeaderFK] = header.Id
@@ -87,15 +87,15 @@ var _ = Describe("Executing the median transformer", func() {
 			kissLog := test_data.CreateTestLog(header.Id, db)
 			kissModel := test_data.MedianKissSingleModel()
 
-			medianAddressID, medianAddressErr := shared.GetOrCreateAddress(contractAddress.Hex(), db)
+			medianAddressID, medianAddressErr := repository.GetOrCreateAddress(db, contractAddress.Hex())
 			Expect(medianAddressErr).NotTo(HaveOccurred())
 
 			aAddress := "0xffb0382ca7cfdc4fc4d5cc8913af1393d7ee1ef1"
-			aAddressID, aAddressErr := shared.GetOrCreateAddress(aAddress, db)
+			aAddressID, aAddressErr := repository.GetOrCreateAddress(db, aAddress)
 			Expect(aAddressErr).NotTo(HaveOccurred())
 
 			msgSenderAddress := "0x" + fakes.RandomString(40)
-			msgSenderAddressID, msgSenderAddressErr := shared.GetOrCreateAddress(msgSenderAddress, db)
+			msgSenderAddressID, msgSenderAddressErr := repository.GetOrCreateAddress(db, msgSenderAddress)
 			Expect(msgSenderAddressErr).NotTo(HaveOccurred())
 
 			kissModel.ColumnValues[event.HeaderFK] = header.Id
@@ -125,15 +125,15 @@ var _ = Describe("Executing the median transformer", func() {
 			liftLog := test_data.CreateTestLog(header.Id, db)
 			liftModel := test_data.MedianLiftModelWithOneAccount()
 
-			medianAddressID, medianAddressErr := shared.GetOrCreateAddress(contractAddress.Hex(), db)
+			medianAddressID, medianAddressErr := repository.GetOrCreateAddress(db, contractAddress.Hex())
 			Expect(medianAddressErr).NotTo(HaveOccurred())
 
 			aAddress := "0xaC8519b3495d8A3E3E44c041521cF7aC3f8F63B3"
-			aAddressID, aAddressErr := shared.GetOrCreateAddress(aAddress, db)
+			aAddressID, aAddressErr := repository.GetOrCreateAddress(db, aAddress)
 			Expect(aAddressErr).NotTo(HaveOccurred())
 
 			msgSenderAddress := "0x" + fakes.RandomString(40)
-			msgSenderAddressID, msgSenderAddressErr := shared.GetOrCreateAddress(msgSenderAddress, db)
+			msgSenderAddressID, msgSenderAddressErr := repository.GetOrCreateAddress(db, msgSenderAddress)
 			Expect(msgSenderAddressErr).NotTo(HaveOccurred())
 
 			liftModel.ColumnValues[event.HeaderFK] = header.Id
@@ -163,15 +163,15 @@ var _ = Describe("Executing the median transformer", func() {
 			liftLog := test_data.CreateTestLog(header.Id, db)
 			liftModel := test_data.MedianLiftModelWithOneAccount()
 
-			medianAddressID, medianAddressErr := shared.GetOrCreateAddress(contractAddress.Hex(), db)
+			medianAddressID, medianAddressErr := repository.GetOrCreateAddress(db, contractAddress.Hex())
 			Expect(medianAddressErr).NotTo(HaveOccurred())
 
 			aAddress := "0xaC8519b3495d8A3E3E44c041521cF7aC3f8F63B3"
-			_, aAddressErr := shared.GetOrCreateAddress(aAddress, db)
+			_, aAddressErr := repository.GetOrCreateAddress(db, aAddress)
 			Expect(aAddressErr).NotTo(HaveOccurred())
 
 			msgSenderAddress := "0x" + fakes.RandomString(40)
-			msgSenderAddressID, msgSenderAddressErr := shared.GetOrCreateAddress(msgSenderAddress, db)
+			msgSenderAddressID, msgSenderAddressErr := repository.GetOrCreateAddress(db, msgSenderAddress)
 			Expect(msgSenderAddressErr).NotTo(HaveOccurred())
 
 			liftModel.ColumnValues[event.HeaderFK] = header.Id
@@ -193,7 +193,7 @@ var _ = Describe("Executing the median transformer", func() {
 			var slotResult test_helpers.MappingResWithAddress
 			err := db.Get(&slotResult, `SELECT diff_id, header_id, address_id, slot_id AS key, slot AS value from maker.median_slot`)
 			Expect(err).NotTo(HaveOccurred())
-			slotValueAddressID, slotErr := shared.GetOrCreateAddress(value.String(), db)
+			slotValueAddressID, slotErr := repository.GetOrCreateAddress(db, value.String())
 			Expect(slotErr).NotTo(HaveOccurred())
 			solidityKey := "172"
 			test_helpers.AssertMappingWithAddress(slotResult, liftDiff.ID, header.Id, medianAddressID, solidityKey, strconv.FormatInt(slotValueAddressID, 10))

--- a/transformers/component_tests/queries/all_bites_query_test.go
+++ b/transformers/component_tests/queries/all_bites_query_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
@@ -334,7 +335,7 @@ var _ = Describe("Bites query", func() {
 func generateBite(ilk, urn string, headerID, logID int64, db *postgres.DB) event.InsertionModel {
 	urnID, urnErr := shared.GetOrCreateUrn(urn, ilk, db)
 	Expect(urnErr).NotTo(HaveOccurred())
-	addressID, addressErr := shared.GetOrCreateAddress(test_data.Cat100Address(), db)
+	addressID, addressErr := repository.GetOrCreateAddress(db, test_data.Cat100Address())
 	Expect(addressErr).NotTo(HaveOccurred())
 	biteEvent := test_data.BiteModel()
 	test_data.AssignAddressID(test_data.BiteEventLog, biteEvent, db)

--- a/transformers/component_tests/queries/all_flap_bid_events_test.go
+++ b/transformers/component_tests/queries/all_flap_bid_events_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/component_tests/queries/test_helpers"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/storage"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
@@ -40,7 +40,7 @@ var _ = Describe("Flap bid events query", func() {
 		timestampOne = int(rand.Int31())
 		headerOne = createHeader(blockOne, timestampOne, headerRepo)
 		flapKickLog := test_data.CreateTestLog(headerOne.Id, db)
-		addressId, addressErr := shared.GetOrCreateAddress(contractAddress, db)
+		addressId, addressErr := repository.GetOrCreateAddress(db, contractAddress)
 		Expect(addressErr).NotTo(HaveOccurred())
 
 		flapKickEvent = test_data.FlapKickModel()
@@ -112,7 +112,7 @@ var _ = Describe("Flap bid events query", func() {
 			headerTwo := createHeader(blockOne+1, timestampOne+1, headerRepo)
 
 			flapKickEventTwoLog := test_data.CreateTestLog(headerTwo.Id, db)
-			addressId, addressErr := shared.GetOrCreateAddress(contractAddress, db)
+			addressId, addressErr := repository.GetOrCreateAddress(db, contractAddress)
 			Expect(addressErr).NotTo(HaveOccurred())
 			flapKickEventTwo := test_data.FlapKickModel()
 			flapKickEventTwo.ColumnValues[event.HeaderFK] = headerTwo.Id
@@ -149,7 +149,7 @@ var _ = Describe("Flap bid events query", func() {
 			bidAmountOne := rand.Int()
 
 			flapKickEventTwoLog := test_data.CreateTestLog(headerOne.Id, db)
-			addressId, addressErr := shared.GetOrCreateAddress(contractAddress, db)
+			addressId, addressErr := repository.GetOrCreateAddress(db, contractAddress)
 			Expect(addressErr).NotTo(HaveOccurred())
 			flapKickEventTwo := test_data.FlapKickModel()
 			flapKickEventTwo.ColumnValues[event.HeaderFK] = headerOne.Id
@@ -257,7 +257,7 @@ var _ = Describe("Flap bid events query", func() {
 		It("ignores bid events from flops", func() {
 			flopKickLog := test_data.CreateTestLog(headerOne.Id, db)
 			flopAddress := test_data.RandomString(40)
-			addressId, addressErr := shared.GetOrCreateAddress(flopAddress, db)
+			addressId, addressErr := repository.GetOrCreateAddress(db, flopAddress)
 			Expect(addressErr).NotTo(HaveOccurred())
 
 			flopKickEvent := test_data.FlopKickModel()

--- a/transformers/component_tests/queries/all_flip_bid_events_test.go
+++ b/transformers/component_tests/queries/all_flip_bid_events_test.go
@@ -23,11 +23,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/component_tests/queries/test_helpers"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/storage"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
@@ -60,7 +60,7 @@ var _ = Describe("All flip bid events query", func() {
 		flipKickLog := test_data.CreateTestLog(headerOne.Id, db)
 
 		var addressErr error
-		addressId, addressErr = shared.GetOrCreateAddress(contractAddress, db)
+		addressId, addressErr = repository.GetOrCreateAddress(db, contractAddress)
 		Expect(addressErr).NotTo(HaveOccurred())
 
 		flipKickEvent = test_data.FlipKickModel()
@@ -294,7 +294,7 @@ var _ = Describe("All flip bid events query", func() {
 			differentLot := rand.Int()
 			differentBidAmount := rand.Int()
 
-			anotherAddressId, addressErr := shared.GetOrCreateAddress(anotherFlipContractAddress, db)
+			anotherAddressId, addressErr := repository.GetOrCreateAddress(db, anotherFlipContractAddress)
 			Expect(addressErr).NotTo(HaveOccurred())
 
 			flipKickLog := test_data.CreateTestLog(headerOne.Id, db)

--- a/transformers/component_tests/queries/all_flop_bid_events_test.go
+++ b/transformers/component_tests/queries/all_flop_bid_events_test.go
@@ -6,11 +6,11 @@ import (
 
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/component_tests/queries/test_helpers"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/storage"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
@@ -41,7 +41,7 @@ var _ = Describe("Flop bid events query", func() {
 
 		flopKickLog := test_data.CreateTestLog(headerOne.Id, db)
 
-		addressId, addressErr := shared.GetOrCreateAddress(contractAddress, db)
+		addressId, addressErr := repository.GetOrCreateAddress(db, contractAddress)
 		Expect(addressErr).NotTo(HaveOccurred())
 
 		flopKickEvent = test_data.FlopKickModel()
@@ -104,7 +104,7 @@ var _ = Describe("Flop bid events query", func() {
 
 			flopKickEventTwoLog := test_data.CreateTestLog(headerOne.Id, db)
 
-			addressId, addressErr := shared.GetOrCreateAddress(contractAddress, db)
+			addressId, addressErr := repository.GetOrCreateAddress(db, contractAddress)
 			Expect(addressErr).NotTo(HaveOccurred())
 
 			flopKickEventTwo := test_data.FlopKickModel()
@@ -155,7 +155,7 @@ var _ = Describe("Flop bid events query", func() {
 		It("ignores bid events from flaps", func() {
 			flapKickLog := test_data.CreateTestLog(headerOne.Id, db)
 
-			addressId, addressErr := shared.GetOrCreateAddress(contractAddress, db)
+			addressId, addressErr := repository.GetOrCreateAddress(db, contractAddress)
 			Expect(addressErr).NotTo(HaveOccurred())
 			flapKickEvent := test_data.FlapKickModel()
 			flapKickEvent.ColumnValues[event.AddressFK] = addressId
@@ -412,7 +412,7 @@ var _ = Describe("Flop bid events query", func() {
 			updatedBidAmount = bidAmount + 100
 
 			logID := test_data.CreateTestLog(headerOne.Id, db).ID
-			addressId, addressErr := shared.GetOrCreateAddress(contractAddress, db)
+			addressId, addressErr := repository.GetOrCreateAddress(db, contractAddress)
 			Expect(addressErr).NotTo(HaveOccurred())
 
 			flopKickBlockOne = test_data.FlopKickModel()

--- a/transformers/component_tests/queries/flap_bid_event_computed_columns_test.go
+++ b/transformers/component_tests/queries/flap_bid_event_computed_columns_test.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/component_tests/queries/test_helpers"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
@@ -39,7 +39,7 @@ var _ = Describe("flap_bid_event computed columns", func() {
 		headerOne = createHeader(blockOne, timestampOne, headerRepo)
 		flapKickLog = test_data.CreateTestLog(headerOne.Id, db)
 
-		addressId, addressErr := shared.GetOrCreateAddress(contractAddress, db)
+		addressId, addressErr := repository.GetOrCreateAddress(db, contractAddress)
 		Expect(addressErr).NotTo(HaveOccurred())
 
 		flapKickEvent = test_data.FlapKickModel()

--- a/transformers/component_tests/queries/flap_bid_snapshot_computed_columns_test.go
+++ b/transformers/component_tests/queries/flap_bid_snapshot_computed_columns_test.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/component_tests/queries/test_helpers"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
@@ -42,7 +42,7 @@ var _ = Describe("Flap computed columns", func() {
 
 			flapStorageValues := test_helpers.GetFlapStorageValues(1, fakeBidId)
 			test_helpers.CreateFlap(db, headerOne, flapStorageValues, test_helpers.GetFlapMetadatas(strconv.Itoa(fakeBidId)), contractAddress)
-			addressId, addressErr := shared.GetOrCreateAddress(contractAddress, db)
+			addressId, addressErr := repository.GetOrCreateAddress(db, contractAddress)
 			Expect(addressErr).NotTo(HaveOccurred())
 
 			flapKickEvent := test_data.FlapKickModel()
@@ -74,7 +74,7 @@ var _ = Describe("Flap computed columns", func() {
 
 			flapStorageValues := test_helpers.GetFlapStorageValues(1, fakeBidId)
 			test_helpers.CreateFlap(db, headerOne, flapStorageValues, test_helpers.GetFlapMetadatas(strconv.Itoa(fakeBidId)), contractAddress)
-			addressId, addressErr := shared.GetOrCreateAddress(contractAddress, db)
+			addressId, addressErr := repository.GetOrCreateAddress(db, contractAddress)
 			Expect(addressErr).NotTo(HaveOccurred())
 
 			flapKickEvent := test_data.FlapKickModel()
@@ -129,7 +129,7 @@ var _ = Describe("Flap computed columns", func() {
 
 				flapStorageValues := test_helpers.GetFlapStorageValues(1, fakeBidId)
 				test_helpers.CreateFlap(db, headerOne, flapStorageValues, test_helpers.GetFlapMetadatas(strconv.Itoa(fakeBidId)), contractAddress)
-				addressId, addressErr := shared.GetOrCreateAddress(contractAddress, db)
+				addressId, addressErr := repository.GetOrCreateAddress(db, contractAddress)
 				Expect(addressErr).NotTo(HaveOccurred())
 
 				flapKickEvent = test_data.FlapKickModel()

--- a/transformers/component_tests/queries/flip_bid_event_computed_columns_test.go
+++ b/transformers/component_tests/queries/flip_bid_event_computed_columns_test.go
@@ -24,10 +24,10 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/component_tests/queries/test_helpers"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
@@ -147,7 +147,7 @@ var _ = Describe("Flip bid event computed columns", func() {
 			flipKickEventLog := test_data.CreateTestLog(headerOne.Id, db)
 			flipKickGethLog = flipKickEventLog.Log
 
-			addressId, addressErr := shared.GetOrCreateAddress(contractAddress, db)
+			addressId, addressErr := repository.GetOrCreateAddress(db, contractAddress)
 			Expect(addressErr).NotTo(HaveOccurred())
 
 			flipKickEvent := test_data.FlipKickModel()

--- a/transformers/component_tests/queries/flip_bid_snapshot_computed_columns_test.go
+++ b/transformers/component_tests/queries/flip_bid_snapshot_computed_columns_test.go
@@ -22,11 +22,11 @@ import (
 
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/component_tests/queries/test_helpers"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/storage/vat"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
@@ -169,7 +169,7 @@ var _ = Describe("flip_bid_snapshot computed columns", func() {
 			)
 
 			BeforeEach(func() {
-				addressId, addressErr := shared.GetOrCreateAddress(contractAddress, db)
+				addressId, addressErr := repository.GetOrCreateAddress(db, contractAddress)
 				Expect(addressErr).NotTo(HaveOccurred())
 
 				flipKickEvent = test_data.FlipKickModel()

--- a/transformers/component_tests/queries/flop_bid_event_computed_columns_test.go
+++ b/transformers/component_tests/queries/flop_bid_event_computed_columns_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/component_tests/queries/test_helpers"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
@@ -42,7 +42,7 @@ var _ = Describe("Flop bid event computed columns", func() {
 		flopKickEventLog := test_data.CreateTestLog(headerOne.Id, db)
 		flopKickGethLog = flopKickEventLog.Log
 
-		addressId, addressErr := shared.GetOrCreateAddress(contractAddress, db)
+		addressId, addressErr := repository.GetOrCreateAddress(db, contractAddress)
 		Expect(addressErr).NotTo(HaveOccurred())
 
 		flopKickEvent = test_data.FlopKickModel()

--- a/transformers/component_tests/queries/flop_bid_snapshot_computed_columns_test.go
+++ b/transformers/component_tests/queries/flop_bid_snapshot_computed_columns_test.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/component_tests/queries/test_helpers"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
@@ -43,7 +43,7 @@ var _ = Describe("Flop computed columns", func() {
 			flopStorageValues := test_helpers.GetFlopStorageValues(1, fakeBidId)
 			test_helpers.CreateFlop(db, headerOne, flopStorageValues, test_helpers.GetFlopMetadatas(strconv.Itoa(fakeBidId)), contractAddress)
 
-			addressId, addressErr := shared.GetOrCreateAddress(contractAddress, db)
+			addressId, addressErr := repository.GetOrCreateAddress(db, contractAddress)
 			Expect(addressErr).NotTo(HaveOccurred())
 
 			flopKickEvent := test_data.FlopKickModel()
@@ -75,7 +75,7 @@ var _ = Describe("Flop computed columns", func() {
 			flopStorageValues := test_helpers.GetFlopStorageValues(1, fakeBidId)
 			test_helpers.CreateFlop(db, headerOne, flopStorageValues, test_helpers.GetFlopMetadatas(strconv.Itoa(fakeBidId)), contractAddress)
 
-			addressId, addressErr := shared.GetOrCreateAddress(contractAddress, db)
+			addressId, addressErr := repository.GetOrCreateAddress(db, contractAddress)
 			Expect(addressErr).NotTo(HaveOccurred())
 
 			flopKickEvent := test_data.FlopKickModel()
@@ -131,7 +131,7 @@ var _ = Describe("Flop computed columns", func() {
 				flopStorageValues := test_helpers.GetFlopStorageValues(1, fakeBidId)
 				test_helpers.CreateFlop(db, headerOne, flopStorageValues, test_helpers.GetFlopMetadatas(strconv.Itoa(fakeBidId)), contractAddress)
 
-				addressId, addressErr := shared.GetOrCreateAddress(contractAddress, db)
+				addressId, addressErr := repository.GetOrCreateAddress(db, contractAddress)
 				Expect(addressErr).NotTo(HaveOccurred())
 
 				flopKickEvent = test_data.FlopKickModel()

--- a/transformers/component_tests/queries/test_helpers/test_helpers.go
+++ b/transformers/component_tests/queries/test_helpers/test_helpers.go
@@ -40,6 +40,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	vdbStorageFactory "github.com/makerdao/vulcanizedb/libraries/shared/factories/storage"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/libraries/shared/storage/types"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
@@ -591,7 +592,7 @@ func SetUpFlopBidContext(setupData FlopBidCreationInput) (err error) {
 }
 
 func CreateDeal(input DealCreationInput) (err error) {
-	addressID, addressErr := shared.GetOrCreateAddress(input.ContractAddress, input.DB)
+	addressID, addressErr := repository.GetOrCreateAddress(input.DB, input.ContractAddress)
 	Expect(addressErr).NotTo(HaveOccurred())
 	dealLog := test_data.CreateTestLog(input.DealHeaderId, input.DB)
 	dealModel := test_data.DealModel()
@@ -605,7 +606,7 @@ func CreateDeal(input DealCreationInput) (err error) {
 }
 
 func CreateFlipKick(contractAddress string, bidId int, headerId, logId int64, usr string, db *postgres.DB) error {
-	addressId, addressErr := shared.GetOrCreateAddress(contractAddress, db)
+	addressId, addressErr := repository.GetOrCreateAddress(db, contractAddress)
 	Expect(addressErr).NotTo(HaveOccurred())
 	flipKickModel := test_data.FlipKickModel()
 	flipKickModel.ColumnValues[event.HeaderFK] = headerId
@@ -618,7 +619,7 @@ func CreateFlipKick(contractAddress string, bidId int, headerId, logId int64, us
 
 func CreateFlapKick(contractAddress string, bidId int, headerId, logId int64, db *postgres.DB) error {
 	flapKickModel := test_data.FlapKickModel()
-	addressId, addressErr := shared.GetOrCreateAddress(contractAddress, db)
+	addressId, addressErr := repository.GetOrCreateAddress(db, contractAddress)
 	Expect(addressErr).NotTo(HaveOccurred())
 	flapKickModel.ColumnValues[event.HeaderFK] = headerId
 	flapKickModel.ColumnValues[event.LogFK] = logId
@@ -628,7 +629,7 @@ func CreateFlapKick(contractAddress string, bidId int, headerId, logId int64, db
 }
 
 func CreateFlopKick(contractAddress string, bidId int, headerId, logId int64, db *postgres.DB) error {
-	addressId, addressErr := shared.GetOrCreateAddress(contractAddress, db)
+	addressId, addressErr := repository.GetOrCreateAddress(db, contractAddress)
 	Expect(addressErr).NotTo(HaveOccurred())
 	flopKickModel := test_data.FlopKickModel()
 	flopKickModel.ColumnValues[event.HeaderFK] = headerId
@@ -639,7 +640,7 @@ func CreateFlopKick(contractAddress string, bidId int, headerId, logId int64, db
 }
 
 func CreateTend(input TendCreationInput) (err error) {
-	addressID, addressErr := shared.GetOrCreateAddress(input.ContractAddress, input.DB)
+	addressID, addressErr := repository.GetOrCreateAddress(input.DB, input.ContractAddress)
 	Expect(addressErr).NotTo(HaveOccurred())
 	tendModel := test_data.TendModel()
 	tendLog := test_data.CreateTestLog(input.TendHeaderId, input.DB)
@@ -654,7 +655,7 @@ func CreateTend(input TendCreationInput) (err error) {
 }
 
 func CreateDent(input DentCreationInput) (err error) {
-	addressID, addressErr := shared.GetOrCreateAddress(input.ContractAddress, input.DB)
+	addressID, addressErr := repository.GetOrCreateAddress(input.DB, input.ContractAddress)
 	Expect(addressErr).NotTo(HaveOccurred())
 	dentModel := test_data.DentModel()
 	dentModel.ColumnValues[constants.BidIDColumn] = strconv.Itoa(input.BidId)
@@ -668,7 +669,7 @@ func CreateDent(input DentCreationInput) (err error) {
 }
 
 func CreateYank(input YankCreationInput) (err error) {
-	addressID, addressErr := shared.GetOrCreateAddress(input.ContractAddress, input.DB)
+	addressID, addressErr := repository.GetOrCreateAddress(input.DB, input.ContractAddress)
 	Expect(addressErr).NotTo(HaveOccurred())
 	yankModel := test_data.YankModel()
 	yankModel.ColumnValues[event.AddressFK] = addressID
@@ -680,7 +681,7 @@ func CreateYank(input YankCreationInput) (err error) {
 }
 
 func CreateTick(input TickCreationInput) (err error) {
-	addressID, addressErr := shared.GetOrCreateAddress(input.ContractAddress, input.DB)
+	addressID, addressErr := repository.GetOrCreateAddress(input.DB, input.ContractAddress)
 	Expect(addressErr).NotTo(HaveOccurred())
 	tickLog := test_data.CreateTestLog(input.TickHeaderId, input.DB)
 	tickModel := test_data.TickModel()

--- a/transformers/component_tests/spot/configured_transformer_test.go
+++ b/transformers/component_tests/spot/configured_transformer_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/storage"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
 	"github.com/makerdao/vulcanizedb/pkg/fakes"
 	. "github.com/onsi/ginkgo"
@@ -40,11 +41,11 @@ var _ = Describe("Executing the transformer", func() {
 		db                = test_config.NewTestDB(test_config.NewTestNode())
 		contractAddress   = common.HexToAddress(test_data.SpotAddress())
 		storageKeysLookup = storage.NewKeysLookup(spot.NewKeysLoader(&mcdStorage.MakerStorageRepository{}, contractAddress.Hex()))
-		repository        = spot.StorageRepository{ContractAddress: contractAddress.Hex()}
+		repo              = spot.StorageRepository{ContractAddress: contractAddress.Hex()}
 		transformer       = storage.Transformer{
 			Address:           contractAddress,
 			StorageKeysLookup: storageKeysLookup,
-			Repository:        &repository,
+			Repository:        &repo,
 		}
 		header = fakes.FakeHeader
 	)
@@ -105,15 +106,15 @@ var _ = Describe("Executing the transformer", func() {
 			denyLog := test_data.CreateTestLog(header.Id, db)
 			denyModel := test_data.DenyModel()
 
-			spotAddressID, spotAddressErr := shared.GetOrCreateAddress(contractAddress.Hex(), db)
+			spotAddressID, spotAddressErr := repository.GetOrCreateAddress(db, contractAddress.Hex())
 			Expect(spotAddressErr).NotTo(HaveOccurred())
 
 			userAddress := "0x2be4b34a34c3cda056dc9e514a30040b6358bf89"
-			userAddressID, userAddressErr := shared.GetOrCreateAddress(userAddress, db)
+			userAddressID, userAddressErr := repository.GetOrCreateAddress(db, userAddress)
 			Expect(userAddressErr).NotTo(HaveOccurred())
 
 			msgSenderAddress := "0x" + fakes.RandomString(40)
-			msgSenderAddressID, msgSenderAddressErr := shared.GetOrCreateAddress(msgSenderAddress, db)
+			msgSenderAddressID, msgSenderAddressErr := repository.GetOrCreateAddress(db, msgSenderAddress)
 			Expect(msgSenderAddressErr).NotTo(HaveOccurred())
 
 			denyModel.ColumnValues[event.HeaderFK] = header.Id

--- a/transformers/component_tests/triggers/bid_creation/shared_kick_trigger_suite.go
+++ b/transformers/component_tests/triggers/bid_creation/shared_kick_trigger_suite.go
@@ -7,11 +7,11 @@ import (
 	"strconv"
 
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	. "github.com/makerdao/vdb-mcd-transformers/transformers/storage/test_helpers"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 	. "github.com/onsi/ginkgo"
@@ -66,7 +66,7 @@ func SharedBidCreationTriggerTests(tableName, contractAddress string, kickModel 
 		})
 
 		It("does not update records from a different contract", func() {
-			randomAddressID, addressErr := shared.GetOrCreateAddress(test_data.RandomString(40), db)
+			randomAddressID, addressErr := repository.GetOrCreateAddress(db, test_data.RandomString(40))
 			Expect(addressErr).NotTo(HaveOccurred())
 			_, setupErr := db.Exec(insertEmptyRowQuery, headerTwo.BlockNumber,
 				kickModel.ColumnValues[constants.BidIDColumn], randomAddressID, FormatTimestamp(rawTimestampTwo))
@@ -117,7 +117,7 @@ func SharedBidCreationTriggerTests(tableName, contractAddress string, kickModel 
 }
 
 func updateKickKeys(kickModel event.InsertionModel, headerID, logID int64, contractAddress, bidID string, db *postgres.DB) event.ColumnValues {
-	addressID, addressErr := shared.GetOrCreateAddress(contractAddress, db)
+	addressID, addressErr := repository.GetOrCreateAddress(db, contractAddress)
 	Expect(addressErr).NotTo(HaveOccurred())
 
 	kickModel.ColumnValues[event.HeaderFK] = headerID

--- a/transformers/component_tests/triggers/bid_event_trigger_test.go
+++ b/transformers/component_tests/triggers/bid_event_trigger_test.go
@@ -8,13 +8,13 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/component_tests/queries/test_helpers"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/storage"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/storage/flip"
 	. "github.com/makerdao/vdb-mcd-transformers/transformers/storage/test_helpers"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/libraries/shared/storage/types"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	. "github.com/onsi/ginkgo"
@@ -40,7 +40,7 @@ var _ = Describe("Updating bid_event table", func() {
 
 	Specify("inserting a flip_kick event triggers a bid_event insertion", func() {
 		flipAddress := test_data.FlipEthV100Address()
-		addressID, addressErr := shared.GetOrCreateAddress(flipAddress, db)
+		addressID, addressErr := repository.GetOrCreateAddress(db, flipAddress)
 		Expect(addressErr).NotTo(HaveOccurred())
 		flipKickModel := test_data.FlipKickModel()
 		flipKickModel.ColumnValues[event.HeaderFK] = headerOne.Id
@@ -59,7 +59,7 @@ var _ = Describe("Updating bid_event table", func() {
 
 	Specify("inserting a flop_kick event triggers a bid_event insertion", func() {
 		flopAddress := test_data.FlopV101Address()
-		addressID, addressErr := shared.GetOrCreateAddress(flopAddress, db)
+		addressID, addressErr := repository.GetOrCreateAddress(db, flopAddress)
 		Expect(addressErr).NotTo(HaveOccurred())
 		logID := test_data.CreateTestLog(headerOne.Id, db).ID
 		flopKickModel := test_data.FlopKickModel()
@@ -79,7 +79,7 @@ var _ = Describe("Updating bid_event table", func() {
 
 	Specify("inserting a flap_kick event triggers a bid_event insertion", func() {
 		flapAddress := test_data.FlapV100Address()
-		addressID, addressErr := shared.GetOrCreateAddress(flapAddress, db)
+		addressID, addressErr := repository.GetOrCreateAddress(db, flapAddress)
 		Expect(addressErr).NotTo(HaveOccurred())
 		logID := test_data.CreateTestLog(headerOne.Id, db).ID
 		flapKickModel := test_data.FlapKickModel()
@@ -99,7 +99,7 @@ var _ = Describe("Updating bid_event table", func() {
 
 	Specify("inserting a tend event triggers a bid_event insertion", func() {
 		address := test_data.FlipEthV100Address()
-		addressID, addressErr := shared.GetOrCreateAddress(address, db)
+		addressID, addressErr := repository.GetOrCreateAddress(db, address)
 		Expect(addressErr).NotTo(HaveOccurred())
 
 		tendLog := test_data.CreateTestLogFromEventLog(headerOne.Id, test_data.TendEventLog.Log, db)
@@ -121,7 +121,7 @@ var _ = Describe("Updating bid_event table", func() {
 
 	Specify("inserting a dent event triggers a bid_event insertion", func() {
 		address := test_data.FlipEthV100Address()
-		addressID, addressErr := shared.GetOrCreateAddress(address, db)
+		addressID, addressErr := repository.GetOrCreateAddress(db, address)
 		Expect(addressErr).NotTo(HaveOccurred())
 		logID := test_data.CreateTestLog(headerOne.Id, db).ID
 		dentModel := test_data.DentModel()
@@ -142,7 +142,7 @@ var _ = Describe("Updating bid_event table", func() {
 
 	Specify("inserting a tick event triggers a bid_event insertion", func() {
 		address := test_data.FlipEthV100Address()
-		addressID, addressErr := shared.GetOrCreateAddress(address, db)
+		addressID, addressErr := repository.GetOrCreateAddress(db, address)
 		Expect(addressErr).NotTo(HaveOccurred())
 		logID := test_data.CreateTestLog(headerOne.Id, db).ID
 		tickModel := test_data.TickModel()
@@ -163,7 +163,7 @@ var _ = Describe("Updating bid_event table", func() {
 
 	Specify("inserting a deal event triggers a bid_event insertion", func() {
 		address := test_data.FlipEthV100Address()
-		addressID, addressErr := shared.GetOrCreateAddress(address, db)
+		addressID, addressErr := repository.GetOrCreateAddress(db, address)
 		Expect(addressErr).NotTo(HaveOccurred())
 		logID := test_data.CreateTestLog(headerOne.Id, db).ID
 		dealModel := test_data.DealModel()
@@ -184,7 +184,7 @@ var _ = Describe("Updating bid_event table", func() {
 
 	Specify("inserting a yank event triggers a bid_event insertion", func() {
 		address := test_data.FlipEthV100Address()
-		addressID, addressErr := shared.GetOrCreateAddress(address, db)
+		addressID, addressErr := repository.GetOrCreateAddress(db, address)
 		Expect(addressErr).NotTo(HaveOccurred())
 		logID := test_data.CreateTestLog(headerOne.Id, db).ID
 		yankModel := test_data.YankModel()
@@ -212,7 +212,7 @@ var _ = Describe("Updating bid_event table", func() {
 		)
 
 		BeforeEach(func() {
-			flipAddressID, addressErr := shared.GetOrCreateAddress(flipAddress, db)
+			flipAddressID, addressErr := repository.GetOrCreateAddress(db, flipAddress)
 			Expect(addressErr).NotTo(HaveOccurred())
 			flipRepo = flip.StorageRepository{ContractAddress: flipAddress}
 			flipRepo.SetDB(db)
@@ -268,7 +268,7 @@ var _ = Describe("Updating bid_event table", func() {
 
 		BeforeEach(func() {
 			flipAddress = test_data.FlipEthV100Address()
-			flipAddressID, addressErr := shared.GetOrCreateAddress(flipAddress, db)
+			flipAddressID, addressErr := repository.GetOrCreateAddress(db, flipAddress)
 			Expect(addressErr).NotTo(HaveOccurred())
 			flipRepo = flip.StorageRepository{ContractAddress: flipAddress}
 			flipRepo.SetDB(db)
@@ -340,7 +340,7 @@ var _ = Describe("Updating bid_event table", func() {
 			logThreeID = test_data.CreateTestLog(headerTwo.Id, db).ID
 
 			flipAddress = test_data.FlipEthV100Address()
-			ethFlipAddressID, ethFlipAddressErr := shared.GetOrCreateAddress(flipAddress, db)
+			ethFlipAddressID, ethFlipAddressErr := repository.GetOrCreateAddress(db, flipAddress)
 			Expect(ethFlipAddressErr).NotTo(HaveOccurred())
 
 			flipRepo = flip.StorageRepository{ContractAddress: flipAddress}
@@ -399,7 +399,7 @@ var _ = Describe("Updating bid_event table", func() {
 			ilkIdentifier := test_helpers.FakeIlk.Identifier
 			Expect(initialIlks).To(ConsistOf(ilkIdentifier, ilkIdentifier, ilkIdentifier))
 
-			flipAddressID, flipAddressErr := shared.GetOrCreateAddress(flipAddress, db)
+			flipAddressID, flipAddressErr := repository.GetOrCreateAddress(db, flipAddress)
 			Expect(flipAddressErr).NotTo(HaveOccurred())
 
 			_, deleteIlkErr := db.Exec(`DELETE FROM maker.flip_ilk WHERE address_id = $1`, flipAddressID)

--- a/transformers/component_tests/vat/configured_transformer_test.go
+++ b/transformers/component_tests/vat/configured_transformer_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/storage"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
 	"github.com/makerdao/vulcanizedb/pkg/fakes"
 	. "github.com/onsi/ginkgo"
@@ -39,12 +40,12 @@ var _ = Describe("Executing the transformer", func() {
 	var (
 		db                = test_config.NewTestDB(test_config.NewTestNode())
 		storageKeysLookup = storage.NewKeysLookup(vat.NewKeysLoader(&mcdStorage.MakerStorageRepository{}))
-		repository        = vat.StorageRepository{}
+		repo              = vat.StorageRepository{}
 		contractAddress   = common.HexToAddress(test_data.VatAddress())
 		transformer       = storage.Transformer{
 			Address:           contractAddress,
 			StorageKeysLookup: storageKeysLookup,
-			Repository:        &repository,
+			Repository:        &repo,
 		}
 		header = fakes.FakeHeader
 	)
@@ -62,15 +63,15 @@ var _ = Describe("Executing the transformer", func() {
 		vatDenyLog := test_data.CreateTestLog(header.Id, db)
 		vatDenyModel := test_data.VatDenyModel()
 
-		vatAddressID, vatAddressErr := shared.GetOrCreateAddress(contractAddress.Hex(), db)
+		vatAddressID, vatAddressErr := repository.GetOrCreateAddress(db, contractAddress.Hex())
 		Expect(vatAddressErr).NotTo(HaveOccurred())
 
 		userAddress := "0x13141b8a5e4a82ebc6b636849dd6a515185d6236"
-		userAddressID, userAddressErr := shared.GetOrCreateAddress(userAddress, db)
+		userAddressID, userAddressErr := repository.GetOrCreateAddress(db, userAddress)
 		Expect(userAddressErr).NotTo(HaveOccurred())
 
 		msgSenderAddress := "0x" + fakes.RandomString(40)
-		msgSenderAddressID, msgSenderAddressErr := shared.GetOrCreateAddress(msgSenderAddress, db)
+		msgSenderAddressID, msgSenderAddressErr := repository.GetOrCreateAddress(db, msgSenderAddress)
 		Expect(msgSenderAddressErr).NotTo(HaveOccurred())
 
 		vatDenyModel.ColumnValues[event.HeaderFK] = header.Id

--- a/transformers/component_tests/vow/configured_transformer_test.go
+++ b/transformers/component_tests/vow/configured_transformer_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	mcdStorage "github.com/makerdao/vdb-mcd-transformers/transformers/storage"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/storage/test_helpers"
@@ -29,6 +28,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/storage"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
 	"github.com/makerdao/vulcanizedb/pkg/fakes"
 	. "github.com/onsi/ginkgo"
@@ -40,11 +40,11 @@ var _ = Describe("Executing the transformer", func() {
 		db                = test_config.NewTestDB(test_config.NewTestNode())
 		contractAddress   = common.HexToAddress(test_data.VowAddress())
 		storageKeysLookup = storage.NewKeysLookup(vow.NewKeysLoader(&mcdStorage.MakerStorageRepository{}, contractAddress.Hex()))
-		repository        = vow.StorageRepository{ContractAddress: contractAddress.Hex()}
+		repo              = vow.StorageRepository{ContractAddress: contractAddress.Hex()}
 		transformer       = storage.Transformer{
 			Address:           contractAddress,
 			StorageKeysLookup: storageKeysLookup,
-			Repository:        &repository,
+			Repository:        &repo,
 		}
 		header = fakes.FakeHeader
 	)
@@ -63,15 +63,15 @@ var _ = Describe("Executing the transformer", func() {
 			denyLog := test_data.CreateTestLog(header.Id, db)
 			denyModel := test_data.DenyModel()
 
-			vowAddressID, vowAddressErr := shared.GetOrCreateAddress(contractAddress.Hex(), db)
+			vowAddressID, vowAddressErr := repository.GetOrCreateAddress(db, contractAddress.Hex())
 			Expect(vowAddressErr).NotTo(HaveOccurred())
 
 			userAddress := "0x13141b8a5e4a82ebc6b636849dd6a515185d6236"
-			userAddressID, userAddressErr := shared.GetOrCreateAddress(userAddress, db)
+			userAddressID, userAddressErr := repository.GetOrCreateAddress(db, userAddress)
 			Expect(userAddressErr).NotTo(HaveOccurred())
 
 			msgSenderAddress := "0x" + fakes.RandomString(40)
-			msgSenderAddressID, msgSenderAddressErr := shared.GetOrCreateAddress(msgSenderAddress, db)
+			msgSenderAddressID, msgSenderAddressErr := repository.GetOrCreateAddress(db, msgSenderAddress)
 			Expect(msgSenderAddressErr).NotTo(HaveOccurred())
 
 			denyModel.ColumnValues[event.HeaderFK] = header.Id

--- a/transformers/events/auction_file/transformer.go
+++ b/transformers/events/auction_file/transformer.go
@@ -6,6 +6,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -20,14 +21,14 @@ func (t Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) (
 			return nil, fmt.Errorf("auction file log missing topics: %w", err)
 		}
 
-		contractAddressID, contractAddressErr := shared.GetOrCreateAddress(log.Log.Address.String(), db)
+		contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, log.Log.Address.String())
 		if contractAddressErr != nil {
 			errorMsgToFmt := "could not get or creat auction contract address id: %w"
 			return nil, fmt.Errorf(errorMsgToFmt, shared.ErrCouldNotCreateFK(contractAddressErr))
 		}
 
 		msgSender := log.Log.Topics[1].Hex()
-		msgSenderAddressID, msgSenderAddressErr := shared.GetOrCreateAddress(msgSender, db)
+		msgSenderAddressID, msgSenderAddressErr := repository.GetOrCreateAddress(db, msgSender)
 		if msgSenderAddressErr != nil {
 			errorMsgToFmt := "could not get or create msg sender address id: %w"
 			return nil, fmt.Errorf(errorMsgToFmt, shared.ErrCouldNotCreateFK(msgSenderAddressErr))

--- a/transformers/events/auth/transformer.go
+++ b/transformers/events/auth/transformer.go
@@ -5,6 +5,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -22,19 +23,19 @@ func (t Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) (
 		}
 
 		contractAddress := log.Log.Address.String()
-		contractAddressID, contractAddressErr := shared.GetOrCreateAddress(contractAddress, db)
+		contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, contractAddress)
 		if contractAddressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(contractAddressErr)
 		}
 
 		msgSenderAddress := common.HexToAddress(log.Log.Topics[1].Hex()).Hex()
-		msgSenderAddressID, msgSenderAddressErr := shared.GetOrCreateAddress(msgSenderAddress, db)
+		msgSenderAddressID, msgSenderAddressErr := repository.GetOrCreateAddress(db, msgSenderAddress)
 		if msgSenderAddressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(msgSenderAddressErr)
 		}
 
 		usrAddress := common.HexToAddress(log.Log.Topics[2].Hex()).Hex()
-		usrAddressID, usrAddressErr := shared.GetOrCreateAddress(usrAddress, db)
+		usrAddressID, usrAddressErr := repository.GetOrCreateAddress(db, usrAddress)
 		if usrAddressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(usrAddressErr)
 		}

--- a/transformers/events/bite/transformer.go
+++ b/transformers/events/bite/transformer.go
@@ -19,17 +19,16 @@ package bite
 import (
 	"fmt"
 
-	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
-	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
-
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/makerdao/vulcanizedb/pkg/core"
-	"github.com/makerdao/vulcanizedb/pkg/eth"
-
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
+	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
+	"github.com/makerdao/vulcanizedb/pkg/core"
+	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
+	"github.com/makerdao/vulcanizedb/pkg/eth"
 )
 
 type Transformer struct{}
@@ -75,7 +74,7 @@ func (t Transformer) ToModels(abi string, logs []core.EventLog, db *postgres.DB)
 			return nil, shared.ErrCouldNotCreateFK(urnErr)
 		}
 
-		addressId, addressErr := shared.GetOrCreateAddress(biteEntity.ContractAddress.Hex(), db)
+		addressId, addressErr := repository.GetOrCreateAddress(db, biteEntity.ContractAddress.Hex())
 		if addressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(addressErr)
 		}

--- a/transformers/events/cat_claw/transformer.go
+++ b/transformers/events/cat_claw/transformer.go
@@ -4,6 +4,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -17,11 +18,11 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 		if verifyLogErr != nil {
 			return nil, verifyLogErr
 		}
-		addressID, addressErr := shared.GetOrCreateAddress(log.Log.Address.Hex(), db)
+		addressID, addressErr := repository.GetOrCreateAddress(db, log.Log.Address.Hex())
 		if addressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(addressErr)
 		}
-		msgSenderID, msgSenderErr := shared.GetOrCreateAddress(log.Log.Topics[1].Hex(), db)
+		msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, log.Log.Topics[1].Hex())
 		if msgSenderErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(msgSenderErr)
 		}

--- a/transformers/events/cat_claw/transformer_test.go
+++ b/transformers/events/cat_claw/transformer_test.go
@@ -5,10 +5,10 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/cat_claw"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -28,11 +28,11 @@ var _ = Describe("Cat Claw Transformer", func() {
 		models, err := transformer.ToModels(constants.Cat110ABI(), []core.EventLog{test_data.CatClawEventLog}, db)
 		Expect(err).NotTo(HaveOccurred())
 
-		addressID, addressErr := shared.GetOrCreateAddress(test_data.Cat110Address(), db)
+		addressID, addressErr := repository.GetOrCreateAddress(db, test_data.Cat110Address())
 		Expect(addressErr).NotTo(HaveOccurred())
 
 		msgSender := "0xF32836B9E1f47a0515c6Ec431592D5EbC276407f"
-		msgSenderID, msgSenderErr := shared.GetOrCreateAddress(msgSender, db)
+		msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, msgSender)
 		Expect(msgSenderErr).NotTo(HaveOccurred())
 
 		expectedModel := test_data.CatClawModel()

--- a/transformers/events/cat_file/box/transformer.go
+++ b/transformers/events/cat_file/box/transformer.go
@@ -4,6 +4,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -21,12 +22,12 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 		what := shared.DecodeHexToText(log.Log.Topics[2].Hex())
 		data := shared.ConvertUint256HexToBigInt(log.Log.Topics[3].Hex())
 
-		addressID, addressErr := shared.GetOrCreateAddress(log.Log.Address.Hex(), db)
+		addressID, addressErr := repository.GetOrCreateAddress(db, log.Log.Address.Hex())
 		if addressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(addressErr)
 		}
 
-		msgSenderID, msgSenderErr := shared.GetOrCreateAddress(log.Log.Topics[1].Hex(), db)
+		msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, log.Log.Topics[1].Hex())
 		if msgSenderErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(msgSenderErr)
 		}

--- a/transformers/events/cat_file/chop_lump_dunk/transformer.go
+++ b/transformers/events/cat_file/chop_lump_dunk/transformer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -34,11 +35,11 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 		if verifyErr != nil {
 			return nil, verifyErr
 		}
-		addressID, addressErr := shared.GetOrCreateAddress(log.Log.Address.Hex(), db)
+		addressID, addressErr := repository.GetOrCreateAddress(db, log.Log.Address.Hex())
 		if addressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(addressErr)
 		}
-		msgSenderID, msgSenderErr := shared.GetOrCreateAddress(log.Log.Topics[1].Hex(), db)
+		msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, log.Log.Topics[1].Hex())
 		if msgSenderErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(msgSenderErr)
 		}

--- a/transformers/events/cat_file/flip/transformer.go
+++ b/transformers/events/cat_file/flip/transformer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -34,12 +35,12 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 		if verifyErr != nil {
 			return nil, verifyErr
 		}
-		addressID, addressErr := shared.GetOrCreateAddress(log.Log.Address.Hex(), db)
+		addressID, addressErr := repository.GetOrCreateAddress(db, log.Log.Address.Hex())
 		if addressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(addressErr)
 		}
 		msgSender := log.Log.Topics[1].Hex()
-		msgSenderID, msgSenderErr := shared.GetOrCreateAddress(msgSender, db)
+		msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, msgSender)
 		if msgSenderErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(msgSenderErr)
 		}

--- a/transformers/events/cat_file/vow/transformer.go
+++ b/transformers/events/cat_file/vow/transformer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -34,11 +35,11 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 		if err != nil {
 			return nil, err
 		}
-		addressID, addressErr := shared.GetOrCreateAddress(log.Log.Address.Hex(), db)
+		addressID, addressErr := repository.GetOrCreateAddress(db, log.Log.Address.Hex())
 		if addressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(addressErr)
 		}
-		msgSenderID, msgSenderErr := shared.GetOrCreateAddress(log.Log.Topics[1].Hex(), db)
+		msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, log.Log.Topics[1].Hex())
 		if msgSenderErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(msgSenderErr)
 		}

--- a/transformers/events/deal/transformer.go
+++ b/transformers/events/deal/transformer.go
@@ -20,6 +20,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -36,12 +37,12 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 
 		bidId := log.Log.Topics[2].Big()
 
-		addressID, addressErr := shared.GetOrCreateAddress(log.Log.Address.String(), db)
+		addressID, addressErr := repository.GetOrCreateAddress(db, log.Log.Address.String())
 		if addressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(addressErr)
 		}
 
-		msgSenderID, msgSenderErr := shared.GetOrCreateAddress(log.Log.Topics[1].Hex(), db)
+		msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, log.Log.Topics[1].Hex())
 		if msgSenderErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(msgSenderErr)
 		}

--- a/transformers/events/dent/transformer.go
+++ b/transformers/events/dent/transformer.go
@@ -22,6 +22,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -37,12 +38,12 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 		}
 
 		msgSender := common.HexToAddress(log.Log.Topics[1].Hex()).Hex()
-		msgSenderID, msgSenderErr := shared.GetOrCreateAddress(msgSender, db)
+		msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, msgSender)
 		if msgSenderErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(msgSenderErr)
 		}
 
-		addressID, addressErr := shared.GetOrCreateAddress(log.Log.Address.String(), db)
+		addressID, addressErr := repository.GetOrCreateAddress(db, log.Log.Address.String())
 		if addressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(addressErr)
 		}

--- a/transformers/events/flap_kick/transformer.go
+++ b/transformers/events/flap_kick/transformer.go
@@ -24,6 +24,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 	"github.com/makerdao/vulcanizedb/pkg/eth"
@@ -65,7 +66,7 @@ func (t Transformer) ToModels(abi string, logs []core.EventLog, db *postgres.DB)
 		if flapKickEntity.Id == nil {
 			return nil, errors.New("flapKick log ID cannot be nil")
 		}
-		addressId, addressErr := shared.GetOrCreateAddress(flapKickEntity.ContractAddress.Hex(), db)
+		addressId, addressErr := repository.GetOrCreateAddress(db, flapKickEntity.ContractAddress.Hex())
 		if addressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(addressErr)
 		}

--- a/transformers/events/flip_file/cat/transformer.go
+++ b/transformers/events/flip_file/cat/transformer.go
@@ -4,6 +4,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -20,17 +21,17 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 
 		what := shared.DecodeHexToText(log.Log.Topics[2].Hex())
 
-		addressID, addressErr := shared.GetOrCreateAddress(log.Log.Address.Hex(), db)
+		addressID, addressErr := repository.GetOrCreateAddress(db, log.Log.Address.Hex())
 		if addressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(addressErr)
 		}
 
-		msgSenderID, msgSenderErr := shared.GetOrCreateAddress(log.Log.Topics[1].Hex(), db)
+		msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, log.Log.Topics[1].Hex())
 		if msgSenderErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(msgSenderErr)
 		}
 
-		dataColumnID, dataColumnErr := shared.GetOrCreateAddress(log.Log.Topics[3].Hex(), db)
+		dataColumnID, dataColumnErr := repository.GetOrCreateAddress(db, log.Log.Topics[3].Hex())
 		if dataColumnErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(dataColumnErr)
 		}

--- a/transformers/events/flip_file/cat/transformer_test.go
+++ b/transformers/events/flip_file/cat/transformer_test.go
@@ -5,9 +5,9 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/flip_file/cat"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -27,7 +27,7 @@ var _ = Describe("Flip file cat transformer", func() {
 		models, err := transformer.ToModels(constants.FlipV110ABI(), []core.EventLog{test_data.FlipFileCatEventLog}, db)
 		Expect(err).NotTo(HaveOccurred())
 
-		dataColumnID, dataColumnErr := shared.GetOrCreateAddress("0xA950524441892A31ebddF91d3cEEFa04Bf454466", db)
+		dataColumnID, dataColumnErr := repository.GetOrCreateAddress(db, "0xA950524441892A31ebddF91d3cEEFa04Bf454466")
 		Expect(dataColumnErr).NotTo(HaveOccurred())
 
 		expectedFlipFileCat := test_data.FlipFileCatModel()

--- a/transformers/events/flip_kick/transformer.go
+++ b/transformers/events/flip_kick/transformer.go
@@ -24,6 +24,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 	"github.com/makerdao/vulcanizedb/pkg/eth"
@@ -65,7 +66,7 @@ func (t Transformer) ToModels(abi string, logs []core.EventLog, db *postgres.DB)
 		if flipKickEntity.Id == nil {
 			return nil, errors.New("flip kick bid ID cannot be nil")
 		}
-		addressId, addressErr := shared.GetOrCreateAddress(flipKickEntity.ContractAddress.Hex(), db)
+		addressId, addressErr := repository.GetOrCreateAddress(db, flipKickEntity.ContractAddress.Hex())
 		if addressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(addressErr)
 		}

--- a/transformers/events/flop_kick/transformer.go
+++ b/transformers/events/flop_kick/transformer.go
@@ -19,16 +19,14 @@ package flop_kick
 import (
 	"fmt"
 
-	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
-	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
-
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
-	"github.com/makerdao/vulcanizedb/pkg/core"
-
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/makerdao/vulcanizedb/pkg/eth"
-
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
+	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
+	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
+	"github.com/makerdao/vulcanizedb/pkg/core"
+	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
+	"github.com/makerdao/vulcanizedb/pkg/eth"
 )
 
 type Transformer struct{}
@@ -63,7 +61,7 @@ func (t Transformer) ToModels(abi string, logs []core.EventLog, db *postgres.DB)
 		return nil, fmt.Errorf("FlopKick transformer couldn't convert logs to entities: %v", entityErr)
 	}
 	for _, flopKickEntity := range entities {
-		addressId, addressErr := shared.GetOrCreateAddress(flopKickEntity.ContractAddress.Hex(), db)
+		addressId, addressErr := repository.GetOrCreateAddress(db, flopKickEntity.ContractAddress.Hex())
 		if addressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(addressErr)
 		}

--- a/transformers/events/jug_drip/transformer.go
+++ b/transformers/events/jug_drip/transformer.go
@@ -20,6 +20,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -34,7 +35,7 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 			return nil, err
 		}
 
-		msgSenderID, msgSenderErr := shared.GetOrCreateAddress(log.Log.Topics[1].Hex(), db)
+		msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, log.Log.Topics[1].Hex())
 		if msgSenderErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(msgSenderErr)
 		}

--- a/transformers/events/jug_file/base/transformer.go
+++ b/transformers/events/jug_file/base/transformer.go
@@ -20,6 +20,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -38,7 +39,7 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 		data := shared.ConvertUint256HexToBigInt(log.Log.Topics[3].Hex())
 
 		msgSender := shared.GetChecksumAddressString(log.Log.Topics[1].Hex())
-		msgSenderID, msgSenderErr := shared.GetOrCreateAddress(msgSender, db)
+		msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, msgSender)
 		if msgSenderErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(msgSenderErr)
 		}

--- a/transformers/events/jug_file/ilk/transformer.go
+++ b/transformers/events/jug_file/ilk/transformer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -36,7 +37,7 @@ func (Transformer) ToModels(contractAbi string, logs []core.EventLog, db *postgr
 		}
 
 		msgSender := shared.GetChecksumAddressString(log.Log.Topics[1].Hex())
-		msgSenderID, msgSenderErr := shared.GetOrCreateAddress(msgSender, db)
+		msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, msgSender)
 		if msgSenderErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(msgSenderErr)
 		}

--- a/transformers/events/jug_file/vow/transformer.go
+++ b/transformers/events/jug_file/vow/transformer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -36,7 +37,7 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 		}
 
 		msgSender := shared.GetChecksumAddressString(log.Log.Topics[1].Hex())
-		msgSenderID, msgSenderErr := shared.GetOrCreateAddress(msgSender, db)
+		msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, msgSender)
 		if msgSenderErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(msgSenderErr)
 		}

--- a/transformers/events/jug_init/transformer.go
+++ b/transformers/events/jug_init/transformer.go
@@ -20,6 +20,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -34,7 +35,7 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 			return nil, err
 		}
 
-		msgSenderID, msgSenderErr := shared.GetOrCreateAddress(log.Log.Topics[1].Hex(), db)
+		msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, log.Log.Topics[1].Hex())
 		if msgSenderErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(msgSenderErr)
 		}

--- a/transformers/events/log_median_price/transformer.go
+++ b/transformers/events/log_median_price/transformer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 	"github.com/makerdao/vulcanizedb/pkg/eth"
@@ -47,7 +48,7 @@ func (t Transformer) ToModels(abi string, logs []core.EventLog, db *postgres.DB)
 
 	var models []event.InsertionModel
 	for _, LogMedianPriceEntity := range entities {
-		addressID, addressErr := shared.GetOrCreateAddress(LogMedianPriceEntity.ContractAddress.Hex(), db)
+		addressID, addressErr := repository.GetOrCreateAddress(db, LogMedianPriceEntity.ContractAddress.Hex())
 		if addressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(addressErr)
 		}

--- a/transformers/events/log_value/transformer.go
+++ b/transformers/events/log_value/transformer.go
@@ -22,6 +22,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -37,7 +38,7 @@ func (t Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) (
 			return nil, err
 		}
 
-		contractAddressID, contractAddressErr := shared.GetOrCreateAddress(log.Log.Address.String(), db)
+		contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, log.Log.Address.String())
 		if contractAddressErr != nil {
 			return nil, err
 		}

--- a/transformers/events/median_diss/batch/transformer.go
+++ b/transformers/events/median_diss/batch/transformer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -21,13 +22,13 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 			return nil, err
 		}
 
-		contractAddressID, contractAddressErr := shared.GetOrCreateAddress(log.Log.Address.String(), db)
+		contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, log.Log.Address.String())
 		if contractAddressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(contractAddressErr)
 		}
 
 		msgSender := log.Log.Topics[1].Hex()
-		msgSenderAddressID, msgSenderAddressErr := shared.GetOrCreateAddress(msgSender, db)
+		msgSenderAddressID, msgSenderAddressErr := repository.GetOrCreateAddress(db, msgSender)
 		if msgSenderAddressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(msgSenderAddressErr)
 		}

--- a/transformers/events/median_diss/single/transformer.go
+++ b/transformers/events/median_diss/single/transformer.go
@@ -4,6 +4,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -18,19 +19,19 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 			return nil, err
 		}
 
-		contractAddressID, contractAddressErr := shared.GetOrCreateAddress(log.Log.Address.String(), db)
+		contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, log.Log.Address.String())
 		if contractAddressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(contractAddressErr)
 		}
 
 		msgSender := log.Log.Topics[1].Hex()
-		msgSenderAddressID, msgSenderAddressErr := shared.GetOrCreateAddress(msgSender, db)
+		msgSenderAddressID, msgSenderAddressErr := repository.GetOrCreateAddress(db, msgSender)
 		if msgSenderAddressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(msgSenderAddressErr)
 		}
 
 		a := log.Log.Topics[2].Hex()
-		aAddressID, aAddressErr := shared.GetOrCreateAddress(a, db)
+		aAddressID, aAddressErr := repository.GetOrCreateAddress(db, a)
 		if aAddressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(aAddressErr)
 		}

--- a/transformers/events/median_diss/single/transformer_test.go
+++ b/transformers/events/median_diss/single/transformer_test.go
@@ -3,9 +3,9 @@ package single_test
 import (
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/median_diss/single"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -34,7 +34,7 @@ var _ = Describe("Median diss (single) transformer", func() {
 		expectedModel := test_data.MedianDissSingleModel()
 		test_data.AssignAddressID(test_data.MedianDissSingleLog, expectedModel, db)
 		test_data.AssignMessageSenderID(test_data.MedianDissSingleLog, expectedModel, db)
-		aAddressID, aAddressErr := shared.GetOrCreateAddress(test_data.MedianDissSingleLog.Log.Topics[2].Hex(), db)
+		aAddressID, aAddressErr := repository.GetOrCreateAddress(db, test_data.MedianDissSingleLog.Log.Topics[2].Hex())
 		Expect(aAddressErr).NotTo(HaveOccurred())
 		expectedModel.ColumnValues[constants.AColumn] = aAddressID
 

--- a/transformers/events/median_drop/transformer.go
+++ b/transformers/events/median_drop/transformer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -22,13 +23,13 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 			return nil, err
 		}
 
-		contractAddressID, contractAddressErr := shared.GetOrCreateAddress(log.Log.Address.String(), db)
+		contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, log.Log.Address.String())
 		if contractAddressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(contractAddressErr)
 		}
 
 		msgSender := log.Log.Topics[1].Hex()
-		msgSenderAddressID, msgSenderAddressErr := shared.GetOrCreateAddress(msgSender, db)
+		msgSenderAddressID, msgSenderAddressErr := repository.GetOrCreateAddress(db, msgSender)
 		if msgSenderAddressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(msgSenderAddressErr)
 		}

--- a/transformers/events/median_kiss/batch/transformer.go
+++ b/transformers/events/median_kiss/batch/transformer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -21,13 +22,13 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 			return nil, err
 		}
 
-		contractAddressID, contractAddressErr := shared.GetOrCreateAddress(log.Log.Address.String(), db)
+		contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, log.Log.Address.String())
 		if contractAddressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(contractAddressErr)
 		}
 
 		msgSender := log.Log.Topics[1].Hex()
-		msgSenderAddressID, msgSenderAddressErr := shared.GetOrCreateAddress(msgSender, db)
+		msgSenderAddressID, msgSenderAddressErr := repository.GetOrCreateAddress(db, msgSender)
 		if msgSenderAddressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(msgSenderAddressErr)
 		}

--- a/transformers/events/median_kiss/single/transformer.go
+++ b/transformers/events/median_kiss/single/transformer.go
@@ -4,6 +4,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -18,19 +19,19 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 			return nil, err
 		}
 
-		contractAddressID, contractAddressErr := shared.GetOrCreateAddress(log.Log.Address.String(), db)
+		contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, log.Log.Address.String())
 		if contractAddressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(contractAddressErr)
 		}
 
 		msgSender := log.Log.Topics[1].Hex()
-		msgSenderAddressID, msgSenderAddressErr := shared.GetOrCreateAddress(msgSender, db)
+		msgSenderAddressID, msgSenderAddressErr := repository.GetOrCreateAddress(db, msgSender)
 		if msgSenderAddressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(msgSenderAddressErr)
 		}
 
 		a := log.Log.Topics[2].Hex()
-		aAddressID, aAddressErr := shared.GetOrCreateAddress(a, db)
+		aAddressID, aAddressErr := repository.GetOrCreateAddress(db, a)
 		if aAddressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(aAddressErr)
 		}

--- a/transformers/events/median_kiss/single/transformer_test.go
+++ b/transformers/events/median_kiss/single/transformer_test.go
@@ -3,9 +3,9 @@ package single_test
 import (
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/median_kiss/single"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -34,7 +34,7 @@ var _ = Describe("Median kiss (single) transformer", func() {
 		expectedModel := test_data.MedianKissSingleModel()
 		test_data.AssignAddressID(test_data.MedianKissSingleLog, expectedModel, db)
 		test_data.AssignMessageSenderID(test_data.MedianKissSingleLog, expectedModel, db)
-		aAddressID, aAddressErr := shared.GetOrCreateAddress(test_data.MedianKissSingleLog.Log.Topics[2].Hex(), db)
+		aAddressID, aAddressErr := repository.GetOrCreateAddress(db, test_data.MedianKissSingleLog.Log.Topics[2].Hex())
 		Expect(aAddressErr).NotTo(HaveOccurred())
 		expectedModel.ColumnValues[constants.AColumn] = aAddressID
 

--- a/transformers/events/median_lift/transformer.go
+++ b/transformers/events/median_lift/transformer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -22,13 +23,13 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 			return nil, err
 		}
 
-		contractAddressID, contractAddressErr := shared.GetOrCreateAddress(log.Log.Address.String(), db)
+		contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, log.Log.Address.String())
 		if contractAddressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(contractAddressErr)
 		}
 
 		msgSender := log.Log.Topics[1].Hex()
-		msgSenderAddressID, msgSenderAddressErr := shared.GetOrCreateAddress(msgSender, db)
+		msgSenderAddressID, msgSenderAddressErr := repository.GetOrCreateAddress(db, msgSender)
 		if msgSenderAddressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(msgSenderAddressErr)
 		}

--- a/transformers/events/osm_change/transformer.go
+++ b/transformers/events/osm_change/transformer.go
@@ -4,6 +4,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -18,19 +19,19 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 			return nil, err
 		}
 
-		contractAddressID, contractAddressErr := shared.GetOrCreateAddress(log.Log.Address.String(), db)
+		contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, log.Log.Address.String())
 		if contractAddressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(contractAddressErr)
 		}
 
 		msgSender := log.Log.Topics[1].Hex()
-		msgSenderAddressID, msgSenderAddressErr := shared.GetOrCreateAddress(msgSender, db)
+		msgSenderAddressID, msgSenderAddressErr := repository.GetOrCreateAddress(db, msgSender)
 		if msgSenderAddressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(msgSenderAddressErr)
 		}
 
 		src := log.Log.Topics[2].Hex()
-		srcAddressID, srcAddressErr := shared.GetOrCreateAddress(src, db)
+		srcAddressID, srcAddressErr := repository.GetOrCreateAddress(db, src)
 		if srcAddressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(srcAddressErr)
 		}

--- a/transformers/events/osm_change/transformer_test.go
+++ b/transformers/events/osm_change/transformer_test.go
@@ -3,9 +3,9 @@ package osm_change_test
 import (
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/osm_change"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -34,7 +34,7 @@ var _ = Describe("OsmChange transformer", func() {
 		expectedModel := test_data.OsmChangeModel()
 		test_data.AssignAddressID(test_data.OsmChangeEventLog, expectedModel, db)
 		test_data.AssignMessageSenderID(test_data.OsmChangeEventLog, expectedModel, db)
-		srcAddressID, srcAddressErr := shared.GetOrCreateAddress(test_data.OsmChangeEventLog.Log.Topics[2].Hex(), db)
+		srcAddressID, srcAddressErr := repository.GetOrCreateAddress(db, test_data.OsmChangeEventLog.Log.Topics[2].Hex())
 		Expect(srcAddressErr).NotTo(HaveOccurred())
 		expectedModel.ColumnValues[constants.SrcColumn] = srcAddressID
 

--- a/transformers/events/pot_cage/transformer.go
+++ b/transformers/events/pot_cage/transformer.go
@@ -4,6 +4,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -21,7 +22,7 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 		}
 
 		msgSender := shared.GetChecksumAddressString(log.Log.Topics[1].Hex())
-		msgSenderID, msgSenderErr := shared.GetOrCreateAddress(msgSender, db)
+		msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, msgSender)
 		if msgSenderErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(msgSenderErr)
 		}

--- a/transformers/events/pot_drip/transformer.go
+++ b/transformers/events/pot_drip/transformer.go
@@ -5,6 +5,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -20,7 +21,7 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 		}
 
 		msgSender := common.BytesToAddress(log.Log.Topics[1].Bytes()).Hex()
-		addressId, addressErr := shared.GetOrCreateAddress(msgSender, db)
+		addressId, addressErr := repository.GetOrCreateAddress(db, msgSender)
 		if addressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(addressErr)
 		}

--- a/transformers/events/pot_exit/transformer.go
+++ b/transformers/events/pot_exit/transformer.go
@@ -5,6 +5,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -20,7 +21,7 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 		}
 
 		msgSender := common.BytesToAddress(log.Log.Topics[1].Bytes()).Hex()
-		addressID, addressErr := shared.GetOrCreateAddress(msgSender, db)
+		addressID, addressErr := repository.GetOrCreateAddress(db, msgSender)
 		if addressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(addressErr)
 		}

--- a/transformers/events/pot_file/dsr/transformer.go
+++ b/transformers/events/pot_file/dsr/transformer.go
@@ -4,6 +4,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -20,7 +21,7 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 			return nil, verifyErr
 		}
 		msgSender := shared.GetChecksumAddressString(log.Log.Topics[1].Hex())
-		msgSenderID, msgSenderErr := shared.GetOrCreateAddress(msgSender, db)
+		msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, msgSender)
 		if msgSenderErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(msgSenderErr)
 		}

--- a/transformers/events/pot_file/vow/transformer.go
+++ b/transformers/events/pot_file/vow/transformer.go
@@ -5,6 +5,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -21,7 +22,7 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 			return nil, verifyErr
 		}
 		msgSender := shared.GetChecksumAddressString(log.Log.Topics[1].Hex())
-		msgSenderID, msgSenderErr := shared.GetOrCreateAddress(msgSender, db)
+		msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, msgSender)
 		if msgSenderErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(msgSenderErr)
 		}

--- a/transformers/events/pot_join/transformer.go
+++ b/transformers/events/pot_join/transformer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -36,7 +37,7 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 		}
 
 		msgSender := common.BytesToAddress(log.Log.Topics[1].Bytes()).Hex()
-		addressID, addressErr := shared.GetOrCreateAddress(msgSender, db)
+		addressID, addressErr := repository.GetOrCreateAddress(db, msgSender)
 		if addressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(addressErr)
 		}

--- a/transformers/events/spot_file/mat/transformer.go
+++ b/transformers/events/spot_file/mat/transformer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -35,7 +36,7 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 			return nil, err
 		}
 
-		msgSenderID, msgSenderErr := shared.GetOrCreateAddress(log.Log.Topics[1].Hex(), db)
+		msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, log.Log.Topics[1].Hex())
 		if msgSenderErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(msgSenderErr)
 		}

--- a/transformers/events/spot_file/par/transformer.go
+++ b/transformers/events/spot_file/par/transformer.go
@@ -4,6 +4,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -18,7 +19,7 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 			return nil, err
 		}
 
-		msgSenderID, msgSenderErr := shared.GetOrCreateAddress(log.Log.Topics[1].Hex(), db)
+		msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, log.Log.Topics[1].Hex())
 
 		if msgSenderErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(msgSenderErr)

--- a/transformers/events/spot_file/pip/transformer.go
+++ b/transformers/events/spot_file/pip/transformer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -35,7 +36,7 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 			return nil, err
 		}
 
-		msgSenderID, msgSenderErr := shared.GetOrCreateAddress(log.Log.Topics[1].Hex(), db)
+		msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, log.Log.Topics[1].Hex())
 		if msgSenderErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(msgSenderErr)
 		}

--- a/transformers/events/tend/transformer.go
+++ b/transformers/events/tend/transformer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -35,12 +36,12 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 			return nil, err
 		}
 
-		addressID, addressErr := shared.GetOrCreateAddress(log.Log.Address.String(), db)
+		addressID, addressErr := repository.GetOrCreateAddress(db, log.Log.Address.String())
 		if addressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(addressErr)
 		}
 
-		msgSenderAddressID, msgSenderAddressErr := shared.GetOrCreateAddress(log.Log.Topics[1].String(), db)
+		msgSenderAddressID, msgSenderAddressErr := repository.GetOrCreateAddress(db, log.Log.Topics[1].String())
 		if msgSenderAddressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(msgSenderAddressErr)
 		}

--- a/transformers/events/tick/transformer.go
+++ b/transformers/events/tick/transformer.go
@@ -20,6 +20,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -36,13 +37,13 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 			return nil, validateErr
 		}
 
-		addressID, addressErr := shared.GetOrCreateAddress(log.Log.Address.String(), db)
+		addressID, addressErr := repository.GetOrCreateAddress(db, log.Log.Address.String())
 		if addressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(addressErr)
 		}
 
 		msgSender := shared.GetChecksumAddressString(log.Log.Topics[1].Hex())
-		msgSenderID, msgSenderErr := shared.GetOrCreateAddress(msgSender, db)
+		msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, msgSender)
 		if msgSenderErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(msgSenderErr)
 		}

--- a/transformers/events/vat_auth/transformer.go
+++ b/transformers/events/vat_auth/transformer.go
@@ -5,6 +5,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -22,7 +23,7 @@ func (t Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) (
 		}
 
 		usrAddress := common.HexToAddress(log.Log.Topics[1].Hex()).Hex()
-		usrAddressID, usrAddressErr := shared.GetOrCreateAddress(usrAddress, db)
+		usrAddressID, usrAddressErr := repository.GetOrCreateAddress(db, usrAddress)
 		if usrAddressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(usrAddressErr)
 		}

--- a/transformers/events/vat_auth/transformer_test.go
+++ b/transformers/events/vat_auth/transformer_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -25,7 +26,7 @@ var _ = Describe("Vat Auth Transformer", func() {
 		models, err := converter.ToModels("", []core.EventLog{test_data.VatRelyEventLog}, db)
 		Expect(err).NotTo(HaveOccurred())
 
-		usrAddressID, usrAddressErr := shared.GetOrCreateAddress(test_data.VatRelyEventLog.Log.Topics[1].Hex(), db)
+		usrAddressID, usrAddressErr := repository.GetOrCreateAddress(db, test_data.VatRelyEventLog.Log.Topics[1].Hex())
 		Expect(usrAddressErr).NotTo(HaveOccurred())
 
 		expectedModel := test_data.VatRelyModel()
@@ -39,7 +40,7 @@ var _ = Describe("Vat Auth Transformer", func() {
 		models, err := converter.ToModels("", []core.EventLog{test_data.VatDenyEventLog}, db)
 		Expect(err).NotTo(HaveOccurred())
 
-		usrAddressID, usrAddressErr := shared.GetOrCreateAddress(test_data.VatDenyEventLog.Log.Topics[1].Hex(), db)
+		usrAddressID, usrAddressErr := repository.GetOrCreateAddress(db, test_data.VatDenyEventLog.Log.Topics[1].Hex())
 		Expect(usrAddressErr).NotTo(HaveOccurred())
 
 		expectedModel := test_data.VatDenyModel()
@@ -53,7 +54,7 @@ var _ = Describe("Vat Auth Transformer", func() {
 		models, err := converter.ToModels("", []core.EventLog{test_data.VatHopeEventLog}, db)
 		Expect(err).NotTo(HaveOccurred())
 
-		usrAddressID, usrAddressErr := shared.GetOrCreateAddress(test_data.VatHopeEventLog.Log.Topics[1].Hex(), db)
+		usrAddressID, usrAddressErr := repository.GetOrCreateAddress(db, test_data.VatHopeEventLog.Log.Topics[1].Hex())
 		Expect(usrAddressErr).NotTo(HaveOccurred())
 
 		expectedModel := test_data.VatHopeModel()
@@ -67,7 +68,7 @@ var _ = Describe("Vat Auth Transformer", func() {
 		models, err := converter.ToModels("", []core.EventLog{test_data.VatNopeEventLog}, db)
 		Expect(err).NotTo(HaveOccurred())
 
-		usrAddressID, usrAddressErr := shared.GetOrCreateAddress(test_data.VatNopeEventLog.Log.Topics[1].Hex(), db)
+		usrAddressID, usrAddressErr := repository.GetOrCreateAddress(db, test_data.VatNopeEventLog.Log.Topics[1].Hex())
 		Expect(usrAddressErr).NotTo(HaveOccurred())
 
 		expectedModel := test_data.VatNopeModel()

--- a/transformers/events/vow_fess/transformer.go
+++ b/transformers/events/vow_fess/transformer.go
@@ -20,6 +20,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -36,7 +37,7 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 
 		tab := log.Log.Topics[2].Big()
 
-		msgSenderID, msgSenderErr := shared.GetOrCreateAddress(log.Log.Topics[1].Hex(), db)
+		msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, log.Log.Topics[1].Hex())
 		if msgSenderErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(msgSenderErr)
 		}

--- a/transformers/events/vow_file/auction_address/transformer.go
+++ b/transformers/events/vow_file/auction_address/transformer.go
@@ -5,6 +5,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -20,14 +21,14 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 		}
 
 		msgSenderAddress := common.HexToAddress(log.Log.Topics[1].Hex()).Hex()
-		msgSenderAddressId, msgSenderAddressErr := shared.GetOrCreateAddress(msgSenderAddress, db)
+		msgSenderAddressId, msgSenderAddressErr := repository.GetOrCreateAddress(db, msgSenderAddress)
 		if msgSenderAddressErr != nil {
 			return nil, msgSenderAddressErr
 		}
 
 		what := shared.DecodeHexToText(log.Log.Topics[2].Hex())
 		dataAddress := common.HexToAddress(log.Log.Topics[3].Hex()).Hex()
-		dataAddressId, dataAddressErr := shared.GetOrCreateAddress(dataAddress, db)
+		dataAddressId, dataAddressErr := repository.GetOrCreateAddress(db, dataAddress)
 		if dataAddressErr != nil {
 			return nil, dataAddressErr
 		}

--- a/transformers/events/vow_file/auction_attributes/transformer.go
+++ b/transformers/events/vow_file/auction_attributes/transformer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -36,7 +37,7 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 		}
 
 		msgSenderAddress := common.HexToAddress(log.Log.Topics[1].Hex()).Hex()
-		msgSenderAddressID, msgSenderAddressErr := shared.GetOrCreateAddress(msgSenderAddress, db)
+		msgSenderAddressID, msgSenderAddressErr := repository.GetOrCreateAddress(db, msgSenderAddress)
 		if msgSenderAddressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(msgSenderAddressErr)
 		}

--- a/transformers/events/vow_flog/transformer.go
+++ b/transformers/events/vow_flog/transformer.go
@@ -20,6 +20,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -34,7 +35,7 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 			return nil, err
 		}
 
-		msgSenderID, msgSenderErr := shared.GetOrCreateAddress(log.Log.Topics[1].Hex(), db)
+		msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, log.Log.Topics[1].Hex())
 		if msgSenderErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(msgSenderErr)
 		}

--- a/transformers/events/vow_heal/transformer.go
+++ b/transformers/events/vow_heal/transformer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -22,7 +23,7 @@ func (t Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) (
 		}
 
 		msgSenderAddress := common.HexToAddress(log.Log.Topics[1].Hex()).Hex()
-		msgSenderAddressID, msgSenderErr := shared.GetOrCreateAddress(msgSenderAddress, db)
+		msgSenderAddressID, msgSenderErr := repository.GetOrCreateAddress(db, msgSenderAddress)
 		if msgSenderErr != nil {
 			msg := "error getting or creating address %s for vow heal msg sender: %w"
 			return nil, fmt.Errorf(msg, msgSenderAddress, msgSenderErr)

--- a/transformers/events/yank/transformer.go
+++ b/transformers/events/yank/transformer.go
@@ -20,6 +20,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -32,11 +33,11 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) (re
 		if validationErr != nil {
 			return nil, validationErr
 		}
-		msgSenderID, msgSenderErr := shared.GetOrCreateAddress(log.Log.Topics[1].Hex(), db)
+		msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, log.Log.Topics[1].Hex())
 		if msgSenderErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(msgSenderErr)
 		}
-		addressID, addressErr := shared.GetOrCreateAddress(log.Log.Address.String(), db)
+		addressID, addressErr := repository.GetOrCreateAddress(db, log.Log.Address.String())
 		if addressErr != nil {
 			return nil, shared.ErrCouldNotCreateFK(addressErr)
 		}

--- a/transformers/integration_tests/auction_file_test.go
+++ b/transformers/integration_tests/auction_file_test.go
@@ -6,11 +6,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/auction_file"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -108,9 +108,9 @@ func auctionFileIntegrationTest(blockNumber int64, contractAddressHex, msgSender
 		err := db.Select(&dbResults, `SELECT address_id, msg_sender, what, data FROM maker.auction_file`)
 		Expect(err).NotTo(HaveOccurred())
 
-		contractAddressID, contractAddressErr := shared.GetOrCreateAddress(contractAddressHex, db)
+		contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, contractAddressHex)
 		Expect(contractAddressErr).NotTo(HaveOccurred())
-		msgSenderAddressID, msgSenderAddressErr := shared.GetOrCreateAddress(msgSenderAddressHex, db)
+		msgSenderAddressID, msgSenderAddressErr := repository.GetOrCreateAddress(db, msgSenderAddressHex)
 		Expect(msgSenderAddressErr).NotTo(HaveOccurred())
 
 		var matchFound bool

--- a/transformers/integration_tests/bite_test.go
+++ b/transformers/integration_tests/bite_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -100,7 +101,7 @@ func biteIntegrationTest(blockNumber int64, contractAddressHex, contractABI, ilk
 		Expect(urnErr).NotTo(HaveOccurred())
 		expectedResult.Urn = urnID
 
-		addressID, addressErr := shared.GetOrCreateAddress(contractAddressHex, db)
+		addressID, addressErr := repository.GetOrCreateAddress(db, contractAddressHex)
 		Expect(addressErr).NotTo(HaveOccurred())
 		expectedResult.AddressID = addressID
 

--- a/transformers/integration_tests/cat_claw_test.go
+++ b/transformers/integration_tests/cat_claw_test.go
@@ -4,11 +4,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/cat_claw"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -57,11 +57,11 @@ var _ = Describe("Cat Claw transformer", func() {
 		err = db.Get(&dbResult, `SELECT address_id, msg_sender, rad FROM maker.cat_claw`)
 		Expect(err).NotTo(HaveOccurred())
 
-		addressID, addressErr := shared.GetOrCreateAddress(test_data.Cat110Address(), db)
+		addressID, addressErr := repository.GetOrCreateAddress(db, test_data.Cat110Address())
 		Expect(addressErr).NotTo(HaveOccurred())
 
 		msgSender := "0xF32836B9E1f47a0515c6Ec431592D5EbC276407f"
-		msgSenderID, msgSenderErr := shared.GetOrCreateAddress(msgSender, db)
+		msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, msgSender)
 		Expect(msgSenderErr).NotTo(HaveOccurred())
 
 		Expect(dbResult.AddressID).To(Equal(addressID))

--- a/transformers/integration_tests/cat_file_test.go
+++ b/transformers/integration_tests/cat_file_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -77,9 +78,9 @@ var _ = Describe("Cat File transformer", func() {
 			getErr := db.Get(&dbResult, `SELECT address_id, msg_sender, ilk_id, what, data FROM maker.cat_file_chop_lump_dunk`)
 			Expect(getErr).NotTo(HaveOccurred())
 
-			addressID, addressErr := shared.GetOrCreateAddress("0x78F2c2AF65126834c51822F56Be0d7469D7A523E", db)
+			addressID, addressErr := repository.GetOrCreateAddress(db, "0x78F2c2AF65126834c51822F56Be0d7469D7A523E")
 			Expect(addressErr).NotTo(HaveOccurred())
-			msgSenderID, msgSenderErr := shared.GetOrCreateAddress("0xBE8E3e3618f7474F8cB1d074A26afFef007E98FB", db)
+			msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, "0xBE8E3e3618f7474F8cB1d074A26afFef007E98FB")
 			Expect(msgSenderErr).NotTo(HaveOccurred())
 			ilkID, ilkErr := shared.GetOrCreateIlk("0x4554482d41000000000000000000000000000000000000000000000000000000", db)
 			Expect(ilkErr).NotTo(HaveOccurred())
@@ -120,9 +121,9 @@ var _ = Describe("Cat File transformer", func() {
 			getErr := db.Get(&dbResult, `SELECT address_id, msg_sender, ilk_id, what, data FROM maker.cat_file_chop_lump_dunk`)
 			Expect(getErr).NotTo(HaveOccurred())
 
-			addressID, addressErr := shared.GetOrCreateAddress("0x78F2c2AF65126834c51822F56Be0d7469D7A523E", db)
+			addressID, addressErr := repository.GetOrCreateAddress(db, "0x78F2c2AF65126834c51822F56Be0d7469D7A523E")
 			Expect(addressErr).NotTo(HaveOccurred())
-			msgSenderID, msgSenderErr := shared.GetOrCreateAddress("0xBE8E3e3618f7474F8cB1d074A26afFef007E98FB", db)
+			msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, "0xBE8E3e3618f7474F8cB1d074A26afFef007E98FB")
 			Expect(msgSenderErr).NotTo(HaveOccurred())
 			ilkID, ilkErr := shared.GetOrCreateIlk("0x4554482d41000000000000000000000000000000000000000000000000000000", db)
 			Expect(ilkErr).NotTo(HaveOccurred())
@@ -164,14 +165,14 @@ var _ = Describe("Cat File transformer", func() {
 			err = db.Get(&dbResult, `SELECT ilk_id, msg_sender, address_id, what, flip FROM maker.cat_file_flip`)
 			Expect(err).NotTo(HaveOccurred())
 
-			addressID, addressErr := shared.GetOrCreateAddress("0x78F2c2AF65126834c51822F56Be0d7469D7A523E", db)
+			addressID, addressErr := repository.GetOrCreateAddress(db, "0x78F2c2AF65126834c51822F56Be0d7469D7A523E")
 			Expect(addressErr).NotTo(HaveOccurred())
 
 			ilkID, err := shared.GetOrCreateIlk("0x4554482d41000000000000000000000000000000000000000000000000000000", db)
 			Expect(err).NotTo(HaveOccurred())
 
 			msgSender := shared.GetChecksumAddressString("0x000000000000000000000000baa65281c2fa2baacb2cb550ba051525a480d3f4")
-			msgSenderID, msgSenderErr := shared.GetOrCreateAddress(msgSender, db)
+			msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, msgSender)
 			Expect(msgSenderErr).NotTo(HaveOccurred())
 
 			Expect(dbResult.MsgSender).To(Equal(msgSenderID))
@@ -211,10 +212,10 @@ var _ = Describe("Cat File transformer", func() {
 			getErr := db.Get(&dbResult, `SELECT address_id, msg_sender, what, data FROM maker.cat_file_vow`)
 			Expect(getErr).NotTo(HaveOccurred())
 
-			addressID, addressErr := shared.GetOrCreateAddress("0x78F2c2AF65126834c51822F56Be0d7469D7A523E", db)
+			addressID, addressErr := repository.GetOrCreateAddress(db, "0x78F2c2AF65126834c51822F56Be0d7469D7A523E")
 			Expect(addressErr).NotTo(HaveOccurred())
 
-			msgSenderID, msgSenderErr := shared.GetOrCreateAddress("0xbaa65281c2FA2baAcb2cb550BA051525A480D3F4", db)
+			msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, "0xbaa65281c2FA2baAcb2cb550BA051525A480D3F4")
 			Expect(msgSenderErr).NotTo(HaveOccurred())
 
 			Expect(dbResult.AddressID).To(Equal(addressID))
@@ -260,9 +261,9 @@ var _ = Describe("Cat File transformer", func() {
 			err = db.Get(&dbResult, `SELECT address_id, msg_sender, what, data FROM maker.cat_file_box`)
 			Expect(err).NotTo(HaveOccurred())
 
-			addressID, err := shared.GetOrCreateAddress(test_data.Cat110Address(), db)
+			addressID, err := repository.GetOrCreateAddress(db, test_data.Cat110Address())
 			Expect(err).NotTo(HaveOccurred())
-			msgSenderID, err := shared.GetOrCreateAddress("0xBE8E3e3618f7474F8cB1d074A26afFef007E98FB", db)
+			msgSenderID, err := repository.GetOrCreateAddress(db, "0xBE8E3e3618f7474F8cB1d074A26afFef007E98FB")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(dbResult.AddressID).To(Equal(addressID))
 			Expect(dbResult.MsgSenderID).To(Equal(msgSenderID))
@@ -297,11 +298,11 @@ var _ = Describe("Cat File transformer", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			var dbResults []catFileChopLumpDunkModel
-			msgSenderID, err := shared.GetOrCreateAddress("0xBE8E3e3618f7474F8cB1d074A26afFef007E98FB", db)
+			msgSenderID, err := repository.GetOrCreateAddress(db, "0xBE8E3e3618f7474F8cB1d074A26afFef007E98FB")
 			Expect(err).NotTo(HaveOccurred())
 			err = db.Select(&dbResults, `SELECT address_id, msg_sender, what, data FROM maker.cat_file_chop_lump_dunk`)
 			Expect(err).NotTo(HaveOccurred())
-			addressID, err := shared.GetOrCreateAddress(test_data.Cat110Address(), db)
+			addressID, err := repository.GetOrCreateAddress(db, test_data.Cat110Address())
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(len(dbResults)).To(Equal(18))

--- a/transformers/integration_tests/deal_test.go
+++ b/transformers/integration_tests/deal_test.go
@@ -20,11 +20,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/deal"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -82,9 +82,9 @@ var _ = Describe("Deal transformer", func() {
 		err := db.Get(&dbResult, `SELECT bid_id, address_id, msg_sender FROM maker.deal`)
 		Expect(err).NotTo(HaveOccurred())
 
-		flipAddressID, flipAddressErr := shared.GetOrCreateAddress(test_data.FlipEthV100Address(), db)
+		flipAddressID, flipAddressErr := repository.GetOrCreateAddress(db, test_data.FlipEthV100Address())
 		Expect(flipAddressErr).NotTo(HaveOccurred())
-		msgSenderID, msgSenderErr := shared.GetOrCreateAddress("0x00aBe7471ec9b6953A3BD0ed3C06c46F29Aa4280", db)
+		msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, "0x00aBe7471ec9b6953A3BD0ed3C06c46F29Aa4280")
 		Expect(msgSenderErr).NotTo(HaveOccurred())
 
 		Expect(dbResult.BidID).To(Equal("115"))
@@ -113,9 +113,9 @@ var _ = Describe("Deal transformer", func() {
 		err := db.Get(&dbResult, `SELECT bid_id, address_id, msg_sender FROM maker.deal`)
 		Expect(err).NotTo(HaveOccurred())
 
-		flopAddressID, addressErr := shared.GetOrCreateAddress(test_data.FlopV101Address(), db)
+		flopAddressID, addressErr := repository.GetOrCreateAddress(db, test_data.FlopV101Address())
 		Expect(addressErr).NotTo(HaveOccurred())
-		msgSenderID, msgSenderErr := shared.GetOrCreateAddress("0x06C36BEA54A74dB813Af0fc136c2E8d0B08e2FB1", db)
+		msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, "0x06C36BEA54A74dB813Af0fc136c2E8d0B08e2FB1")
 		Expect(msgSenderErr).NotTo(HaveOccurred())
 
 		Expect(dbResult.BidID).To(Equal("102"))
@@ -144,9 +144,9 @@ var _ = Describe("Deal transformer", func() {
 		err := db.Get(&dbResult, `SELECT bid_id, address_id, msg_sender FROM maker.deal ORDER BY log_id`)
 		Expect(err).NotTo(HaveOccurred())
 
-		flapAddressID, addressErr := shared.GetOrCreateAddress(test_data.FlapV100Address(), db)
+		flapAddressID, addressErr := repository.GetOrCreateAddress(db, test_data.FlapV100Address())
 		Expect(addressErr).NotTo(HaveOccurred())
-		msgSenderID, msgSenderErr := shared.GetOrCreateAddress("0xFDc7768e92B479F27dD11635c9207d542177ae72", db)
+		msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, "0xFDc7768e92B479F27dD11635c9207d542177ae72")
 		Expect(msgSenderErr).NotTo(HaveOccurred())
 
 		Expect(dbResult.BidID).To(Equal("48"))

--- a/transformers/integration_tests/dent_test.go
+++ b/transformers/integration_tests/dent_test.go
@@ -20,11 +20,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/dent"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -81,10 +81,10 @@ var _ = Describe("Dent transformer", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		msgSender := common.HexToAddress("0xe06ac4777f04ac7638f736a0b95f7bfeadcee556").Hex()
-		msgSenderId, msgSenderErr := shared.GetOrCreateAddress(msgSender, db)
+		msgSenderId, msgSenderErr := repository.GetOrCreateAddress(db, msgSender)
 		Expect(msgSenderErr).NotTo(HaveOccurred())
 
-		flopContractAddressId, addressErr := shared.GetOrCreateAddress(test_data.FlopV101Address(), db)
+		flopContractAddressId, addressErr := repository.GetOrCreateAddress(db, test_data.FlopV101Address())
 		Expect(addressErr).NotTo(HaveOccurred())
 
 		expectedModel := dentModel{
@@ -118,11 +118,11 @@ var _ = Describe("Dent transformer", func() {
 		err = db.Get(&dbResult, `SELECT bid, bid_id, lot, msg_sender, address_id FROM maker.dent`)
 		Expect(err).NotTo(HaveOccurred())
 
-		flipContractAddressId, err := shared.GetOrCreateAddress(test_data.FlipEthV100Address(), db)
+		flipContractAddressId, err := repository.GetOrCreateAddress(db, test_data.FlipEthV100Address())
 		Expect(err).NotTo(HaveOccurred())
 
 		msgSender := common.HexToAddress("0xabe7471ec9b6953a3bd0ed3c06c46f29aa4280").Hex()
-		msgSenderId, msgSenderErr := shared.GetOrCreateAddress(msgSender, db)
+		msgSenderId, msgSenderErr := repository.GetOrCreateAddress(db, msgSender)
 		Expect(msgSenderErr).NotTo(HaveOccurred())
 
 		Expect(dbResult.Bid).To(Equal("111871106928171434728687324748784117143125320430"))

--- a/transformers/integration_tests/deny_test.go
+++ b/transformers/integration_tests/deny_test.go
@@ -6,11 +6,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/auth"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -268,11 +268,11 @@ func denyIntegrationTest(blockNumber int64, contractAddressHex, msgSenderAddress
 		err := db.Select(&dbResult, `SELECT address_id, msg_sender, usr FROM maker.deny`)
 		Expect(err).NotTo(HaveOccurred())
 
-		contractAddressID, contractAddressErr := shared.GetOrCreateAddress(contractAddressHex, db)
+		contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, contractAddressHex)
 		Expect(contractAddressErr).NotTo(HaveOccurred())
-		msgSenderAddressID, msgSenderAddressErr := shared.GetOrCreateAddress(msgSenderAddressHex, db)
+		msgSenderAddressID, msgSenderAddressErr := repository.GetOrCreateAddress(db, msgSenderAddressHex)
 		Expect(msgSenderAddressErr).NotTo(HaveOccurred())
-		usrAddressID, usrAddressErr := shared.GetOrCreateAddress(usrAddressHex, db)
+		usrAddressID, usrAddressErr := repository.GetOrCreateAddress(db, usrAddressHex)
 		Expect(usrAddressErr).NotTo(HaveOccurred())
 
 		var matchFound bool

--- a/transformers/integration_tests/flap_kick_test.go
+++ b/transformers/integration_tests/flap_kick_test.go
@@ -20,11 +20,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/flap_kick"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -70,7 +70,7 @@ var _ = Describe("FlapKick Transformer", func() {
 		err = db.Get(&dbResult, `SELECT address_id, bid, bid_id, lot FROM maker.flap_kick`)
 		Expect(err).NotTo(HaveOccurred())
 
-		flapAddressID, addressErr := shared.GetOrCreateAddress(test_data.FlapV100Address(), db)
+		flapAddressID, addressErr := repository.GetOrCreateAddress(db, test_data.FlapV100Address())
 		Expect(addressErr).NotTo(HaveOccurred())
 		expectedModel := FlapKickModel{
 			AddressID: flapAddressID,

--- a/transformers/integration_tests/flip_kick_test.go
+++ b/transformers/integration_tests/flip_kick_test.go
@@ -20,11 +20,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/flip_kick"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -234,7 +234,7 @@ func flipKickIntegrationTest(blockNumber int64, contractAddressHex, contractABI 
 		err = db.Get(&dbResult, `SELECT bid_id, lot, bid, tab, usr, gal, address_id FROM maker.flip_kick`)
 		Expect(err).NotTo(HaveOccurred())
 
-		flipContractAddressId, addrErr := shared.GetOrCreateAddress(contractAddressHex, db)
+		flipContractAddressId, addrErr := repository.GetOrCreateAddress(db, contractAddressHex)
 		Expect(addrErr).NotTo(HaveOccurred())
 		expectedResult.AddressId = flipContractAddressId
 

--- a/transformers/integration_tests/flop_kick_test.go
+++ b/transformers/integration_tests/flop_kick_test.go
@@ -22,11 +22,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/flop_kick"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -81,7 +81,7 @@ var _ = Describe("FlopKick Transformer", func() {
 		err := db.Get(&dbResult, `SELECT bid, bid_id, address_id, gal, lot FROM maker.flop_kick`)
 		Expect(err).NotTo(HaveOccurred())
 
-		flopAddressID, flopAddressErr := shared.GetOrCreateAddress(test_data.FlopV101Address(), db)
+		flopAddressID, flopAddressErr := repository.GetOrCreateAddress(db, test_data.FlopV101Address())
 		Expect(flopAddressErr).NotTo(HaveOccurred())
 
 		expectedModel := FlopKickModel{

--- a/transformers/integration_tests/jug_drip_test.go
+++ b/transformers/integration_tests/jug_drip_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -72,7 +73,7 @@ var _ = Describe("JugDrip Transformer", func() {
 		err = db.Get(&result, `SELECT msg_sender, ilk_id from maker.jug_drip`)
 		Expect(err).NotTo(HaveOccurred())
 
-		msgSenderID, msgSenderErr := shared.GetOrCreateAddress("0xBE8E3e3618f7474F8cB1d074A26afFef007E98FB", db)
+		msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, "0xBE8E3e3618f7474F8cB1d074A26afFef007E98FB")
 		Expect(msgSenderErr).NotTo(HaveOccurred())
 		ilkID, ilkErr := shared.GetOrCreateIlk("0x4554482d41000000000000000000000000000000000000000000000000000000", db)
 		Expect(ilkErr).NotTo(HaveOccurred())

--- a/transformers/integration_tests/jug_file_base_test.go
+++ b/transformers/integration_tests/jug_file_base_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -72,7 +73,7 @@ var _ = Describe("Jug File Base EventTransformer", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		msgSender := shared.GetChecksumAddressString("0x000000000000000000000000be8e3e3618f7474f8cb1d074a26affef007e98fb")
-		msgSenderId, msgSenderErr := shared.GetOrCreateAddress(msgSender, db)
+		msgSenderId, msgSenderErr := repository.GetOrCreateAddress(db, msgSender)
 		Expect(msgSenderErr).NotTo(HaveOccurred())
 
 		Expect(dbResult.What).To(Equal("base"))

--- a/transformers/integration_tests/jug_file_ilk_test.go
+++ b/transformers/integration_tests/jug_file_ilk_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -74,7 +75,7 @@ var _ = Describe("Jug File Ilk EventTransformer", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		msgSender := shared.GetChecksumAddressString("0x000000000000000000000000be8e3e3618f7474f8cb1d074a26affef007e98fb")
-		msgSenderId, msgSenderErr := shared.GetOrCreateAddress(msgSender, db)
+		msgSenderId, msgSenderErr := repository.GetOrCreateAddress(db, msgSender)
 		Expect(msgSenderErr).NotTo(HaveOccurred())
 
 		ilkID, err := shared.GetOrCreateIlk("0x4554482d41000000000000000000000000000000000000000000000000000000", db)

--- a/transformers/integration_tests/jug_file_vow_test.go
+++ b/transformers/integration_tests/jug_file_vow_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -72,7 +73,7 @@ var _ = Describe("Jug File Vow EventTransformer", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		msgSender := shared.GetChecksumAddressString("0x000000000000000000000000baa65281c2fa2baacb2cb550ba051525a480d3f4")
-		msgSenderId, msgSenderErr := shared.GetOrCreateAddress(msgSender, db)
+		msgSenderId, msgSenderErr := repository.GetOrCreateAddress(db, msgSender)
 		Expect(msgSenderErr).NotTo(HaveOccurred())
 
 		Expect(dbResult.MsgSender).To(Equal(msgSenderId))

--- a/transformers/integration_tests/jug_init_test.go
+++ b/transformers/integration_tests/jug_init_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -71,7 +72,7 @@ var _ = Describe("JugInit EventTransformer", func() {
 		expectedIlkID, ilkErr := shared.GetOrCreateIlk("0x4554482d41000000000000000000000000000000000000000000000000000000", db)
 		Expect(ilkErr).NotTo(HaveOccurred())
 
-		expectedMsgSenderID, msgSenderErr := shared.GetOrCreateAddress(eventLogs[0].Log.Topics[1].Hex(), db)
+		expectedMsgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, eventLogs[0].Log.Topics[1].Hex())
 		Expect(msgSenderErr).NotTo(HaveOccurred())
 
 		Expect(dbResult.MsgSenderID).To(Equal(expectedMsgSenderID))

--- a/transformers/integration_tests/log_median_price_test.go
+++ b/transformers/integration_tests/log_median_price_test.go
@@ -4,11 +4,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/log_median_price"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -108,7 +108,7 @@ func logMedianPriceIntegrationTest(blockNumber int64, contractAddressHex, val, a
 		var dbResults []logMedianPriceModel
 		queryErr := db.Select(&dbResults, `SELECT address_id, val, age from maker.log_median_price`)
 		Expect(queryErr).NotTo(HaveOccurred())
-		contractAddressID, contractAddressErr := shared.GetOrCreateAddress(contractAddressHex, db)
+		contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, contractAddressHex)
 		Expect(contractAddressErr).NotTo(HaveOccurred())
 
 		Expect(len(dbResults)).To(Equal(1))

--- a/transformers/integration_tests/median_diss_batch_test.go
+++ b/transformers/integration_tests/median_diss_batch_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/lib/pq"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/median_diss/batch"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -58,11 +58,11 @@ var _ = Describe("MedianDissBatch EventTransformer", func() {
 		Expect(len(dbResults)).To(Equal(1))
 		dbResult := dbResults[0]
 
-		contractAddressID, contractAddressErr := shared.GetOrCreateAddress(test_data.MedianEthAddress(), db)
+		contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, test_data.MedianEthAddress())
 		Expect(contractAddressErr).NotTo(HaveOccurred())
 		Expect(dbResult.AddressID).To(Equal(strconv.FormatInt(contractAddressID, 10)))
 
-		msgSenderAddressID, msgSenderAddressErr := shared.GetOrCreateAddress("0xe87F55Af91068a1DA44095138F3d37C45894Eb21", db)
+		msgSenderAddressID, msgSenderAddressErr := repository.GetOrCreateAddress(db, "0xe87F55Af91068a1DA44095138F3d37C45894Eb21")
 		Expect(msgSenderAddressErr).NotTo(HaveOccurred())
 		Expect(dbResult.MsgSender).To(Equal(strconv.FormatInt(msgSenderAddressID, 10)))
 

--- a/transformers/integration_tests/median_diss_single_test.go
+++ b/transformers/integration_tests/median_diss_single_test.go
@@ -6,11 +6,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/median_diss/single"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -58,15 +58,15 @@ var _ = XDescribe("MedianDissSingle EventTransformer", func() {
 		Expect(len(dbResults)).To(Equal(2))
 		dbResult := dbResults[1]
 
-		contractAddressID, contractAddressErr := shared.GetOrCreateAddress("0x18B4633D6E39870f398597f3c1bA8c4A41294966", db)
+		contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, "0x18B4633D6E39870f398597f3c1bA8c4A41294966")
 		Expect(contractAddressErr).NotTo(HaveOccurred())
 		Expect(dbResult.AddressID).To(Equal(strconv.FormatInt(contractAddressID, 10)))
 
-		msgSenderAddressID, msgSenderAddressErr := shared.GetOrCreateAddress("0x000000000000000000000000ddb108893104de4e1c6d0e47c42237db4e617acc", db)
+		msgSenderAddressID, msgSenderAddressErr := repository.GetOrCreateAddress(db, "0x000000000000000000000000ddb108893104de4e1c6d0e47c42237db4e617acc")
 		Expect(msgSenderAddressErr).NotTo(HaveOccurred())
 		Expect(dbResult.MsgSender).To(Equal(strconv.FormatInt(msgSenderAddressID, 10)))
 
-		aAddressID, aAddressErr := shared.GetOrCreateAddress("0x000000000000000000000000b4eb54af9cc7882df0121d26c5b97e802915abe6", db)
+		aAddressID, aAddressErr := repository.GetOrCreateAddress(db, "0x000000000000000000000000b4eb54af9cc7882df0121d26c5b97e802915abe6")
 		Expect(aAddressErr).NotTo(HaveOccurred())
 		Expect(dbResult.A).To(Equal(strconv.FormatInt(aAddressID, 10)))
 	})

--- a/transformers/integration_tests/median_drop_test.go
+++ b/transformers/integration_tests/median_drop_test.go
@@ -6,11 +6,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/median_drop"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -58,15 +58,15 @@ var _ = XDescribe("MedianDrop EventTransformer", func() {
 		Expect(len(dbResults)).To(Equal(2))
 		dbResult := dbResults[1]
 
-		contractAddressID, contractAddressErr := shared.GetOrCreateAddress("0x18B4633D6E39870f398597f3c1bA8c4A41294966", db)
+		contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, "0x18B4633D6E39870f398597f3c1bA8c4A41294966")
 		Expect(contractAddressErr).NotTo(HaveOccurred())
 		Expect(dbResult.AddressID).To(Equal(strconv.FormatInt(contractAddressID, 10)))
 
-		msgSenderAddressID, msgSenderAddressErr := shared.GetOrCreateAddress("0x000000000000000000000000ddb108893104de4e1c6d0e47c42237db4e617acc", db)
+		msgSenderAddressID, msgSenderAddressErr := repository.GetOrCreateAddress(db, "0x000000000000000000000000ddb108893104de4e1c6d0e47c42237db4e617acc")
 		Expect(msgSenderAddressErr).NotTo(HaveOccurred())
 		Expect(dbResult.MsgSender).To(Equal(strconv.FormatInt(msgSenderAddressID, 10)))
 
-		aAddressID, aAddressErr := shared.GetOrCreateAddress("0x000000000000000000000000b4eb54af9cc7882df0121d26c5b97e802915abe6", db)
+		aAddressID, aAddressErr := repository.GetOrCreateAddress(db, "0x000000000000000000000000b4eb54af9cc7882df0121d26c5b97e802915abe6")
 		Expect(aAddressErr).NotTo(HaveOccurred())
 		Expect(dbResult.A).To(Equal(strconv.FormatInt(aAddressID, 10)))
 	})

--- a/transformers/integration_tests/median_kiss_batch_test.go
+++ b/transformers/integration_tests/median_kiss_batch_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/lib/pq"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/median_kiss/batch"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -58,11 +58,11 @@ var _ = Describe("MedianKissBatch EventTransformer", func() {
 		Expect(len(dbResults)).To(Equal(1))
 		dbResult := dbResults[0]
 
-		contractAddressID, contractAddressErr := shared.GetOrCreateAddress(test_data.MedianEthAddress(), db)
+		contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, test_data.MedianEthAddress())
 		Expect(contractAddressErr).NotTo(HaveOccurred())
 		Expect(dbResult.AddressID).To(Equal(strconv.FormatInt(contractAddressID, 10)))
 
-		msgSenderAddressID, msgSenderAddressErr := shared.GetOrCreateAddress("0xe87F55Af91068a1DA44095138F3d37C45894Eb21", db)
+		msgSenderAddressID, msgSenderAddressErr := repository.GetOrCreateAddress(db, "0xe87F55Af91068a1DA44095138F3d37C45894Eb21")
 		Expect(msgSenderAddressErr).NotTo(HaveOccurred())
 		Expect(dbResult.MsgSender).To(Equal(strconv.FormatInt(msgSenderAddressID, 10)))
 

--- a/transformers/integration_tests/median_kiss_single_test.go
+++ b/transformers/integration_tests/median_kiss_single_test.go
@@ -6,11 +6,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/median_kiss/single"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -57,15 +57,15 @@ var _ = Describe("MedianKissSingle EventTransformer", func() {
 		Expect(len(dbResults)).To(Equal(2))
 		dbResult := dbResults[1]
 
-		contractAddressID, contractAddressErr := shared.GetOrCreateAddress("0x18B4633D6E39870f398597f3c1bA8c4A41294966", db)
+		contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, "0x18B4633D6E39870f398597f3c1bA8c4A41294966")
 		Expect(contractAddressErr).NotTo(HaveOccurred())
 		Expect(dbResult.AddressID).To(Equal(strconv.FormatInt(contractAddressID, 10)))
 
-		msgSenderAddressID, msgSenderAddressErr := shared.GetOrCreateAddress("0x000000000000000000000000ddb108893104de4e1c6d0e47c42237db4e617acc", db)
+		msgSenderAddressID, msgSenderAddressErr := repository.GetOrCreateAddress(db, "0x000000000000000000000000ddb108893104de4e1c6d0e47c42237db4e617acc")
 		Expect(msgSenderAddressErr).NotTo(HaveOccurred())
 		Expect(dbResult.MsgSender).To(Equal(strconv.FormatInt(msgSenderAddressID, 10)))
 
-		aAddressID, aAddressErr := shared.GetOrCreateAddress("0x000000000000000000000000b4eb54af9cc7882df0121d26c5b97e802915abe6", db)
+		aAddressID, aAddressErr := repository.GetOrCreateAddress(db, "0x000000000000000000000000b4eb54af9cc7882df0121d26c5b97e802915abe6")
 		Expect(aAddressErr).NotTo(HaveOccurred())
 		Expect(dbResult.A).To(Equal(strconv.FormatInt(aAddressID, 10)))
 	})

--- a/transformers/integration_tests/median_lift_test.go
+++ b/transformers/integration_tests/median_lift_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/lib/pq"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/median_lift"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -59,11 +59,11 @@ var _ = Describe("MedianLift EventTransformer", func() {
 		Expect(len(dbResults)).To(Equal(1))
 		dbResult := dbResults[0]
 
-		contractAddressID, contractAddressErr := shared.GetOrCreateAddress(test_data.MedianEthAddress(), db)
+		contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, test_data.MedianEthAddress())
 		Expect(contractAddressErr).NotTo(HaveOccurred())
 		Expect(dbResult.AddressID).To(Equal(strconv.FormatInt(contractAddressID, 10)))
 
-		msgSenderAddressID, msgSenderAddressErr := shared.GetOrCreateAddress("0xdDb108893104dE4E1C6d0E47c42237dB4E617ACc", db)
+		msgSenderAddressID, msgSenderAddressErr := repository.GetOrCreateAddress(db, "0xdDb108893104dE4E1C6d0E47c42237dB4E617ACc")
 		Expect(msgSenderAddressErr).NotTo(HaveOccurred())
 		Expect(dbResult.MsgSender).To(Equal(strconv.FormatInt(msgSenderAddressID, 10)))
 
@@ -115,11 +115,11 @@ var _ = Describe("MedianLift EventTransformer", func() {
 		Expect(len(dbResults)).To(Equal(1))
 		dbResult := dbResults[0]
 
-		contractAddressID, contractAddressErr := shared.GetOrCreateAddress(test_data.MedianWbtcAddress(), db)
+		contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, test_data.MedianWbtcAddress())
 		Expect(contractAddressErr).NotTo(HaveOccurred())
 		Expect(dbResult.AddressID).To(Equal(strconv.FormatInt(contractAddressID, 10)))
 
-		msgSenderAddressID, msgSenderAddressErr := shared.GetOrCreateAddress("0xdDb108893104dE4E1C6d0E47c42237dB4E617ACc", db)
+		msgSenderAddressID, msgSenderAddressErr := repository.GetOrCreateAddress(db, "0xdDb108893104dE4E1C6d0E47c42237dB4E617ACc")
 		Expect(msgSenderAddressErr).NotTo(HaveOccurred())
 		Expect(dbResult.MsgSender).To(Equal(strconv.FormatInt(msgSenderAddressID, 10)))
 

--- a/transformers/integration_tests/osm_change_test.go
+++ b/transformers/integration_tests/osm_change_test.go
@@ -6,11 +6,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/osm_change"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -58,15 +58,15 @@ var _ = XDescribe("OsmChange EventTransformer", func() {
 		Expect(len(dbResults)).To(Equal(1))
 		dbResult := dbResults[0]
 
-		contractAddressID, contractAddressErr := shared.GetOrCreateAddress("0x000000000000000000000000a950524441892a31ebddf91d3ceefa04bf454466", db)
+		contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, "0x000000000000000000000000a950524441892a31ebddf91d3ceefa04bf454466")
 		Expect(contractAddressErr).NotTo(HaveOccurred())
 		Expect(dbResult.AddressID).To(Equal(strconv.FormatInt(contractAddressID, 10)))
 
-		msgSenderAddressID, msgSenderAddressErr := shared.GetOrCreateAddress("0x000000000000000000000000a950524441892a31ebddf91d3ceefa04bf454466", db)
+		msgSenderAddressID, msgSenderAddressErr := repository.GetOrCreateAddress(db, "0x000000000000000000000000a950524441892a31ebddf91d3ceefa04bf454466")
 		Expect(msgSenderAddressErr).NotTo(HaveOccurred())
 		Expect(dbResult.MsgSender).To(Equal(strconv.FormatInt(msgSenderAddressID, 10)))
 
-		srcAddressID, srcAddressErr := shared.GetOrCreateAddress("0x000000000000000000000000a950524441892a31ebddf91d3ceefa04bf454466", db)
+		srcAddressID, srcAddressErr := repository.GetOrCreateAddress(db, "0x000000000000000000000000a950524441892a31ebddf91d3ceefa04bf454466")
 		Expect(srcAddressErr).NotTo(HaveOccurred())
 		Expect(dbResult.Src).To(Equal(strconv.FormatInt(srcAddressID, 10)))
 	})

--- a/transformers/integration_tests/pot_cage_test.go
+++ b/transformers/integration_tests/pot_cage_test.go
@@ -5,11 +5,11 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/pot_cage"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -73,7 +73,7 @@ var _ = XDescribe("PotCage EventTransformer", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			msgSender := common.HexToAddress("0xe06ac4777f04ac7638f736a0b95f7bfeadcee556").Hex()
-			msgSenderID, msgSenderErr := shared.GetOrCreateAddress(msgSender, db)
+			msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, msgSender)
 			Expect(msgSenderErr).NotTo(HaveOccurred())
 
 			Expect(dbResult.ID).To(Equal(1))

--- a/transformers/integration_tests/pot_drip_test.go
+++ b/transformers/integration_tests/pot_drip_test.go
@@ -4,11 +4,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/pot_drip"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -56,7 +56,7 @@ var _ = Describe("PotDrip Transformer", func() {
 		err = db.Get(&msgSender, `SELECT msg_sender from maker.pot_drip`)
 		Expect(err).NotTo(HaveOccurred())
 
-		expectedAddrID, addrErr := shared.GetOrCreateAddress("0x825100c63933cABA16C8CE40814DAc88305D8810", db)
+		expectedAddrID, addrErr := repository.GetOrCreateAddress(db, "0x825100c63933cABA16C8CE40814DAc88305D8810")
 		Expect(addrErr).NotTo(HaveOccurred())
 		Expect(msgSender).To(Equal(expectedAddrID))
 	})

--- a/transformers/integration_tests/pot_exit_test.go
+++ b/transformers/integration_tests/pot_exit_test.go
@@ -6,11 +6,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/pot_exit"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -53,7 +53,7 @@ var _ = Describe("PotExit Transformer", func() {
 		queryErr := db.Get(&dbResult, `SELECT msg_sender, wad from maker.pot_exit`)
 		Expect(queryErr).NotTo(HaveOccurred())
 
-		addressID, addressErr := shared.GetOrCreateAddress("0x2D8990618391aD152c336649D27F164b2618bf60", db)
+		addressID, addressErr := repository.GetOrCreateAddress(db, "0x2D8990618391aD152c336649D27F164b2618bf60")
 		Expect(addressErr).NotTo(HaveOccurred())
 		Expect(dbResult.MsgSender).To(Equal(strconv.FormatInt(addressID, 10)))
 		Expect(dbResult.Wad).To(Equal("200473120597989120478"))

--- a/transformers/integration_tests/pot_file_test.go
+++ b/transformers/integration_tests/pot_file_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -71,7 +72,7 @@ var _ = Describe("PotFile EventTransformers", func() {
 			Expect(getFileErr).NotTo(HaveOccurred())
 
 			msgSender := shared.GetChecksumAddressString("0x000000000000000000000000be8e3e3618f7474f8cb1d074a26affef007e98fb")
-			msgSenderID, msgSenderErr := shared.GetOrCreateAddress(msgSender, db)
+			msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, msgSender)
 			Expect(msgSenderErr).NotTo(HaveOccurred())
 
 			Expect(dbResult.MsgSender).To(Equal(msgSenderID))
@@ -130,7 +131,7 @@ var _ = Describe("PotFile EventTransformers", func() {
 			Expect(getFileErr).NotTo(HaveOccurred())
 
 			msgSender := shared.GetChecksumAddressString("0x000000000000000000000000baa65281c2fa2baacb2cb550ba051525a480d3f4")
-			msgSenderID, msgSenderErr := shared.GetOrCreateAddress(msgSender, db)
+			msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, msgSender)
 			Expect(msgSenderErr).NotTo(HaveOccurred())
 
 			Expect(dbResult.MsgSender).To(Equal(msgSenderID))

--- a/transformers/integration_tests/pot_join_test.go
+++ b/transformers/integration_tests/pot_join_test.go
@@ -22,11 +22,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/pot_join"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -69,7 +69,7 @@ var _ = Describe("PotJoin Transformer", func() {
 		queryErr := db.Get(&dbResult, `SELECT msg_sender, wad from maker.pot_join`)
 		Expect(queryErr).NotTo(HaveOccurred())
 
-		addressID, addressErr := shared.GetOrCreateAddress("0x06AF07097C9Eeb7fD685c692751D5C66dB49c215", db)
+		addressID, addressErr := repository.GetOrCreateAddress(db, "0x06AF07097C9Eeb7fD685c692751D5C66dB49c215")
 		Expect(addressErr).NotTo(HaveOccurred())
 		Expect(dbResult.MsgSender).To(Equal(strconv.FormatInt(addressID, 10)))
 		Expect(dbResult.Wad).To(Equal("1065452848025509462649"))

--- a/transformers/integration_tests/rely_test.go
+++ b/transformers/integration_tests/rely_test.go
@@ -6,11 +6,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/auth"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -358,11 +358,11 @@ func relyIntegrationTest(blockNumber int64, contractAddressHex, msgSenderAddress
 		err := db.Select(&dbResult, `SELECT address_id, msg_sender, usr FROM maker.rely ORDER BY log_id`)
 		Expect(err).NotTo(HaveOccurred())
 
-		contractAddressID, contractAddressErr := shared.GetOrCreateAddress(contractAddressHex, db)
+		contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, contractAddressHex)
 		Expect(contractAddressErr).NotTo(HaveOccurred())
-		msgSenderAddressID, msgSenderAddressErr := shared.GetOrCreateAddress(msgSenderAddressHex, db)
+		msgSenderAddressID, msgSenderAddressErr := repository.GetOrCreateAddress(db, msgSenderAddressHex)
 		Expect(msgSenderAddressErr).NotTo(HaveOccurred())
-		usrAddressID, usrAddressErr := shared.GetOrCreateAddress(usrAddressHex, db)
+		usrAddressID, usrAddressErr := repository.GetOrCreateAddress(db, usrAddressHex)
 		Expect(usrAddressErr).NotTo(HaveOccurred())
 
 		var matchFound bool

--- a/transformers/integration_tests/spot_file_test.go
+++ b/transformers/integration_tests/spot_file_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -93,7 +94,7 @@ var _ = Describe("SpotFile EventTransformers", func() {
 			ilkID, ilkErr := shared.GetOrCreateIlk("0x4554482d41000000000000000000000000000000000000000000000000000000", db)
 			Expect(ilkErr).NotTo(HaveOccurred())
 
-			msgSenderID, msgSenderErr := shared.GetOrCreateAddress("0xbe8e3e3618f7474f8cb1d074a26affef007e98fb", db)
+			msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, "0xbe8e3e3618f7474f8cb1d074a26affef007e98fb")
 			Expect(msgSenderErr).NotTo(HaveOccurred())
 
 			Expect(dbResult.Ilk).To(Equal(strconv.FormatInt(ilkID, 10)))
@@ -161,7 +162,7 @@ var _ = Describe("SpotFile EventTransformers", func() {
 			ilkID, ilkErr := shared.GetOrCreateIlk("0x4554482d41000000000000000000000000000000000000000000000000000000", db)
 			Expect(ilkErr).NotTo(HaveOccurred())
 
-			msgSenderID, msgSenderErr := shared.GetOrCreateAddress("0xbaa65281c2fa2baacb2cb550ba051525a480d3f4", db)
+			msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, "0xbaa65281c2fa2baacb2cb550ba051525a480d3f4")
 			Expect(msgSenderErr).NotTo(HaveOccurred())
 			Expect(dbResult.Ilk).To(Equal(strconv.FormatInt(ilkID, 10)))
 			Expect(dbResult.Pip).To(Equal("0x81FE72B5A8d1A857d176C3E7d5Bd2679A9B85763"))

--- a/transformers/integration_tests/tend_test.go
+++ b/transformers/integration_tests/tend_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -79,11 +80,11 @@ var _ = Describe("Tend EventTransformer", func() {
 		err = db.Get(&flipTend, `SELECT address_id, msg_sender, bid, bid_id, lot FROM maker.tend`)
 		Expect(err).NotTo(HaveOccurred())
 
-		flipAddressID, addrErr := shared.GetOrCreateAddress(test_data.FlipEthV100Address(), db)
+		flipAddressID, addrErr := repository.GetOrCreateAddress(db, test_data.FlipEthV100Address())
 		Expect(addrErr).NotTo(HaveOccurred())
 
 		msgSender := shared.GetChecksumAddressString("0x00000000000000000000000000abe7471ec9b6953a3bd0ed3c06c46f29aa4280")
-		msgSenderID, msgSenderErr := shared.GetOrCreateAddress(msgSender, db)
+		msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, msgSender)
 		Expect(msgSenderErr).NotTo(HaveOccurred())
 
 		expectedFlipTend := tendModel{
@@ -117,11 +118,11 @@ var _ = Describe("Tend EventTransformer", func() {
 		err = db.Get(&flapTend, `SELECT address_id, msg_sender, bid, bid_id, lot FROM maker.tend`)
 		Expect(err).NotTo(HaveOccurred())
 
-		flapAddressID, addrErr := shared.GetOrCreateAddress(test_data.FlapV100Address(), db)
+		flapAddressID, addrErr := repository.GetOrCreateAddress(db, test_data.FlapV100Address())
 		Expect(addrErr).NotTo(HaveOccurred())
 
 		msgSender := shared.GetChecksumAddressString("0x000000000000000000000000d9d1e81bb35db066986fa441113a27708663d70b")
-		msgSenderID, msgSenderErr := shared.GetOrCreateAddress(msgSender, db)
+		msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, msgSender)
 		Expect(msgSenderErr).NotTo(HaveOccurred())
 
 		expectedFlapTend := tendModel{

--- a/transformers/integration_tests/tick_test.go
+++ b/transformers/integration_tests/tick_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -80,11 +81,11 @@ var _ = Describe("Tick EventTransformer", func() {
 		err := db.Get(&dbResult, `SELECT bid_id, address_id, msg_sender FROM maker.tick`)
 		Expect(err).NotTo(HaveOccurred())
 
-		flipAddressID, flipAddressErr := shared.GetOrCreateAddress(test_data.FlipEthV100Address(), db)
+		flipAddressID, flipAddressErr := repository.GetOrCreateAddress(db, test_data.FlipEthV100Address())
 		Expect(flipAddressErr).NotTo(HaveOccurred())
 
 		msgSender := shared.GetChecksumAddressString("0x000000000000000000000000b00b6d69822da235a99d2242376066507c9a97b7")
-		msgSenderID, msgSenderErr := shared.GetOrCreateAddress(msgSender, db)
+		msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, msgSender)
 		Expect(msgSenderErr).NotTo(HaveOccurred())
 
 		Expect(dbResult.AddressID).To(Equal(flipAddressID))
@@ -113,7 +114,7 @@ var _ = Describe("Tick EventTransformer", func() {
 		err := db.Select(&dbResult, `SELECT bid_id, address_id FROM maker.tick`)
 		Expect(err).NotTo(HaveOccurred())
 
-		flapAddressID, flapAddressErr := shared.GetOrCreateAddress(test_data.FlapV100Address(), db)
+		flapAddressID, flapAddressErr := repository.GetOrCreateAddress(db, test_data.FlapV100Address())
 		Expect(flapAddressErr).NotTo(HaveOccurred())
 
 		Expect(len(dbResult)).To(Equal(1))
@@ -142,7 +143,7 @@ var _ = Describe("Tick EventTransformer", func() {
 		err := db.Select(&dbResult, `SELECT bid_id, address_id FROM maker.tick`)
 		Expect(err).NotTo(HaveOccurred())
 
-		flopAddressID, flopAddressErr := shared.GetOrCreateAddress(test_data.FlopV101Address(), db)
+		flopAddressID, flopAddressErr := repository.GetOrCreateAddress(db, test_data.FlopV101Address())
 		Expect(flopAddressErr).NotTo(HaveOccurred())
 
 		Expect(len(dbResult)).To(Equal(1))

--- a/transformers/integration_tests/vat_deny_test.go
+++ b/transformers/integration_tests/vat_deny_test.go
@@ -4,11 +4,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/vat_auth"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -54,7 +54,7 @@ var _ = Describe("Vat Deny transformer", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		usrAddress := "0x403689148fa98a5a6fdcc0b984914ae968d788e5"
-		usrAddressID, usrAddressErr := shared.GetOrCreateAddress(usrAddress, db)
+		usrAddressID, usrAddressErr := repository.GetOrCreateAddress(db, usrAddress)
 		Expect(usrAddressErr).NotTo(HaveOccurred())
 
 		Expect(usr).To(Equal(usrAddressID))

--- a/transformers/integration_tests/vat_hope_test.go
+++ b/transformers/integration_tests/vat_hope_test.go
@@ -4,11 +4,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/vat_auth"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -54,7 +54,7 @@ var _ = Describe("Vat Hope transformer", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		usrAddress := "0x9759A6Ac90977b93B58547b4A71c78317f391A28"
-		usrAddressID, usrAddressErr := shared.GetOrCreateAddress(usrAddress, db)
+		usrAddressID, usrAddressErr := repository.GetOrCreateAddress(db, usrAddress)
 		Expect(usrAddressErr).NotTo(HaveOccurred())
 
 		Expect(usr).To(Equal(usrAddressID))

--- a/transformers/integration_tests/vat_nope_test.go
+++ b/transformers/integration_tests/vat_nope_test.go
@@ -4,11 +4,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/vat_auth"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -54,7 +54,7 @@ var _ = Describe("Vat Nope transformer", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		usrAddress := "0x0000000000000000000000000000000000000000"
-		usrAddressID, usrAddressErr := shared.GetOrCreateAddress(usrAddress, db)
+		usrAddressID, usrAddressErr := repository.GetOrCreateAddress(db, usrAddress)
 		Expect(usrAddressErr).NotTo(HaveOccurred())
 
 		Expect(len(users)).To(Equal(1))

--- a/transformers/integration_tests/vat_rely_test.go
+++ b/transformers/integration_tests/vat_rely_test.go
@@ -4,11 +4,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/vat_auth"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -55,9 +55,9 @@ var _ = Describe("Vat Rely transformer", func() {
 
 		usrAddress := "0xbaa65281c2fa2baacb2cb550ba051525a480d3f4"
 		usrAddress2 := "0x65c79fcb50ca1594b025960e539ed7a9a6d434a3"
-		usrAddressID, usrAddressErr := shared.GetOrCreateAddress(usrAddress, db)
+		usrAddressID, usrAddressErr := repository.GetOrCreateAddress(db, usrAddress)
 		Expect(usrAddressErr).NotTo(HaveOccurred())
-		usrAddressID2, usrAddressErr2 := shared.GetOrCreateAddress(usrAddress2, db)
+		usrAddressID2, usrAddressErr2 := repository.GetOrCreateAddress(db, usrAddress2)
 		Expect(usrAddressErr2).NotTo(HaveOccurred())
 
 		Expect(len(users)).To(Equal(2))

--- a/transformers/integration_tests/vow_fess_test.go
+++ b/transformers/integration_tests/vow_fess_test.go
@@ -20,11 +20,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/vow_fess"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -67,7 +67,7 @@ var _ = Describe("VowFess EventTransformer", func() {
 		err = tr.Execute(eventLogs)
 		Expect(err).NotTo(HaveOccurred())
 
-		msgSenderID, msgSenderErr := shared.GetOrCreateAddress("0x78F2c2AF65126834c51822F56Be0d7469D7A523E", db)
+		msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, "0x78F2c2AF65126834c51822F56Be0d7469D7A523E")
 		Expect(msgSenderErr).NotTo(HaveOccurred())
 
 		var dbResult vowFessModel

--- a/transformers/integration_tests/vow_flog_test.go
+++ b/transformers/integration_tests/vow_flog_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -67,7 +68,7 @@ var _ = Describe("VowFlog EventTransformer", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		msgSender := shared.GetChecksumAddressString("0x00000000000000000000000022e86ab483084053562ce713e94431c29d1adb8b")
-		msgSenderID, msgSenderErr := shared.GetOrCreateAddress(msgSender, db)
+		msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, msgSender)
 		Expect(msgSenderErr).NotTo(HaveOccurred())
 
 		var dbResult vowFlogModel

--- a/transformers/integration_tests/vow_heal_test.go
+++ b/transformers/integration_tests/vow_heal_test.go
@@ -4,11 +4,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/events/vow_heal"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/fetcher"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -51,7 +51,7 @@ var _ = Describe("VowHeal Transformer", func() {
 		err = db.Get(&dbResult, `SELECT msg_sender, rad from maker.vow_heal`)
 		Expect(err).NotTo(HaveOccurred())
 
-		msgSender, msgSenderErr := shared.GetOrCreateAddress("0x233a1b1A5381D7EAa3e9b373C392aB48A47bA596", db)
+		msgSender, msgSenderErr := repository.GetOrCreateAddress(db, "0x233a1b1A5381D7EAa3e9b373C392aB48A47bA596")
 		Expect(msgSenderErr).NotTo(HaveOccurred())
 		expectedModel := vowHealModel{
 			MsgSender: msgSender,

--- a/transformers/shared/fk_utils.go
+++ b/transformers/shared/fk_utils.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/jmoiron/sqlx"
-	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
 
@@ -74,13 +73,4 @@ func GetOrCreateUrnInTransaction(guy string, hexIlk string, tx *sqlx.Tx) (urnID 
 
 	err = tx.Get(&urnID, getOrCreateUrnQuery, guy, ilkID)
 	return urnID, err
-}
-
-func GetOrCreateAddress(address string, db *postgres.DB) (int64, error) {
-	return repository.GetOrCreateAddress(db, address)
-}
-
-func GetOrCreateAddressInTransaction(address string, tx *sqlx.Tx) (int64, error) {
-	addressId, addressErr := repository.GetOrCreateAddressInTransaction(tx, address)
-	return addressId, addressErr
 }

--- a/transformers/shared/fk_utils_test.go
+++ b/transformers/shared/fk_utils_test.go
@@ -19,7 +19,6 @@ package shared_test
 import (
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
-	"github.com/makerdao/vulcanizedb/pkg/fakes"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -60,87 +59,6 @@ var _ = Describe("Shared repository", func() {
 
 			Expect(ilkIDOne).NotTo(BeZero())
 			Expect(ilkIDOne).To(Equal(ilkIDTwo))
-		})
-	})
-
-	Describe("GetOrCreateAddress", func() {
-		It("creates an address record", func() {
-			_, err := shared.GetOrCreateAddress(fakes.FakeAddress.Hex(), db)
-			Expect(err).NotTo(HaveOccurred())
-
-			var address string
-			db.Get(&address, `SELECT address from addresses LIMIT 1`)
-			Expect(address).To(Equal(fakes.FakeAddress.Hex()))
-		})
-
-		It("returns the id for an address that already exists", func() {
-			//create the address record
-			createAddressId, createErr := shared.GetOrCreateAddress(fakes.FakeAddress.Hex(), db)
-			Expect(createErr).NotTo(HaveOccurred())
-
-			//get the address record
-			getAddressId, getErr := shared.GetOrCreateAddress(fakes.FakeAddress.Hex(), db)
-			Expect(getErr).NotTo(HaveOccurred())
-
-			Expect(createAddressId).To(Equal(getAddressId))
-
-			var addressCount int
-			db.Get(&addressCount, `SELECT count(*) from addresses`)
-			Expect(addressCount).To(Equal(1))
-		})
-	})
-
-	Describe("GetOrCreateAddressInTransaction", func() {
-		It("creates an address record", func() {
-			tx, txErr := db.Beginx()
-			Expect(txErr).NotTo(HaveOccurred())
-
-			_, createErr := shared.GetOrCreateAddressInTransaction(fakes.FakeAddress.Hex(), tx)
-			Expect(createErr).NotTo(HaveOccurred())
-
-			commitErr := tx.Commit()
-			Expect(commitErr).NotTo(HaveOccurred())
-
-			var address string
-			db.Get(&address, `SELECT address from addresses LIMIT 1`)
-			Expect(address).To(Equal(fakes.FakeAddress.Hex()))
-		})
-
-		It("returns the id for an address that already exists", func() {
-			tx, txErr := db.Beginx()
-			Expect(txErr).NotTo(HaveOccurred())
-
-			//create the address record
-			createAddressId, createErr := shared.GetOrCreateAddressInTransaction(fakes.FakeAddress.Hex(), tx)
-			Expect(createErr).NotTo(HaveOccurred())
-
-			//get the address record
-			getAddressId, getErr := shared.GetOrCreateAddressInTransaction(fakes.FakeAddress.Hex(), tx)
-			Expect(getErr).NotTo(HaveOccurred())
-
-			commitErr := tx.Commit()
-			Expect(commitErr).NotTo(HaveOccurred())
-
-			Expect(createAddressId).To(Equal(getAddressId))
-
-			var addressCount int
-			db.Get(&addressCount, `SELECT count(*) from addresses`)
-			Expect(addressCount).To(Equal(1))
-		})
-
-		It("doesn't persist the address if the transaction is rolled back", func() {
-			tx, txErr := db.Beginx()
-			Expect(txErr).NotTo(HaveOccurred())
-
-			_, createErr := shared.GetOrCreateAddressInTransaction(fakes.FakeAddress.Hex(), tx)
-			Expect(createErr).NotTo(HaveOccurred())
-
-			commitErr := tx.Rollback()
-			Expect(commitErr).NotTo(HaveOccurred())
-
-			var addressCount int
-			db.Get(&addressCount, `SELECT count(*) from addresses`)
-			Expect(addressCount).To(Equal(0))
 		})
 	})
 })

--- a/transformers/shared/utilities.go
+++ b/transformers/shared/utilities.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/makerdao/vulcanizedb/libraries/shared/constants"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
 
@@ -156,7 +157,7 @@ func InsertRecordWithAddress(diffID, headerID int64, query, value, contractAddre
 		return txErr
 	}
 
-	addressId, addressErr := GetOrCreateAddressInTransaction(contractAddress, tx)
+	addressId, addressErr := repository.GetOrCreateAddressInTransaction(tx, contractAddress)
 	if addressErr != nil {
 		rollbackErr := tx.Rollback()
 		if rollbackErr != nil {
@@ -181,7 +182,7 @@ func InsertRecordWithAddressAndBidID(diffID, headerID int64, query, bidId, value
 	if txErr != nil {
 		return txErr
 	}
-	addressId, addressErr := GetOrCreateAddressInTransaction(contractAddress, tx)
+	addressId, addressErr := repository.GetOrCreateAddressInTransaction(tx, contractAddress)
 	if addressErr != nil {
 		rollbackErr := tx.Rollback()
 		if rollbackErr != nil {

--- a/transformers/storage/cat/repository.go
+++ b/transformers/storage/cat/repository.go
@@ -6,6 +6,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/storage/utilities/wards"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/libraries/shared/storage/types"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -40,140 +41,140 @@ type StorageRepository struct {
 	contractAddressID int64
 }
 
-func (repository *StorageRepository) Create(diffID, headerID int64, metadata types.ValueMetadata, value interface{}) error {
+func (repo *StorageRepository) Create(diffID, headerID int64, metadata types.ValueMetadata, value interface{}) error {
 	switch metadata.Name {
 	case Live:
-		return repository.insertLive(diffID, headerID, value.(string))
+		return repo.insertLive(diffID, headerID, value.(string))
 	case Vat:
-		return repository.insertVat(diffID, headerID, value.(string))
+		return repo.insertVat(diffID, headerID, value.(string))
 	case Vow:
-		return repository.insertVow(diffID, headerID, value.(string))
+		return repo.insertVow(diffID, headerID, value.(string))
 	case Box:
-		return repository.insertBox(diffID, headerID, value.(string))
+		return repo.insertBox(diffID, headerID, value.(string))
 	case Litter:
-		return repository.insertLitter(diffID, headerID, value.(string))
+		return repo.insertLitter(diffID, headerID, value.(string))
 	case wards.Wards:
-		return wards.InsertWards(diffID, headerID, metadata, repository.ContractAddress, value.(string), repository.db)
+		return wards.InsertWards(diffID, headerID, metadata, repo.ContractAddress, value.(string), repo.db)
 	case IlkChop:
-		return repository.insertIlkChop(diffID, headerID, metadata, value.(string))
+		return repo.insertIlkChop(diffID, headerID, metadata, value.(string))
 	case IlkFlip:
-		return repository.insertIlkFlip(diffID, headerID, metadata, value.(string))
+		return repo.insertIlkFlip(diffID, headerID, metadata, value.(string))
 	case IlkLump:
-		return repository.insertIlkLump(diffID, headerID, metadata, value.(string))
+		return repo.insertIlkLump(diffID, headerID, metadata, value.(string))
 	case IlkDunk:
-		return repository.insertIlkDunk(diffID, headerID, metadata, value.(string))
+		return repo.insertIlkDunk(diffID, headerID, metadata, value.(string))
 	default:
 		panic(fmt.Sprintf("unrecognized cat contract storage name: %s", metadata.Name))
 	}
 }
 
-func (repository *StorageRepository) SetDB(db *postgres.DB) {
-	repository.db = db
+func (repo *StorageRepository) SetDB(db *postgres.DB) {
+	repo.db = db
 }
 
-func (repository *StorageRepository) insertLive(diffID, headerID int64, live string) error {
-	addressID, addressErr := repository.ContractAddressID()
+func (repo *StorageRepository) insertLive(diffID, headerID int64, live string) error {
+	addressID, addressErr := repo.ContractAddressID()
 	if addressErr != nil {
-		return fmt.Errorf("could not retrieve address id for %s, error: %w", repository.ContractAddress, addressErr)
+		return fmt.Errorf("could not retrieve address id for %s, error: %w", repo.ContractAddress, addressErr)
 	}
 
-	_, err := repository.db.Exec(insertCatLiveQuery, diffID, headerID, addressID, live)
+	_, err := repo.db.Exec(insertCatLiveQuery, diffID, headerID, addressID, live)
 	if err != nil {
 		return fmt.Errorf("error inserting cat live %s from diff ID %d: %w", live, diffID, err)
 	}
 	return nil
 }
 
-func (repository *StorageRepository) insertVat(diffID, headerID int64, vat string) error {
-	addressID, addressErr := repository.ContractAddressID()
+func (repo *StorageRepository) insertVat(diffID, headerID int64, vat string) error {
+	addressID, addressErr := repo.ContractAddressID()
 	if addressErr != nil {
-		return fmt.Errorf("could not retrieve address id for %s, error: %w", repository.ContractAddress, addressErr)
+		return fmt.Errorf("could not retrieve address id for %s, error: %w", repo.ContractAddress, addressErr)
 	}
 
-	_, err := repository.db.Exec(insertCatVatQuery, diffID, headerID, addressID, vat)
+	_, err := repo.db.Exec(insertCatVatQuery, diffID, headerID, addressID, vat)
 	if err != nil {
 		return fmt.Errorf("error inserting cat vat %s from diff ID %d: %w", vat, diffID, err)
 	}
 	return nil
 }
 
-func (repository *StorageRepository) insertVow(diffID, headerID int64, vow string) error {
-	addressID, addressErr := repository.ContractAddressID()
+func (repo *StorageRepository) insertVow(diffID, headerID int64, vow string) error {
+	addressID, addressErr := repo.ContractAddressID()
 	if addressErr != nil {
-		return fmt.Errorf("could not retrieve address id for %s, error: %w", repository.ContractAddress, addressErr)
+		return fmt.Errorf("could not retrieve address id for %s, error: %w", repo.ContractAddress, addressErr)
 	}
 
-	_, err := repository.db.Exec(insertCatVowQuery, diffID, headerID, addressID, vow)
+	_, err := repo.db.Exec(insertCatVowQuery, diffID, headerID, addressID, vow)
 	if err != nil {
 		return fmt.Errorf("error inserting cat vow %s from diff ID %d: %w", vow, diffID, err)
 	}
 	return nil
 }
 
-func (repository *StorageRepository) insertBox(diffID, headerID int64, box string) error {
-	addressID, addressErr := repository.ContractAddressID()
+func (repo *StorageRepository) insertBox(diffID, headerID int64, box string) error {
+	addressID, addressErr := repo.ContractAddressID()
 	if addressErr != nil {
-		return fmt.Errorf("could not retrieve address id for %s, error: %w", repository.ContractAddress, addressErr)
+		return fmt.Errorf("could not retrieve address id for %s, error: %w", repo.ContractAddress, addressErr)
 	}
 
-	_, err := repository.db.Exec(insertCatBoxQuery, diffID, headerID, addressID, box)
+	_, err := repo.db.Exec(insertCatBoxQuery, diffID, headerID, addressID, box)
 	if err != nil {
 		return fmt.Errorf("error inserting cat box %s from diff ID %d: %w", box, diffID, err)
 	}
 	return nil
 }
 
-func (repository *StorageRepository) insertLitter(diffID, headerID int64, litter string) error {
-	addressID, addressErr := repository.ContractAddressID()
+func (repo *StorageRepository) insertLitter(diffID, headerID int64, litter string) error {
+	addressID, addressErr := repo.ContractAddressID()
 	if addressErr != nil {
-		return fmt.Errorf("could not retrieve address id for %s, error: %w", repository.ContractAddress, addressErr)
+		return fmt.Errorf("could not retrieve address id for %s, error: %w", repo.ContractAddress, addressErr)
 	}
 
-	_, err := repository.db.Exec(insertCatLitterQuery, diffID, headerID, addressID, litter)
+	_, err := repo.db.Exec(insertCatLitterQuery, diffID, headerID, addressID, litter)
 	if err != nil {
 		return fmt.Errorf("error inserting cat litter %s from diff ID %d: %w", litter, diffID, err)
 	}
 	return nil
 }
 
-func (repository *StorageRepository) insertIlkFlip(diffID, headerID int64, metadata types.ValueMetadata, flip string) error {
-	addressID, addressErr := repository.ContractAddressID()
+func (repo *StorageRepository) insertIlkFlip(diffID, headerID int64, metadata types.ValueMetadata, flip string) error {
+	addressID, addressErr := repo.ContractAddressID()
 	if addressErr != nil {
-		return fmt.Errorf("could not retrieve address id for %s, error: %w", repository.ContractAddress, addressErr)
+		return fmt.Errorf("could not retrieve address id for %s, error: %w", repo.ContractAddress, addressErr)
 	}
 
 	ilk, err := getIlk(metadata.Keys)
 	if err != nil {
 		return fmt.Errorf("error getting ilk for ilk flip: %w", err)
 	}
-	insertErr := shared.InsertFieldWithIlkAndAddress(diffID, headerID, addressID, ilk, IlkFlip, InsertCatIlkFlipQuery, flip, repository.db)
+	insertErr := shared.InsertFieldWithIlkAndAddress(diffID, headerID, addressID, ilk, IlkFlip, InsertCatIlkFlipQuery, flip, repo.db)
 	if insertErr != nil {
 		return fmt.Errorf("error inserting ilk %s flip %s from diff ID %d: %w", insertErr, flip, diffID, insertErr)
 	}
 	return nil
 }
 
-func (repository *StorageRepository) insertIlkChop(diffID, headerID int64, metadata types.ValueMetadata, chop string) error {
-	addressID, addressErr := repository.ContractAddressID()
+func (repo *StorageRepository) insertIlkChop(diffID, headerID int64, metadata types.ValueMetadata, chop string) error {
+	addressID, addressErr := repo.ContractAddressID()
 	if addressErr != nil {
-		return fmt.Errorf("could not retrieve address id for %s, error: %w", repository.ContractAddress, addressErr)
+		return fmt.Errorf("could not retrieve address id for %s, error: %w", repo.ContractAddress, addressErr)
 	}
 
 	ilk, err := getIlk(metadata.Keys)
 	if err != nil {
 		return fmt.Errorf("error getting ilk for ilk chop: %w", err)
 	}
-	insertErr := shared.InsertFieldWithIlkAndAddress(diffID, headerID, addressID, ilk, IlkChop, InsertCatIlkChopQuery, chop, repository.db)
+	insertErr := shared.InsertFieldWithIlkAndAddress(diffID, headerID, addressID, ilk, IlkChop, InsertCatIlkChopQuery, chop, repo.db)
 	if insertErr != nil {
 		return fmt.Errorf("error inserting ilk %s chop %s from diff Id %d: %w", ilk, chop, diffID, insertErr)
 	}
 	return nil
 }
 
-func (repository *StorageRepository) insertIlkLump(diffID, headerID int64, metadata types.ValueMetadata, lump string) error {
-	addressID, addressErr := repository.ContractAddressID()
+func (repo *StorageRepository) insertIlkLump(diffID, headerID int64, metadata types.ValueMetadata, lump string) error {
+	addressID, addressErr := repo.ContractAddressID()
 	if addressErr != nil {
-		return fmt.Errorf("could not retrieve address id for %s, error: %w", repository.ContractAddress, addressErr)
+		return fmt.Errorf("could not retrieve address id for %s, error: %w", repo.ContractAddress, addressErr)
 	}
 
 	ilk, err := getIlk(metadata.Keys)
@@ -181,37 +182,37 @@ func (repository *StorageRepository) insertIlkLump(diffID, headerID int64, metad
 		return fmt.Errorf("error getting ilk for ilk lump: %w", err)
 	}
 
-	insertErr := shared.InsertFieldWithIlkAndAddress(diffID, headerID, addressID, ilk, IlkLump, InsertCatIlkLumpQuery, lump, repository.db)
+	insertErr := shared.InsertFieldWithIlkAndAddress(diffID, headerID, addressID, ilk, IlkLump, InsertCatIlkLumpQuery, lump, repo.db)
 	if insertErr != nil {
 		return fmt.Errorf("error inserting ilk %s lump %s from diff ID %d: %w", ilk, lump, diffID, insertErr)
 	}
 	return nil
 }
 
-func (repository *StorageRepository) insertIlkDunk(diffID, headerID int64, metadata types.ValueMetadata, dunk string) error {
-	addressID, addressErr := repository.ContractAddressID()
+func (repo *StorageRepository) insertIlkDunk(diffID, headerID int64, metadata types.ValueMetadata, dunk string) error {
+	addressID, addressErr := repo.ContractAddressID()
 	if addressErr != nil {
-		return fmt.Errorf("could not retrieve address id for %s, error: %w", repository.ContractAddress, addressErr)
+		return fmt.Errorf("could not retrieve address id for %s, error: %w", repo.ContractAddress, addressErr)
 	}
 
 	ilk, err := getIlk(metadata.Keys)
 	if err != nil {
 		return fmt.Errorf("error getting ilk for ilk dunk: %w", err)
 	}
-	insertErr := shared.InsertFieldWithIlkAndAddress(diffID, headerID, addressID, ilk, IlkDunk, insertCatIlkDunkQuery, dunk, repository.db)
+	insertErr := shared.InsertFieldWithIlkAndAddress(diffID, headerID, addressID, ilk, IlkDunk, insertCatIlkDunkQuery, dunk, repo.db)
 	if insertErr != nil {
 		return fmt.Errorf("error inserting ilk %s dunk %s from diff ID %d: %w", ilk, dunk, diffID, insertErr)
 	}
 	return nil
 }
 
-func (repository *StorageRepository) ContractAddressID() (int64, error) {
-	if repository.contractAddressID == 0 {
-		addressID, addressErr := shared.GetOrCreateAddress(repository.ContractAddress, repository.db)
-		repository.contractAddressID = addressID
-		return repository.contractAddressID, addressErr
+func (repo *StorageRepository) ContractAddressID() (int64, error) {
+	if repo.contractAddressID == 0 {
+		addressID, addressErr := repository.GetOrCreateAddress(repo.db, repo.ContractAddress)
+		repo.contractAddressID = addressID
+		return repo.contractAddressID, addressErr
 	}
-	return repository.contractAddressID, nil
+	return repo.contractAddressID, nil
 }
 
 func getIlk(keys map[types.Key]string) (string, error) {

--- a/transformers/storage/cat/repository_test.go
+++ b/transformers/storage/cat/repository_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/storage/utilities/wards"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data/shared_behaviors"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/libraries/shared/storage"
 	"github.com/makerdao/vulcanizedb/libraries/shared/storage/types"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
@@ -148,9 +149,9 @@ var _ = Describe("Cat storage repository", func() {
 			query := fmt.Sprintf(`SELECT diff_id, header_id, address_id, usr AS key, wards AS value FROM %s`, shared.GetFullTableName(constants.MakerSchema, constants.WardsTable))
 			err := db.Get(&result, query)
 			Expect(err).NotTo(HaveOccurred())
-			contractAddressID, contractAddressErr := shared.GetOrCreateAddress(repo.ContractAddress, db)
+			contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, repo.ContractAddress)
 			Expect(contractAddressErr).NotTo(HaveOccurred())
-			userAddressID, userAddressErr := shared.GetOrCreateAddress(fakeUserAddress, db)
+			userAddressID, userAddressErr := repository.GetOrCreateAddress(db, fakeUserAddress)
 			Expect(userAddressErr).NotTo(HaveOccurred())
 			AssertMappingWithAddress(result, diffID, fakeHeaderID, contractAddressID, strconv.FormatInt(userAddressID, 10), fakeUint256)
 		})
@@ -201,7 +202,7 @@ var _ = Describe("Cat storage repository", func() {
 				Expect(err).NotTo(HaveOccurred())
 				ilkID, err := shared.GetOrCreateIlk(test_helpers.FakeIlk.Hex, db)
 				Expect(err).NotTo(HaveOccurred())
-				contractAddressID, contractAddressErr := shared.GetOrCreateAddress(repo.ContractAddress, db)
+				contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, repo.ContractAddress)
 				Expect(contractAddressErr).NotTo(HaveOccurred())
 				AssertMappingWithAddress(result, diffID, fakeHeaderID, contractAddressID, strconv.FormatInt(ilkID, 10), fakeAddress)
 			})
@@ -250,7 +251,7 @@ var _ = Describe("Cat storage repository", func() {
 				err = db.Get(&result, query)
 				Expect(err).NotTo(HaveOccurred())
 				ilkID, err := shared.GetOrCreateIlk(test_helpers.FakeIlk.Hex, db)
-				contractAddressID, contractAddressErr := shared.GetOrCreateAddress(repo.ContractAddress, db)
+				contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, repo.ContractAddress)
 				Expect(contractAddressErr).NotTo(HaveOccurred())
 				Expect(err).NotTo(HaveOccurred())
 				AssertMappingWithAddress(result, diffID, fakeHeaderID, contractAddressID, strconv.FormatInt(ilkID, 10), fakeUint256)
@@ -301,7 +302,7 @@ var _ = Describe("Cat storage repository", func() {
 				Expect(err).NotTo(HaveOccurred())
 				ilkID, err := shared.GetOrCreateIlk(test_helpers.FakeIlk.Hex, db)
 				Expect(err).NotTo(HaveOccurred())
-				contractAddressID, contractAddressErr := shared.GetOrCreateAddress(repo.ContractAddress, db)
+				contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, repo.ContractAddress)
 				Expect(contractAddressErr).NotTo(HaveOccurred())
 				AssertMappingWithAddress(result, diffID, fakeHeaderID, contractAddressID, strconv.FormatInt(ilkID, 10), fakeUint256)
 			})

--- a/transformers/storage/flip/repository.go
+++ b/transformers/storage/flip/repository.go
@@ -8,6 +8,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/storage"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/storage/utilities/wards"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/libraries/shared/storage/types"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -36,59 +37,59 @@ type StorageRepository struct {
 	db              *postgres.DB
 }
 
-func (repository *StorageRepository) Create(diffID, headerID int64, metadata types.ValueMetadata, value interface{}) error {
+func (repo *StorageRepository) Create(diffID, headerID int64, metadata types.ValueMetadata, value interface{}) error {
 	switch metadata.Name {
 	case storage.Vat:
-		return repository.insertVat(diffID, headerID, value.(string))
+		return repo.insertVat(diffID, headerID, value.(string))
 	case storage.Ilk:
-		return repository.insertIlk(diffID, headerID, value.(string))
+		return repo.insertIlk(diffID, headerID, value.(string))
 	case storage.Beg:
-		return repository.insertBeg(diffID, headerID, value.(string))
+		return repo.insertBeg(diffID, headerID, value.(string))
 	case storage.Kicks:
-		return repository.insertKicks(diffID, headerID, value.(string))
+		return repo.insertKicks(diffID, headerID, value.(string))
 	case storage.Cat:
-		return repository.insertCat(diffID, headerID, value.(string))
+		return repo.insertCat(diffID, headerID, value.(string))
 	case wards.Wards:
-		return wards.InsertWards(diffID, headerID, metadata, repository.ContractAddress, value.(string), repository.db)
+		return wards.InsertWards(diffID, headerID, metadata, repo.ContractAddress, value.(string), repo.db)
 	case storage.BidBid:
-		return repository.insertBidBid(diffID, headerID, metadata, value.(string))
+		return repo.insertBidBid(diffID, headerID, metadata, value.(string))
 	case storage.BidLot:
-		return repository.insertBidLot(diffID, headerID, metadata, value.(string))
+		return repo.insertBidLot(diffID, headerID, metadata, value.(string))
 	case storage.BidUsr:
-		return repository.insertBidUsr(diffID, headerID, metadata, value.(string))
+		return repo.insertBidUsr(diffID, headerID, metadata, value.(string))
 	case storage.BidGal:
-		return repository.insertBidGal(diffID, headerID, metadata, value.(string))
+		return repo.insertBidGal(diffID, headerID, metadata, value.(string))
 	case storage.BidTab:
-		return repository.insertBidTab(diffID, headerID, metadata, value.(string))
+		return repo.insertBidTab(diffID, headerID, metadata, value.(string))
 	case storage.Packed:
-		return repository.insertPackedValueRecord(diffID, headerID, metadata, value.(map[int]string))
+		return repo.insertPackedValueRecord(diffID, headerID, metadata, value.(map[int]string))
 	default:
 		panic(fmt.Sprintf("unrecognized flip contract storage name: %s", metadata.Name))
 	}
 }
 
-func (repository *StorageRepository) SetDB(db *postgres.DB) {
-	repository.db = db
+func (repo *StorageRepository) SetDB(db *postgres.DB) {
+	repo.db = db
 }
 
-func (repository *StorageRepository) insertVat(diffID, headerID int64, vat string) error {
+func (repo *StorageRepository) insertVat(diffID, headerID int64, vat string) error {
 	err := shared.InsertRecordWithAddress(
 		diffID,
 		headerID,
 		insertFlipVatQuery,
 		vat,
-		repository.ContractAddress,
-		repository.db)
+		repo.ContractAddress,
+		repo.db)
 	if err != nil {
 		msgToFormat := "error inserting flip %s vat %s from diff ID %d"
-		msg := fmt.Sprintf(msgToFormat, repository.ContractAddress, vat, diffID)
+		msg := fmt.Sprintf(msgToFormat, repo.ContractAddress, vat, diffID)
 		return fmt.Errorf("%s: %w", msg, err)
 	}
 	return nil
 }
 
-func (repository *StorageRepository) insertIlk(diffID, headerID int64, ilk string) error {
-	ilkID, ilkErr := shared.GetOrCreateIlk(ilk, repository.db)
+func (repo *StorageRepository) insertIlk(diffID, headerID int64, ilk string) error {
+	ilkID, ilkErr := shared.GetOrCreateIlk(ilk, repo.db)
 	if ilkErr != nil {
 		return fmt.Errorf("error getting or creating ilk for flip ilk: %w", ilkErr)
 	}
@@ -97,82 +98,82 @@ func (repository *StorageRepository) insertIlk(diffID, headerID int64, ilk strin
 		headerID,
 		insertFlipIlkQuery,
 		strconv.FormatInt(ilkID, 10),
-		repository.ContractAddress,
-		repository.db)
+		repo.ContractAddress,
+		repo.db)
 	if insertErr != nil {
 		msgToFormat := "error inserting flip %s ilk %s from diff ID %d"
-		msg := fmt.Sprintf(msgToFormat, repository.ContractAddress, ilk, diffID)
+		msg := fmt.Sprintf(msgToFormat, repo.ContractAddress, ilk, diffID)
 		return fmt.Errorf("%s: %w", msg, insertErr)
 	}
 	return nil
 }
 
-func (repository *StorageRepository) insertBeg(diffID, headerID int64, beg string) error {
+func (repo *StorageRepository) insertBeg(diffID, headerID int64, beg string) error {
 	err := shared.InsertRecordWithAddress(
 		diffID,
 		headerID,
 		insertFlipBegQuery,
 		beg,
-		repository.ContractAddress,
-		repository.db)
+		repo.ContractAddress,
+		repo.db)
 	if err != nil {
 		msgToFormat := "error inserting flip %s beg %s from diff ID %d"
-		msg := fmt.Sprintf(msgToFormat, repository.ContractAddress, beg, diffID)
+		msg := fmt.Sprintf(msgToFormat, repo.ContractAddress, beg, diffID)
 		return fmt.Errorf("%s: %w", msg, err)
 	}
 	return nil
 }
 
-func (repository *StorageRepository) insertTTL(diffID, headerID int64, ttl string) error {
+func (repo *StorageRepository) insertTTL(diffID, headerID int64, ttl string) error {
 	err := shared.InsertRecordWithAddress(
 		diffID,
 		headerID,
 		insertFlipTTLQuery,
 		ttl,
-		repository.ContractAddress,
-		repository.db)
+		repo.ContractAddress,
+		repo.db)
 	if err != nil {
 		msgToFormat := "error inserting flip %s ttl %s from diff ID %d"
-		msg := fmt.Sprintf(msgToFormat, repository.ContractAddress, ttl, diffID)
+		msg := fmt.Sprintf(msgToFormat, repo.ContractAddress, ttl, diffID)
 		return fmt.Errorf("%s: %w", msg, err)
 	}
 	return nil
 }
 
-func (repository *StorageRepository) insertTau(diffID, headerID int64, tau string) error {
+func (repo *StorageRepository) insertTau(diffID, headerID int64, tau string) error {
 	err := shared.InsertRecordWithAddress(
 		diffID,
 		headerID,
 		insertFlipTauQuery,
 		tau,
-		repository.ContractAddress,
-		repository.db)
+		repo.ContractAddress,
+		repo.db)
 	if err != nil {
 		msgToFormat := "error inserting flip %s tau %s from diff ID %d"
-		msg := fmt.Sprintf(msgToFormat, repository.ContractAddress, tau, diffID)
+		msg := fmt.Sprintf(msgToFormat, repo.ContractAddress, tau, diffID)
 		return fmt.Errorf("%s: %w", msg, err)
 	}
 	return nil
 }
 
-func (repository *StorageRepository) insertKicks(diffID, headerID int64, kicks string) error {
+func (repo *StorageRepository) insertKicks(diffID, headerID int64, kicks string) error {
 	err := shared.InsertRecordWithAddress(
 		diffID,
 		headerID,
 		InsertFlipKicksQuery,
 		kicks,
-		repository.ContractAddress,
-		repository.db)
+		repo.ContractAddress,
+		repo.db)
 	if err != nil {
 		msgToFormat := "error inserting flip %s kicks %s from diff ID %d"
-		msg := fmt.Sprintf(msgToFormat, repository.ContractAddress, kicks, diffID)
+		msg := fmt.Sprintf(msgToFormat, repo.ContractAddress, kicks, diffID)
 		return fmt.Errorf("%s: %w", msg, err)
 	}
 	return nil
 }
 
-func (repository *StorageRepository) insertCat(diffID, headerID int64, cat string) error {
-	catAddressID, addressErr := shared.GetOrCreateAddress(cat, repository.db)
+func (repo *StorageRepository) insertCat(diffID, headerID int64, cat string) error {
+	catAddressID, addressErr := repository.GetOrCreateAddress(repo.db, cat)
 	if addressErr != nil {
 		return fmt.Errorf("error inserting flip cat: %w", addressErr)
 	}
@@ -181,16 +182,16 @@ func (repository *StorageRepository) insertCat(diffID, headerID int64, cat strin
 		headerID,
 		insertFlipCatQuery,
 		strconv.FormatInt(catAddressID, 10),
-		repository.ContractAddress,
-		repository.db)
+		repo.ContractAddress,
+		repo.db)
 	if insertErr != nil {
 		msgToFormat := "error inserting flip %s cat %s from diff ID %d: %w"
-		return fmt.Errorf(msgToFormat, repository.ContractAddress, cat, diffID, insertErr)
+		return fmt.Errorf(msgToFormat, repo.ContractAddress, cat, diffID, insertErr)
 	}
 	return nil
 }
 
-func (repository *StorageRepository) insertBidBid(diffID, headerID int64, metadata types.ValueMetadata, bid string) error {
+func (repo *StorageRepository) insertBidBid(diffID, headerID int64, metadata types.ValueMetadata, bid string) error {
 	bidID, err := getBidID(metadata.Keys)
 	if err != nil {
 		return fmt.Errorf("error getting bid ID for flip bid bid: %w", err)
@@ -201,17 +202,17 @@ func (repository *StorageRepository) insertBidBid(diffID, headerID int64, metada
 		InsertFlipBidBidQuery,
 		bidID,
 		bid,
-		repository.ContractAddress,
-		repository.db)
+		repo.ContractAddress,
+		repo.db)
 	if insertErr != nil {
 		msgToFormat := "error inserting flip %s bid %s bid %s from diff ID %d"
-		msg := fmt.Sprintf(msgToFormat, repository.ContractAddress, bidID, bid, diffID)
+		msg := fmt.Sprintf(msgToFormat, repo.ContractAddress, bidID, bid, diffID)
 		return fmt.Errorf("%s: %w", msg, insertErr)
 	}
 	return nil
 }
 
-func (repository *StorageRepository) insertBidLot(diffID, headerID int64, metadata types.ValueMetadata, lot string) error {
+func (repo *StorageRepository) insertBidLot(diffID, headerID int64, metadata types.ValueMetadata, lot string) error {
 	bidID, err := getBidID(metadata.Keys)
 	if err != nil {
 		return fmt.Errorf("error getting bid ID for flip bid lot: %w", err)
@@ -222,17 +223,17 @@ func (repository *StorageRepository) insertBidLot(diffID, headerID int64, metada
 		InsertFlipBidLotQuery,
 		bidID,
 		lot,
-		repository.ContractAddress,
-		repository.db)
+		repo.ContractAddress,
+		repo.db)
 	if insertErr != nil {
 		msgToFormat := "error inserting flip %s bid %s lot %s from diff ID %d"
-		msg := fmt.Sprintf(msgToFormat, repository.ContractAddress, bidID, lot, diffID)
+		msg := fmt.Sprintf(msgToFormat, repo.ContractAddress, bidID, lot, diffID)
 		return fmt.Errorf("%s: %w", msg, insertErr)
 	}
 	return nil
 }
 
-func (repository *StorageRepository) insertBidGuy(diffID, headerID int64, metadata types.ValueMetadata, guy string) error {
+func (repo *StorageRepository) insertBidGuy(diffID, headerID int64, metadata types.ValueMetadata, guy string) error {
 	bidID, err := getBidID(metadata.Keys)
 	if err != nil {
 		return fmt.Errorf("error getting bid ID for flip bid guy: %w", err)
@@ -243,17 +244,17 @@ func (repository *StorageRepository) insertBidGuy(diffID, headerID int64, metada
 		InsertFlipBidGuyQuery,
 		bidID,
 		guy,
-		repository.ContractAddress,
-		repository.db)
+		repo.ContractAddress,
+		repo.db)
 	if insertErr != nil {
 		msgToFormat := "error inserting flip %s bid %s guy %s from diff ID %d"
-		msg := fmt.Sprintf(msgToFormat, repository.ContractAddress, bidID, guy, diffID)
+		msg := fmt.Sprintf(msgToFormat, repo.ContractAddress, bidID, guy, diffID)
 		return fmt.Errorf("%s: %w", msg, insertErr)
 	}
 	return nil
 }
 
-func (repository *StorageRepository) insertBidTic(diffID, headerID int64, metadata types.ValueMetadata, tic string) error {
+func (repo *StorageRepository) insertBidTic(diffID, headerID int64, metadata types.ValueMetadata, tic string) error {
 	bidID, err := getBidID(metadata.Keys)
 	if err != nil {
 		return fmt.Errorf("error getting bid ID for flip bid tic: %w", err)
@@ -264,17 +265,17 @@ func (repository *StorageRepository) insertBidTic(diffID, headerID int64, metada
 		InsertFlipBidTicQuery,
 		bidID,
 		tic,
-		repository.ContractAddress,
-		repository.db)
+		repo.ContractAddress,
+		repo.db)
 	if insertErr != nil {
 		msgToFormat := "error inserting flip %s bid %s tic %s from diff ID %d"
-		msg := fmt.Sprintf(msgToFormat, repository.ContractAddress, bidID, tic, diffID)
+		msg := fmt.Sprintf(msgToFormat, repo.ContractAddress, bidID, tic, diffID)
 		return fmt.Errorf("%s: %w", msg, insertErr)
 	}
 	return nil
 }
 
-func (repository *StorageRepository) insertBidEnd(diffID, headerID int64, metadata types.ValueMetadata, end string) error {
+func (repo *StorageRepository) insertBidEnd(diffID, headerID int64, metadata types.ValueMetadata, end string) error {
 	bidID, err := getBidID(metadata.Keys)
 	if err != nil {
 		return fmt.Errorf("error getting bid ID for flip bid end: %w", err)
@@ -285,17 +286,17 @@ func (repository *StorageRepository) insertBidEnd(diffID, headerID int64, metada
 		InsertFlipBidEndQuery,
 		bidID,
 		end,
-		repository.ContractAddress,
-		repository.db)
+		repo.ContractAddress,
+		repo.db)
 	if insertErr != nil {
 		msgToFormat := "error inserting flip %s bid %s end %s from diff ID %d"
-		msg := fmt.Sprintf(msgToFormat, repository.ContractAddress, bidID, end, diffID)
+		msg := fmt.Sprintf(msgToFormat, repo.ContractAddress, bidID, end, diffID)
 		return fmt.Errorf("%s: %w", msg, insertErr)
 	}
 	return nil
 }
 
-func (repository *StorageRepository) insertBidUsr(diffID, headerID int64, metadata types.ValueMetadata, usr string) error {
+func (repo *StorageRepository) insertBidUsr(diffID, headerID int64, metadata types.ValueMetadata, usr string) error {
 	bidID, err := getBidID(metadata.Keys)
 	if err != nil {
 		return fmt.Errorf("error getting bid ID for flip bid usr: %w", err)
@@ -306,17 +307,17 @@ func (repository *StorageRepository) insertBidUsr(diffID, headerID int64, metada
 		InsertFlipBidUsrQuery,
 		bidID,
 		usr,
-		repository.ContractAddress,
-		repository.db)
+		repo.ContractAddress,
+		repo.db)
 	if insertErr != nil {
 		msgToFormat := "error inserting flip %s bid %s usr %s from diff ID %d"
-		msg := fmt.Sprintf(msgToFormat, repository.ContractAddress, bidID, usr, diffID)
+		msg := fmt.Sprintf(msgToFormat, repo.ContractAddress, bidID, usr, diffID)
 		return fmt.Errorf("%s: %w", msg, insertErr)
 	}
 	return nil
 }
 
-func (repository *StorageRepository) insertBidGal(diffID, headerID int64, metadata types.ValueMetadata, gal string) error {
+func (repo *StorageRepository) insertBidGal(diffID, headerID int64, metadata types.ValueMetadata, gal string) error {
 	bidID, err := getBidID(metadata.Keys)
 	if err != nil {
 		return fmt.Errorf("error getting bid ID for flip bid gal: %w", err)
@@ -327,17 +328,17 @@ func (repository *StorageRepository) insertBidGal(diffID, headerID int64, metada
 		InsertFlipBidGalQuery,
 		bidID,
 		gal,
-		repository.ContractAddress,
-		repository.db)
+		repo.ContractAddress,
+		repo.db)
 	if insertErr != nil {
 		msgToFormat := "error inserting flip %s bid %s gal %s from diff ID %d"
-		msg := fmt.Sprintf(msgToFormat, repository.ContractAddress, bidID, gal, diffID)
+		msg := fmt.Sprintf(msgToFormat, repo.ContractAddress, bidID, gal, diffID)
 		return fmt.Errorf("%s: %w", msg, insertErr)
 	}
 	return nil
 }
 
-func (repository *StorageRepository) insertBidTab(diffID, headerID int64, metadata types.ValueMetadata, tab string) error {
+func (repo *StorageRepository) insertBidTab(diffID, headerID int64, metadata types.ValueMetadata, tab string) error {
 	bidID, err := getBidID(metadata.Keys)
 	if err != nil {
 		return fmt.Errorf("error getting bid ID for flip bid tab: %w", err)
@@ -348,30 +349,30 @@ func (repository *StorageRepository) insertBidTab(diffID, headerID int64, metada
 		InsertFlipBidTabQuery,
 		bidID,
 		tab,
-		repository.ContractAddress,
-		repository.db)
+		repo.ContractAddress,
+		repo.db)
 	if insertErr != nil {
 		msgToFormat := "error inserting flip %s bid %s tab %s from diff ID %d"
-		msg := fmt.Sprintf(msgToFormat, repository.ContractAddress, bidID, tab, diffID)
+		msg := fmt.Sprintf(msgToFormat, repo.ContractAddress, bidID, tab, diffID)
 		return fmt.Errorf("%s: %w", msg, insertErr)
 	}
 	return nil
 }
 
-func (repository *StorageRepository) insertPackedValueRecord(diffID, headerID int64, metadata types.ValueMetadata, packedValues map[int]string) error {
+func (repo *StorageRepository) insertPackedValueRecord(diffID, headerID int64, metadata types.ValueMetadata, packedValues map[int]string) error {
 	for order, value := range packedValues {
 		var insertErr error
 		switch metadata.PackedNames[order] {
 		case storage.Ttl:
-			insertErr = repository.insertTTL(diffID, headerID, value)
+			insertErr = repo.insertTTL(diffID, headerID, value)
 		case storage.Tau:
-			insertErr = repository.insertTau(diffID, headerID, value)
+			insertErr = repo.insertTau(diffID, headerID, value)
 		case storage.BidGuy:
-			insertErr = repository.insertBidGuy(diffID, headerID, metadata, value)
+			insertErr = repo.insertBidGuy(diffID, headerID, metadata, value)
 		case storage.BidTic:
-			insertErr = repository.insertBidTic(diffID, headerID, metadata, value)
+			insertErr = repo.insertBidTic(diffID, headerID, metadata, value)
 		case storage.BidEnd:
-			insertErr = repository.insertBidEnd(diffID, headerID, metadata, value)
+			insertErr = repo.insertBidEnd(diffID, headerID, metadata, value)
 		default:
 			panic(fmt.Sprintf("unrecognized flip contract storage name in packed values: %s", metadata.Name))
 		}

--- a/transformers/storage/flip/repository_test.go
+++ b/transformers/storage/flip/repository_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/storage/utilities/wards"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data/shared_behaviors"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/libraries/shared/storage/types"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
 	"github.com/makerdao/vulcanizedb/pkg/fakes"
@@ -84,7 +85,7 @@ var _ = Describe("Flip storage repository", func() {
 				query := fmt.Sprintf(`SELECT diff_id, header_id, cat AS value FROM %s`, shared.GetFullTableName(constants.MakerSchema, constants.FlipCatTable))
 				getErr := db.Get(&result, query)
 				Expect(getErr).NotTo(HaveOccurred())
-				addressID, addressErr := shared.GetOrCreateAddress(FakeAddress, db)
+				addressID, addressErr := repository.GetOrCreateAddress(db, FakeAddress)
 				Expect(addressErr).NotTo(HaveOccurred())
 				AssertVariable(result, diffID, fakeHeaderID, strconv.FormatInt(addressID, 10))
 			})
@@ -119,9 +120,9 @@ var _ = Describe("Flip storage repository", func() {
 				query := fmt.Sprintf(`SELECT diff_id, header_id, address_id, usr AS key, wards AS value FROM %s`, shared.GetFullTableName(constants.MakerSchema, constants.WardsTable))
 				err := db.Get(&result, query)
 				Expect(err).NotTo(HaveOccurred())
-				contractAddressID, contractAddressErr := shared.GetOrCreateAddress(repo.ContractAddress, db)
+				contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, repo.ContractAddress)
 				Expect(contractAddressErr).NotTo(HaveOccurred())
-				userAddressID, userAddressErr := shared.GetOrCreateAddress(fakeUserAddress, db)
+				userAddressID, userAddressErr := repository.GetOrCreateAddress(db, fakeUserAddress)
 				Expect(userAddressErr).NotTo(HaveOccurred())
 				AssertMappingWithAddress(result, diffID, fakeHeaderID, contractAddressID, strconv.FormatInt(userAddressID, 10), fakeUint256)
 			})

--- a/transformers/storage/flop/repository_test.go
+++ b/transformers/storage/flop/repository_test.go
@@ -5,6 +5,8 @@ import (
 	"math/rand"
 	"strconv"
 
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
+
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
@@ -242,9 +244,9 @@ var _ = Describe("Flop storage repository", func() {
 			query := fmt.Sprintf(`SELECT diff_id, header_id, address_id, usr AS key, wards AS value FROM %s`, shared.GetFullTableName(constants.MakerSchema, constants.WardsTable))
 			err := db.Get(&result, query)
 			Expect(err).NotTo(HaveOccurred())
-			contractAddressID, contractAddressErr := shared.GetOrCreateAddress(repo.ContractAddress, db)
+			contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, repo.ContractAddress)
 			Expect(contractAddressErr).NotTo(HaveOccurred())
-			userAddressID, userAddressErr := shared.GetOrCreateAddress(fakeUserAddress, db)
+			userAddressID, userAddressErr := repository.GetOrCreateAddress(db, fakeUserAddress)
 			Expect(userAddressErr).NotTo(HaveOccurred())
 			AssertMappingWithAddress(result, diffID, fakeHeaderID, contractAddressID, strconv.FormatInt(userAddressID, 10), fakeUint256)
 		})

--- a/transformers/storage/jug/repository_test.go
+++ b/transformers/storage/jug/repository_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/storage/utilities/wards"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data/shared_behaviors"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/libraries/shared/storage/types"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
 	"github.com/makerdao/vulcanizedb/pkg/fakes"
@@ -71,9 +72,9 @@ var _ = Describe("Jug storage repository", func() {
 			query := fmt.Sprintf(`SELECT diff_id, header_id, address_id, usr AS key, wards AS value FROM %s`, shared.GetFullTableName(constants.MakerSchema, constants.WardsTable))
 			err := db.Get(&result, query)
 			Expect(err).NotTo(HaveOccurred())
-			contractAddressID, contractAddressErr := shared.GetOrCreateAddress(repo.ContractAddress, db)
+			contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, repo.ContractAddress)
 			Expect(contractAddressErr).NotTo(HaveOccurred())
-			userAddressID, userAddressErr := shared.GetOrCreateAddress(fakeUserAddress, db)
+			userAddressID, userAddressErr := repository.GetOrCreateAddress(db, fakeUserAddress)
 			Expect(userAddressErr).NotTo(HaveOccurred())
 			AssertMappingWithAddress(result, diffID, fakeHeaderID, contractAddressID, strconv.FormatInt(userAddressID, 10), fakeUint256)
 		})

--- a/transformers/storage/median/repository_test.go
+++ b/transformers/storage/median/repository_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/storage/utilities/wards"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data/shared_behaviors"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/libraries/shared/storage/types"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
 	"github.com/makerdao/vulcanizedb/pkg/fakes"
@@ -66,9 +67,9 @@ var _ = Describe("Median Storage Repository", func() {
 			query := fmt.Sprintf(`SELECT diff_id, header_id, address_id, usr AS key, wards AS value FROM %s`, shared.GetFullTableName(constants.MakerSchema, constants.WardsTable))
 			readErr := db.Get(&result, query)
 			Expect(readErr).NotTo(HaveOccurred())
-			contractAddressID, contractAddressErr := shared.GetOrCreateAddress(repo.ContractAddress, db)
+			contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, repo.ContractAddress)
 			Expect(contractAddressErr).NotTo(HaveOccurred())
-			userAddressID, userAddressErr := shared.GetOrCreateAddress(fakeUserAddress, db)
+			userAddressID, userAddressErr := repository.GetOrCreateAddress(db, fakeUserAddress)
 			Expect(userAddressErr).NotTo(HaveOccurred())
 			AssertMappingWithAddress(result, diffID, fakeHeaderID, contractAddressID, strconv.FormatInt(userAddressID, 10), fakeUint256)
 		})
@@ -179,9 +180,9 @@ var _ = Describe("Median Storage Repository", func() {
 			query := fmt.Sprintf(`SELECT diff_id, header_id, address_id, a AS key, bud AS value FROM %s`, shared.GetFullTableName(constants.MakerSchema, constants.MedianBudTable))
 			readErr := db.Get(&result, query)
 			Expect(readErr).NotTo(HaveOccurred())
-			contractAddressID, contractAddressErr := shared.GetOrCreateAddress(repo.ContractAddress, db)
+			contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, repo.ContractAddress)
 			Expect(contractAddressErr).NotTo(HaveOccurred())
-			budAddressID, budAddressErr := shared.GetOrCreateAddress(fakeBudAddress, db)
+			budAddressID, budAddressErr := repository.GetOrCreateAddress(db, fakeBudAddress)
 			Expect(budAddressErr).NotTo(HaveOccurred())
 			AssertMappingWithAddress(result, diffID, fakeHeaderID, contractAddressID, strconv.FormatInt(budAddressID, 10), fakeUint256)
 		})
@@ -224,9 +225,9 @@ var _ = Describe("Median Storage Repository", func() {
 			query := fmt.Sprintf(`SELECT diff_id, header_id, address_id, a AS key, orcl AS value FROM %s`, shared.GetFullTableName(constants.MakerSchema, constants.MedianOrclTable))
 			readErr := db.Get(&result, query)
 			Expect(readErr).NotTo(HaveOccurred())
-			contractAddressID, contractAddressErr := shared.GetOrCreateAddress(repo.ContractAddress, db)
+			contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, repo.ContractAddress)
 			Expect(contractAddressErr).NotTo(HaveOccurred())
-			orclAddressID, orclAddressErr := shared.GetOrCreateAddress(fakeOrclAddress, db)
+			orclAddressID, orclAddressErr := repository.GetOrCreateAddress(db, fakeOrclAddress)
 			Expect(orclAddressErr).NotTo(HaveOccurred())
 			AssertMappingWithAddress(result, diffID, fakeHeaderID, contractAddressID, strconv.FormatInt(orclAddressID, 10), fakeUint256)
 		})
@@ -268,9 +269,9 @@ var _ = Describe("Median Storage Repository", func() {
 			query := fmt.Sprintf(`SELECT diff_id, header_id, address_id, slot_id AS key, slot AS value FROM %s`, shared.GetFullTableName(constants.MakerSchema, constants.MedianSlotTable))
 			readErr := db.Get(&result, query)
 			Expect(readErr).NotTo(HaveOccurred())
-			contractAddressID, contractAddressErr := shared.GetOrCreateAddress(repo.ContractAddress, db)
+			contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, repo.ContractAddress)
 			Expect(contractAddressErr).NotTo(HaveOccurred())
-			slotAddressID, slotAddressErr := shared.GetOrCreateAddress(fakeSlotAddress, db)
+			slotAddressID, slotAddressErr := repository.GetOrCreateAddress(db, fakeSlotAddress)
 			Expect(slotAddressErr).NotTo(HaveOccurred())
 			AssertMappingWithAddress(result, diffID, fakeHeaderID, contractAddressID, fakeUint8, strconv.FormatInt(slotAddressID, 10))
 		})

--- a/transformers/storage/pot/repository.go
+++ b/transformers/storage/pot/repository.go
@@ -6,6 +6,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/storage/utilities/wards"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/libraries/shared/storage/types"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -26,109 +27,109 @@ type StorageRepository struct {
 	ContractAddress string
 }
 
-func (repository StorageRepository) Create(diffID, headerID int64, metadata types.ValueMetadata, value interface{}) error {
+func (repo StorageRepository) Create(diffID, headerID int64, metadata types.ValueMetadata, value interface{}) error {
 	switch metadata.Name {
 	case UserPie:
-		return repository.insertUserPie(diffID, headerID, metadata, value.(string))
+		return repo.insertUserPie(diffID, headerID, metadata, value.(string))
 	case wards.Wards:
-		return wards.InsertWards(diffID, headerID, metadata, repository.ContractAddress, value.(string), repository.db)
+		return wards.InsertWards(diffID, headerID, metadata, repo.ContractAddress, value.(string), repo.db)
 	case Pie:
-		return repository.insertPie(diffID, headerID, value.(string))
+		return repo.insertPie(diffID, headerID, value.(string))
 	case Dsr:
-		return repository.insertDsr(diffID, headerID, value.(string))
+		return repo.insertDsr(diffID, headerID, value.(string))
 	case Chi:
-		return repository.insertChi(diffID, headerID, value.(string))
+		return repo.insertChi(diffID, headerID, value.(string))
 	case Vat:
-		return repository.insertVat(diffID, headerID, value.(string))
+		return repo.insertVat(diffID, headerID, value.(string))
 	case Vow:
-		return repository.insertVow(diffID, headerID, value.(string))
+		return repo.insertVow(diffID, headerID, value.(string))
 	case Rho:
-		return repository.insertRho(diffID, headerID, value.(string))
+		return repo.insertRho(diffID, headerID, value.(string))
 	case Live:
-		return repository.insertLive(diffID, headerID, value.(string))
+		return repo.insertLive(diffID, headerID, value.(string))
 	default:
 		panic(fmt.Sprintf("unrecognized pot contract storage name: %s", metadata.Name))
 	}
 }
 
-func (repository *StorageRepository) SetDB(db *postgres.DB) {
-	repository.db = db
+func (repo *StorageRepository) SetDB(db *postgres.DB) {
+	repo.db = db
 }
 
-func (repository StorageRepository) insertUserPie(diffID, headerID int64, metadata types.ValueMetadata, pie string) error {
+func (repo StorageRepository) insertUserPie(diffID, headerID int64, metadata types.ValueMetadata, pie string) error {
 	user, err := getUser(metadata.Keys)
 	if err != nil {
 		return fmt.Errorf("error getting user for pot user pie: %w", err)
 	}
-	insertErr := shared.InsertRecordWithAddress(diffID, headerID, insertPotUserPieQuery, pie, user, repository.db)
+	insertErr := shared.InsertRecordWithAddress(diffID, headerID, insertPotUserPieQuery, pie, user, repo.db)
 	if insertErr != nil {
 		return fmt.Errorf("error inserting pot user %s pie %s from diff ID %d: %w", user, pie, diffID, insertErr)
 	}
 	return nil
 }
 
-func (repository StorageRepository) insertPie(diffID, headerID int64, pie string) error {
-	_, err := repository.db.Exec(insertPotPieQuery, diffID, headerID, pie)
+func (repo StorageRepository) insertPie(diffID, headerID int64, pie string) error {
+	_, err := repo.db.Exec(insertPotPieQuery, diffID, headerID, pie)
 	if err != nil {
 		return fmt.Errorf("error inserting pot pie %s from diff ID %d: %w", pie, diffID, err)
 	}
 	return nil
 }
 
-func (repository StorageRepository) insertDsr(diffID, headerID int64, dsr string) error {
-	_, err := repository.db.Exec(insertPotDsrQuery, diffID, headerID, dsr)
+func (repo StorageRepository) insertDsr(diffID, headerID int64, dsr string) error {
+	_, err := repo.db.Exec(insertPotDsrQuery, diffID, headerID, dsr)
 	if err != nil {
 		return fmt.Errorf("error inserting pot dsr %s from diff ID %d: %w", dsr, diffID, err)
 	}
 	return nil
 }
 
-func (repository StorageRepository) insertChi(diffID, headerID int64, chi string) error {
-	_, err := repository.db.Exec(insertPotChiQuery, diffID, headerID, chi)
+func (repo StorageRepository) insertChi(diffID, headerID int64, chi string) error {
+	_, err := repo.db.Exec(insertPotChiQuery, diffID, headerID, chi)
 	if err != nil {
 		return fmt.Errorf("error inserting pot chi %s from diff ID %d: %w", chi, diffID, err)
 	}
 	return nil
 }
 
-func (repository StorageRepository) insertVat(diffID, headerID int64, vat string) error {
-	err := repository.insertAddressID(diffID, headerID, insertPotVatQuery, vat)
+func (repo StorageRepository) insertVat(diffID, headerID int64, vat string) error {
+	err := repo.insertAddressID(diffID, headerID, insertPotVatQuery, vat)
 	if err != nil {
 		return fmt.Errorf("error inserting pot vat %s from diff ID %d: %w", vat, diffID, err)
 	}
 	return nil
 }
 
-func (repository StorageRepository) insertVow(diffID, headerID int64, vow string) error {
-	err := repository.insertAddressID(diffID, headerID, insertPotVowQuery, vow)
+func (repo StorageRepository) insertVow(diffID, headerID int64, vow string) error {
+	err := repo.insertAddressID(diffID, headerID, insertPotVowQuery, vow)
 	if err != nil {
 		return fmt.Errorf("error inserting pot vow %s from diff ID %d: %w", vow, diffID, err)
 	}
 	return nil
 }
 
-func (repository StorageRepository) insertRho(diffID, headerID int64, rho string) error {
-	_, err := repository.db.Exec(insertPotRhoQuery, diffID, headerID, rho)
+func (repo StorageRepository) insertRho(diffID, headerID int64, rho string) error {
+	_, err := repo.db.Exec(insertPotRhoQuery, diffID, headerID, rho)
 	if err != nil {
 		return fmt.Errorf("error inserting pot rho %s from diff ID %d: %w", rho, diffID, err)
 	}
 	return nil
 }
 
-func (repository StorageRepository) insertLive(diffID, headerID int64, live string) error {
-	_, err := repository.db.Exec(insertPotLiveQuery, diffID, headerID, live)
+func (repo StorageRepository) insertLive(diffID, headerID int64, live string) error {
+	_, err := repo.db.Exec(insertPotLiveQuery, diffID, headerID, live)
 	if err != nil {
 		return fmt.Errorf("error inserting pot live %s from diff ID %d: %w", live, diffID, err)
 	}
 	return nil
 }
 
-func (repository *StorageRepository) insertAddressID(diffID, headerID int64, query, address string) error {
-	tx, txErr := repository.db.Beginx()
+func (repo *StorageRepository) insertAddressID(diffID, headerID int64, query, address string) error {
+	tx, txErr := repo.db.Beginx()
 	if txErr != nil {
 		return fmt.Errorf("error beginning transaction: %w", txErr)
 	}
-	addressID, addressErr := shared.GetOrCreateAddressInTransaction(address, tx)
+	addressID, addressErr := repository.GetOrCreateAddressInTransaction(tx, address)
 	if addressErr != nil {
 		rollbackErr := tx.Rollback()
 		if rollbackErr != nil {

--- a/transformers/storage/pot/repository_test.go
+++ b/transformers/storage/pot/repository_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/storage/utilities/wards"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data/shared_behaviors"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/libraries/shared/storage/types"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
 	"github.com/makerdao/vulcanizedb/pkg/fakes"
@@ -62,7 +63,7 @@ var _ = Describe("Pot storage repository", func() {
 			var result MappingRes
 			dbErr := db.Get(&result, `SELECT diff_id, header_id, "user" AS key, pie AS value FROM maker.pot_user_pie`)
 			Expect(dbErr).NotTo(HaveOccurred())
-			addressID, addressErr := shared.GetOrCreateAddress(fakeAddress, db)
+			addressID, addressErr := repository.GetOrCreateAddress(db, fakeAddress)
 			Expect(addressErr).NotTo(HaveOccurred())
 			AssertMapping(result, diffID, fakeHeaderID, strconv.FormatInt(addressID, 10), fakeUint256)
 		})
@@ -134,7 +135,7 @@ var _ = Describe("Pot storage repository", func() {
 			err := repo.Create(diffID, fakeHeaderID, pot.VatMetadata, fakeAddress)
 			Expect(err).NotTo(HaveOccurred())
 
-			addressID, addressErr := shared.GetOrCreateAddress(fakeAddress, db)
+			addressID, addressErr := repository.GetOrCreateAddress(db, fakeAddress)
 			Expect(addressErr).NotTo(HaveOccurred())
 			var result VariableRes
 			err = db.Get(&result, `SELECT diff_id, header_id, vat AS value FROM maker.pot_vat`)
@@ -162,7 +163,7 @@ var _ = Describe("Pot storage repository", func() {
 			err := repo.Create(diffID, fakeHeaderID, pot.VowMetadata, fakeAddress)
 			Expect(err).NotTo(HaveOccurred())
 
-			addressID, addressErr := shared.GetOrCreateAddress(fakeAddress, db)
+			addressID, addressErr := repository.GetOrCreateAddress(db, fakeAddress)
 			Expect(addressErr).NotTo(HaveOccurred())
 			var result VariableRes
 			err = db.Get(&result, `SELECT diff_id, header_id, vow AS value FROM maker.pot_vow`)
@@ -222,9 +223,9 @@ var _ = Describe("Pot storage repository", func() {
 			query := fmt.Sprintf(`SELECT diff_id, header_id, address_id, usr AS key, wards AS value FROM %s`, shared.GetFullTableName(constants.MakerSchema, constants.WardsTable))
 			err := db.Get(&result, query)
 			Expect(err).NotTo(HaveOccurred())
-			contractAddressID, contractAddressErr := shared.GetOrCreateAddress(repo.ContractAddress, db)
+			contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, repo.ContractAddress)
 			Expect(contractAddressErr).NotTo(HaveOccurred())
-			userAddressID, userAddressErr := shared.GetOrCreateAddress(fakeUserAddress, db)
+			userAddressID, userAddressErr := repository.GetOrCreateAddress(db, fakeUserAddress)
 			Expect(userAddressErr).NotTo(HaveOccurred())
 			AssertMappingWithAddress(result, diffID, fakeHeaderID, contractAddressID, strconv.FormatInt(userAddressID, 10), fakeUint256)
 		})

--- a/transformers/storage/spot/repository_test.go
+++ b/transformers/storage/spot/repository_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/storage/utilities/wards"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data/shared_behaviors"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/libraries/shared/storage/types"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
 	"github.com/makerdao/vulcanizedb/pkg/fakes"
@@ -70,9 +71,9 @@ var _ = Describe("Spot storage repository", func() {
 			query := fmt.Sprintf(`SELECT diff_id, header_id, address_id, usr AS key, wards AS value FROM %s`, shared.GetFullTableName(constants.MakerSchema, constants.WardsTable))
 			err := db.Get(&result, query)
 			Expect(err).NotTo(HaveOccurred())
-			contractAddressID, contractAddressErr := shared.GetOrCreateAddress(repo.ContractAddress, db)
+			contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, repo.ContractAddress)
 			Expect(contractAddressErr).NotTo(HaveOccurred())
-			userAddressID, userAddressErr := shared.GetOrCreateAddress(fakeUserAddress, db)
+			userAddressID, userAddressErr := repository.GetOrCreateAddress(db, fakeUserAddress)
 			Expect(userAddressErr).NotTo(HaveOccurred())
 			AssertMappingWithAddress(result, diffID, fakeHeaderID, contractAddressID, strconv.FormatInt(userAddressID, 10), fakeUint256)
 		})

--- a/transformers/storage/utilities/wards/repository.go
+++ b/transformers/storage/utilities/wards/repository.go
@@ -3,6 +3,7 @@ package wards
 import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/libraries/shared/storage/types"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
 )
@@ -20,7 +21,7 @@ func InsertWards(diffID, headerID int64, metadata types.ValueMetadata, contractA
 		return txErr
 	}
 
-	addressID, addressErr := shared.GetOrCreateAddress(contractAddress, db)
+	addressID, addressErr := repository.GetOrCreateAddress(db, contractAddress)
 	if addressErr != nil {
 		rollbackErr := tx.Rollback()
 		if rollbackErr != nil {
@@ -29,7 +30,7 @@ func InsertWards(diffID, headerID int64, metadata types.ValueMetadata, contractA
 		return addressErr
 	}
 
-	userAddressID, userAddressErr := shared.GetOrCreateAddress(user, db)
+	userAddressID, userAddressErr := repository.GetOrCreateAddress(db, user)
 	if userAddressErr != nil {
 		rollbackErr := tx.Rollback()
 		if rollbackErr != nil {

--- a/transformers/storage/vat/repository_test.go
+++ b/transformers/storage/vat/repository_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/storage/vat"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data/shared_behaviors"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/libraries/shared/storage/types"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
@@ -72,9 +73,9 @@ var _ = Describe("Vat storage repository", func() {
 			query := fmt.Sprintf(`SELECT diff_id, header_id, address_id, usr AS key, wards AS value FROM %s`, shared.GetFullTableName(constants.MakerSchema, constants.WardsTable))
 			err := db.Get(&result, query)
 			Expect(err).NotTo(HaveOccurred())
-			contractAddressID, contractAddressErr := shared.GetOrCreateAddress(test_data.VatAddress(), db)
+			contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, test_data.VatAddress())
 			Expect(contractAddressErr).NotTo(HaveOccurred())
-			userAddressID, userAddressErr := shared.GetOrCreateAddress(fakeUserAddress, db)
+			userAddressID, userAddressErr := repository.GetOrCreateAddress(db, fakeUserAddress)
 			Expect(userAddressErr).NotTo(HaveOccurred())
 			AssertMappingWithAddress(result, diffID, fakeHeaderID, contractAddressID, strconv.FormatInt(userAddressID, 10), fakeUint256)
 		})

--- a/transformers/storage/vow/repository_test.go
+++ b/transformers/storage/vow/repository_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/storage/utilities/wards"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/storage/vow"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data/shared_behaviors"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/libraries/shared/storage/types"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
 	"github.com/makerdao/vulcanizedb/pkg/fakes"
@@ -68,9 +69,9 @@ var _ = Describe("Vow storage repository test", func() {
 			query := fmt.Sprintf(`SELECT diff_id, header_id, address_id, usr AS key, wards AS value FROM %s`, shared.GetFullTableName(constants.MakerSchema, constants.WardsTable))
 			err := db.Get(&result, query)
 			Expect(err).NotTo(HaveOccurred())
-			contractAddressID, contractAddressErr := shared.GetOrCreateAddress(repo.ContractAddress, db)
+			contractAddressID, contractAddressErr := repository.GetOrCreateAddress(db, repo.ContractAddress)
 			Expect(contractAddressErr).NotTo(HaveOccurred())
-			userAddressID, userAddressErr := shared.GetOrCreateAddress(fakeUserAddress, db)
+			userAddressID, userAddressErr := repository.GetOrCreateAddress(db, fakeUserAddress)
 			Expect(userAddressErr).NotTo(HaveOccurred())
 			AssertMappingWithAddress(result, diffID, fakeHeaderID, contractAddressID, strconv.FormatInt(userAddressID, 10), fakeUint256)
 		})

--- a/transformers/test_data/shared_behaviors/bid_history_trigger_suite.go
+++ b/transformers/test_data/shared_behaviors/bid_history_trigger_suite.go
@@ -11,13 +11,13 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/makerdao/vdb-mcd-transformers/test_config"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/component_tests/queries/test_helpers"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	mcdStorage "github.com/makerdao/vdb-mcd-transformers/transformers/storage"
 	. "github.com/makerdao/vdb-mcd-transformers/transformers/storage/test_helpers"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/test_data"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	vdbStorage "github.com/makerdao/vulcanizedb/libraries/shared/factories/storage"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/libraries/shared/storage/types"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	. "github.com/onsi/ginkgo"
@@ -76,7 +76,7 @@ func UpdateBidSnapshotTriggerTests(input BidTriggerTestInput) {
 			bidID, parseErr = strconv.Atoi(input.Metadata.Keys[constants.BidId])
 			Expect(parseErr).NotTo(HaveOccurred())
 			var addressErr error
-			addressID, addressErr = shared.GetOrCreateAddress(input.ContractAddress, db)
+			addressID, addressErr = repository.GetOrCreateAddress(db, input.ContractAddress)
 			Expect(addressErr).NotTo(HaveOccurred())
 		})
 
@@ -134,7 +134,7 @@ func UpdateBidSnapshotTriggerTests(input BidTriggerTestInput) {
 
 			It("ignores rows from different address", func() {
 				_, initialColumnVal := randomBidStorageValue(input.Metadata.Type, input.PackedValueType)
-				differentAddressID, addressErr := shared.GetOrCreateAddress(test_data.RandomString(40), db)
+				differentAddressID, addressErr := repository.GetOrCreateAddress(db, test_data.RandomString(40))
 				Expect(addressErr).NotTo(HaveOccurred())
 				_, setupErr := db.Exec(insertFieldQuery, differentAddressID, headerTwo.BlockNumber, bidID, initialColumnVal, timestampTwo)
 				Expect(setupErr).NotTo(HaveOccurred())
@@ -274,7 +274,7 @@ func InsertFlipBidSnapshotTriggerTests(input BidTriggerTestInput) {
 			bidID, parseErr = strconv.Atoi(input.Metadata.Keys[constants.BidId])
 			Expect(parseErr).NotTo(HaveOccurred())
 			var addressErr error
-			addressID, addressErr = shared.GetOrCreateAddress(input.ContractAddress, db)
+			addressID, addressErr = repository.GetOrCreateAddress(db, input.ContractAddress)
 			Expect(addressErr).NotTo(HaveOccurred())
 		})
 
@@ -353,7 +353,7 @@ func InsertBidSnapshotTriggerTests(input BidTriggerTestInput) {
 			bidID, parseErr = strconv.Atoi(input.Metadata.Keys[constants.BidId])
 			Expect(parseErr).NotTo(HaveOccurred())
 			var addressErr error
-			addressID, addressErr = shared.GetOrCreateAddress(input.ContractAddress, db)
+			addressID, addressErr = repository.GetOrCreateAddress(db, input.ContractAddress)
 			Expect(addressErr).NotTo(HaveOccurred())
 		})
 

--- a/transformers/test_data/shared_behaviors/storage_repository_behaviors.go
+++ b/transformers/test_data/shared_behaviors/storage_repository_behaviors.go
@@ -13,6 +13,7 @@ import (
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	. "github.com/makerdao/vdb-mcd-transformers/transformers/storage/test_helpers"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/storage"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/libraries/shared/storage/types"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres/repositories"
@@ -66,7 +67,7 @@ func SharedStorageRepositoryBehaviors(inputs *StorageBehaviorInputs) {
 				Expect(err).NotTo(HaveOccurred())
 				AssertMapping(result, diffID, headerID, inputs.Key, inputs.Value)
 			} else if len(inputs.ContractAddress) > 0 {
-				contractAddressID, contractAddressErr := shared.GetOrCreateAddress(inputs.ContractAddress, database)
+				contractAddressID, contractAddressErr := repository.GetOrCreateAddress(database, inputs.ContractAddress)
 				Expect(contractAddressErr).NotTo(HaveOccurred())
 
 				var result VariableResWithAddress

--- a/transformers/test_data/test_helpers.go
+++ b/transformers/test_data/test_helpers.go
@@ -23,9 +23,9 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/makerdao/vdb-mcd-transformers/transformers/shared"
 	"github.com/makerdao/vdb-mcd-transformers/transformers/shared/constants"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
+	"github.com/makerdao/vulcanizedb/libraries/shared/repository"
 	"github.com/makerdao/vulcanizedb/libraries/shared/test_data"
 	"github.com/makerdao/vulcanizedb/pkg/core"
 	"github.com/makerdao/vulcanizedb/pkg/datastore/postgres"
@@ -131,13 +131,13 @@ func getLogCount(db *postgres.DB) int {
 
 func AssignMessageSenderID(log core.EventLog, insertionModel event.InsertionModel, db *postgres.DB) {
 	Expect(len(log.Log.Topics)).Should(BeNumerically(">=", 2))
-	msgSenderID, msgSenderErr := shared.GetOrCreateAddress(log.Log.Topics[1].Hex(), db)
+	msgSenderID, msgSenderErr := repository.GetOrCreateAddress(db, log.Log.Topics[1].Hex())
 	Expect(msgSenderErr).NotTo(HaveOccurred())
 	insertionModel.ColumnValues[constants.MsgSenderColumn] = msgSenderID
 }
 
 func AssignAddressID(log core.EventLog, insertionModel event.InsertionModel, db *postgres.DB) {
-	addressID, addressIDErr := shared.GetOrCreateAddress(log.Log.Address.Hex(), db)
+	addressID, addressIDErr := repository.GetOrCreateAddress(db, log.Log.Address.Hex())
 	Expect(addressIDErr).NotTo(HaveOccurred())
 	insertionModel.ColumnValues[event.AddressFK] = addressID
 }


### PR DESCRIPTION
- no need for wrappers with the same signature as the underlying
  function

This is a bit of a preparatory refactor for extracting shared code to a separate repo. Since the code that these shared functions were using already lives in vDB, it seems like we can probably just depend on that underlying code.