### PR TITLE
Use passed env var for storage diffs source

### DIFF
--- a/dockerfiles/extract_diffs/startup_script.sh
+++ b/dockerfiles/extract_diffs/startup_script.sh
@@ -6,7 +6,7 @@ MISSING_VAR_MESSAGE=" is required and no value was given"
 
 if test -z "$STORAGEDIFFS_SOURCE"
 then
-    echo STORADEDIFFS_SOURCE $MISSING_VAR_MESSAGE
+    echo STORAGEDIFFS_SOURCE $MISSING_VAR_MESSAGE
     exit 1
 fi
 
@@ -46,4 +46,4 @@ fi
 
 # Run extractDiffs
 echo "Running extractDiffs..."
-./vulcanizedb extractDiffs --config config.toml -s STORAGEDIFFS_SOURCE
+./vulcanizedb extractDiffs --config config.toml -s $STORAGEDIFFS_SOURCE


### PR DESCRIPTION
- missing $ meant passing "STORAGEDIFFS_SOURCE" instead of "geth", etc