### PR TITLE
Use bash in extract-diffs startup_script.sh

### DIFF
--- a/dockerfiles/extract_diffs/startup_script.sh
+++ b/dockerfiles/extract_diffs/startup_script.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Starts the extractDiffs command
 
 # Verify required args present

--- a/dockerfiles/extract_diffs/startup_script.sh
+++ b/dockerfiles/extract_diffs/startup_script.sh
@@ -34,7 +34,6 @@ if test -z "$VDB_PG_CONNECT"; then
 fi
 
 # Run the DB migrations
-echo "Connecting with: $VDB_PG_CONNECT"
 ./goose -dir db/migrations postgres "$VDB_PG_CONNECT" up
 psql $VDB_PG_CONNECT -c 'CREATE SCHEMA IF NOT EXISTS maker;'
 ./goose -table maker.goose_db_version -dir db/vdb-mcd-transformers/migrations postgres "$VDB_PG_CONNECT" up


### PR DESCRIPTION
- to be able to parse the file without syntax errors