### PR TITLE
Vdb 1688 gh action extract diffs

### DIFF
--- a/.github/workflows/check_execute
+++ b/.github/workflows/check_execute
@@ -32,6 +32,7 @@ try:
   stdout, _stderr = popen.communicate(timeout=5)
   # For some reason errors seem to go to stdout
   print(f'docker run failed to start image\nout: {stdout}')
+  print(f'docker run failed to start image\nout: {_stderr}')
   sys.exit(popen.returncode)
 except subprocess.TimeoutExpired:
   print(f'started container from image {args.image} with pid {popen.pid}')

--- a/.github/workflows/check_execute
+++ b/.github/workflows/check_execute
@@ -9,6 +9,7 @@ parser.add_argument("--database_name", help="name of the postgres database", def
 parser.add_argument("--database_port", help="port of the postgres database", default="5432")
 parser.add_argument("--database_user", help="username of the postgres database user", default="postgres")
 parser.add_argument("--database_password", help="password of the postgres database user", default="postgres")
+parser.add_argument("--storagediffs_source", help="geth version", default="new-geth")
 parser.add_argument("--wait_time", help="seconds to wait for the container to be ready", default="60", type=int)
 args = parser.parse_args()
 
@@ -23,7 +24,8 @@ popen = subprocess.Popen(['docker', 'run', '-i',
                           '-e', f'DATABASE_PORT={args.database_port}',
                           '-e', f'DATABASE_USER={args.database_user}',
                           '-e', f'DATABASE_PASSWORD={args.database_password}',
-                          '-e', f'CLIENT_IPCPATH={args.client_ipcpath}', args.image],
+                          '-e', f'CLIENT_IPCPATH={args.client_ipcpath}',
+                          '-e', f'STORAGEDIFFS_SOURCE={args.storagediffs_source}', args.image],
                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
 try:

--- a/.github/workflows/check_vdb_command
+++ b/.github/workflows/check_vdb_command
@@ -9,7 +9,7 @@ parser.add_argument("--database_name", help="name of the postgres database", def
 parser.add_argument("--database_port", help="port of the postgres database", default="5432")
 parser.add_argument("--database_user", help="username of the postgres database user", default="postgres")
 parser.add_argument("--database_password", help="password of the postgres database user", default="postgres")
-parser.add_argument("--storagediffs_source", help="geth version", default="new-geth")
+parser.add_argument("--storagediffs_source", help="geth version", default="geth")
 parser.add_argument("--wait_time", help="seconds to wait for the container to be ready", default="60", type=int)
 args = parser.parse_args()
 
@@ -32,6 +32,7 @@ try:
   stdout, _stderr = popen.communicate(timeout=5)
   # For some reason errors seem to go to stdout
   print(f'docker run failed to start image\nout: {stdout}')
+  print(f'docker run failed to start image\nout: {_stderr}')
   sys.exit(popen.returncode)
 except subprocess.TimeoutExpired:
   print(f'started container from image {args.image} with pid {popen.pid}')

--- a/.github/workflows/check_vdb_command
+++ b/.github/workflows/check_vdb_command
@@ -18,7 +18,7 @@ container_id = cp.stdout.decode('utf-8').strip().replace('"', '')
 
 popen = subprocess.Popen(['docker', 'run', '-i',
                           '--network', f'container:{container_id}',
-                          '--name', 'test_execute',
+                          '--name', 'test_vdb_command',
                           '-e', f'DATABASE_NAME={args.database_name}',
                           '-e', f'DATABASE_HOSTNAME={args.database_hostname}',
                           '-e', f'DATABASE_PORT={args.database_port}',
@@ -32,7 +32,6 @@ try:
   stdout, _stderr = popen.communicate(timeout=5)
   # For some reason errors seem to go to stdout
   print(f'docker run failed to start image\nout: {stdout}')
-  print(f'docker run failed to start image\nout: {_stderr}')
   sys.exit(popen.returncode)
 except subprocess.TimeoutExpired:
   print(f'started container from image {args.image} with pid {popen.pid}')
@@ -41,7 +40,7 @@ time_waiting = 0
 while time_waiting <= args.wait_time:
   time.sleep(5)
   cp = subprocess.run(['docker', 'ps',
-                       '--filter', f'name=test_execute',
+                       '--filter', f'name=test_vdb_command',
                        '--format', '"{{.Status}}"'],
                       stdout=subprocess.PIPE, stderr=subprocess.PIPE)
   status = cp.stdout.decode('utf-8').strip().replace('"', '')

--- a/.github/workflows/test-execute.yml
+++ b/.github/workflows/test-execute.yml
@@ -23,6 +23,15 @@ jobs:
           push: false
           tags: makerdao/extract_diffs:gh_actions_test_version
       -
+        name: Run the extract diffs container
+        env:
+          CLIENT_IPCPATH: ${{ secrets.CLIENT_IPCPATH }}
+          DATABASE_USER: ${{ secrets.DATABASE_USER }}
+          DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
+          DATABASE_NAME: ${{ secrets.DATABASE_NAME }} 
+        run: |
+          ./.github/workflows/check_execute makerdao/extract_diffs:gh_actions_test_version --client_ipcpath $CLIENT_IPCPATH --database_user $DATABASE_USER --database_password $DATABASE_PASSWORD --database_name $DATABASE_NAME
+      -
         name: Build execute image
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/test-execute.yml
+++ b/.github/workflows/test-execute.yml
@@ -16,6 +16,13 @@ jobs:
         with:
           python-version: 3.7
       -
+        name: Build extract diffs image
+        uses: docker/build-push-action@v2
+        with:
+          file: ./dockerfiles/extract_diffs/Dockerfile
+          push: false
+          tags: makerdao/extract_diffs:gh_actions_test_version
+      -
         name: Build execute image
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/test-execute.yml
+++ b/.github/workflows/test-execute.yml
@@ -16,22 +16,6 @@ jobs:
         with:
           python-version: 3.7
       -
-        name: Build extract diffs image
-        uses: docker/build-push-action@v2
-        with:
-          file: ./dockerfiles/extract_diffs/Dockerfile
-          push: false
-          tags: makerdao/extract_diffs:gh_actions_test_version
-      -
-        name: Run the extract diffs container
-        env:
-          CLIENT_IPCPATH: ${{ secrets.CLIENT_IPCPATH }}
-          DATABASE_USER: ${{ secrets.DATABASE_USER }}
-          DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
-          DATABASE_NAME: ${{ secrets.DATABASE_NAME }} 
-        run: |
-          ./.github/workflows/check_execute makerdao/extract_diffs:gh_actions_test_version --storagediffs_source new-geth --client_ipcpath $CLIENT_IPCPATH --database_user $DATABASE_USER --database_password $DATABASE_PASSWORD --database_name $DATABASE_NAME
-      -
         name: Build execute image
         uses: docker/build-push-action@v2
         with:
@@ -61,3 +45,45 @@ jobs:
           --health-timeout 5s
           --health-retries 5
   
+  test-extract:
+    runs-on: ubuntu-latest
+    name: Test Extract_Diffs Image
+    steps:
+      -
+       name: Checkout repo
+       uses: actions/checkout@v2
+      -
+       name: Setup Python
+       uses: actions/setup-python@v2
+       with:
+        python-version: 3.7
+      -
+       name: Build extract diffs image
+       uses: docker/build-push-action@v2
+       with:
+          file: ./dockerfiles/extract_diffs/Dockerfile
+          push: false
+          tags: makerdao/extract_diffs:gh_actions_test_version
+      -
+       name: Run the extract diffs container
+       env:
+        CLIENT_IPCPATH: ${{ secrets.CLIENT_IPCPATH }}
+        DATABASE_USER: ${{ secrets.DATABASE_USER }}
+        DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
+        DATABASE_NAME: ${{ secrets.DATABASE_NAME }} 
+       run: |
+         ./.github/workflows/check_execute makerdao/extract_diffs:gh_actions_test_version --storagediffs_source new-geth --client_ipcpath $CLIENT_IPCPATH --database_user $DATABASE_USER --database_password $DATABASE_PASSWORD --database_name $DATABASE_NAME
+
+    services:
+      postgres:
+        image: postgres:11.6
+        env:
+          POSTGRES_USER: ${{ secrets.DATABASE_USER }}
+          POSTGRES_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
+          POSTGRES_DB: ${{ secrets.DATABASE_NAME }}
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      

--- a/.github/workflows/test-execute.yml
+++ b/.github/workflows/test-execute.yml
@@ -30,7 +30,7 @@ jobs:
           DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
           DATABASE_NAME: ${{ secrets.DATABASE_NAME }} 
         run: |
-          ./.github/workflows/check_execute makerdao/extract_diffs:gh_actions_test_version --client_ipcpath $CLIENT_IPCPATH --database_user $DATABASE_USER --database_password $DATABASE_PASSWORD --database_name $DATABASE_NAME
+          ./.github/workflows/check_execute makerdao/extract_diffs:gh_actions_test_version --storagediffs_source new-geth --client_ipcpath $CLIENT_IPCPATH --database_user $DATABASE_USER --database_password $DATABASE_PASSWORD --database_name $DATABASE_NAME
       -
         name: Build execute image
         uses: docker/build-push-action@v2

--- a/.github/workflows/test-vdb-command.yml
+++ b/.github/workflows/test-vdb-command.yml
@@ -1,9 +1,9 @@
-name: TestExecute
+name: TestVDBCommands
 
 on: push
 
 jobs:
-  test:
+  test-execute:
     runs-on: ubuntu-latest
     name: Test Execute Image
     steps:
@@ -23,14 +23,14 @@ jobs:
           push: false
           tags: makerdao/execute:gh_actions_test_version
       -
-        name: Run the docker container
+        name: Run the execute container
         env:
           CLIENT_IPCPATH: ${{ secrets.CLIENT_IPCPATH }}
           DATABASE_USER: ${{ secrets.DATABASE_USER }}
           DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
           DATABASE_NAME: ${{ secrets.DATABASE_NAME }}
         run: |
-          ./.github/workflows/check_execute makerdao/execute:gh_actions_test_version --client_ipcpath $CLIENT_IPCPATH --database_user $DATABASE_USER --database_password $DATABASE_PASSWORD --database_name $DATABASE_NAME
+          ./.github/workflows/check_vdb_command makerdao/execute:gh_actions_test_version --client_ipcpath $CLIENT_IPCPATH --database_user $DATABASE_USER --database_password $DATABASE_PASSWORD --database_name $DATABASE_NAME
 
     services:
       postgres:
@@ -47,7 +47,7 @@ jobs:
   
   test-extract:
     runs-on: ubuntu-latest
-    name: Test Extract_Diffs Image
+    name: Test Extract Diffs Image
     steps:
       -
        name: Checkout repo
@@ -72,7 +72,7 @@ jobs:
         DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
         DATABASE_NAME: ${{ secrets.DATABASE_NAME }} 
        run: |
-         ./.github/workflows/check_execute makerdao/extract_diffs:gh_actions_test_version --storagediffs_source new-geth --client_ipcpath $CLIENT_IPCPATH --database_user $DATABASE_USER --database_password $DATABASE_PASSWORD --database_name $DATABASE_NAME
+         ./.github/workflows/check_vdb_command makerdao/extract_diffs:gh_actions_test_version --storagediffs_source new-geth --client_ipcpath $CLIENT_IPCPATH --database_user $DATABASE_USER --database_password $DATABASE_PASSWORD --database_name $DATABASE_NAME
 
     services:
       postgres:

--- a/.github/workflows/test-vdb-command.yml
+++ b/.github/workflows/test-vdb-command.yml
@@ -67,12 +67,12 @@ jobs:
       -
        name: Run the extract diffs container
        env:
-        CLIENT_IPCPATH: ${{ secrets.CLIENT_IPCPATH }}
+        CLIENT_WSSPATH: ${{ secrets.CLIENT_WSSPATH }}
         DATABASE_USER: ${{ secrets.DATABASE_USER }}
         DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
         DATABASE_NAME: ${{ secrets.DATABASE_NAME }} 
        run: |
-         ./.github/workflows/check_vdb_command makerdao/extract_diffs:gh_actions_test_version --storagediffs_source geth --client_ipcpath $CLIENT_IPCPATH --database_user $DATABASE_USER --database_password $DATABASE_PASSWORD --database_name $DATABASE_NAME
+         ./.github/workflows/check_vdb_command makerdao/extract_diffs:gh_actions_test_version --storagediffs_source geth --client_ipcpath $CLIENT_WSSPATH --database_user $DATABASE_USER --database_password $DATABASE_PASSWORD --database_name $DATABASE_NAME
 
     services:
       postgres:

--- a/.github/workflows/test-vdb-command.yml
+++ b/.github/workflows/test-vdb-command.yml
@@ -72,7 +72,7 @@ jobs:
         DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
         DATABASE_NAME: ${{ secrets.DATABASE_NAME }} 
        run: |
-         ./.github/workflows/check_vdb_command makerdao/extract_diffs:gh_actions_test_version --storagediffs_source new-geth --client_ipcpath $CLIENT_IPCPATH --database_user $DATABASE_USER --database_password $DATABASE_PASSWORD --database_name $DATABASE_NAME
+         ./.github/workflows/check_vdb_command makerdao/extract_diffs:gh_actions_test_version --storagediffs_source geth --client_ipcpath $CLIENT_IPCPATH --database_user $DATABASE_USER --database_password $DATABASE_PASSWORD --database_name $DATABASE_NAME
 
     services:
       postgres:


### PR DESCRIPTION
This adds to Eric's github action and uses his python :snake: magic to verify that the `extract_diffs` container is 'healthy'. 
It runs as a separate job so the container clean up happens between the `execute` and` extract_diffs` tests and enables the jobs to run in parallel. A new secret was added to support a `wss` vs `http` path for geth when running `extract_diffs`.

as a side note, trying to run [github actions locally](https://github.com/nektos/act/) fails when using this repo due to this [issue](https://github.com/nektos/act/issues/418)