### PR TITLE
Log Errors when ValidateMigrations cannot parse the response

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,14 @@ before_install:
 script:
 - set -e
 - scripts/check_config.sh
-- env GO111MODULE=on make validatemigrationorder
+- echo $TRAVIS_PULL_REQUEST
+- |
+  if [[ $TRAVIS_PULL_REQUEST != "false" ]]; then
+    env GO111MODULE=on make validatemigrationorder
+  fi
 - env GO111MODULE=on make test
 - env GO111MODULE=on make integrationtest
+
 deploy:
 - provider: script
   script: bash ./.travis/deploy.sh staging

--- a/cmd/checkMigrations.go
+++ b/cmd/checkMigrations.go
@@ -114,7 +114,7 @@ func getGithubFileNames() ([]string, error) {
 	jsonErr := json.Unmarshal(body, &files)
 
 	if jsonErr != nil {
-		return []string{}, fmt.Errorf("Failed to unmarshal %s, %w", string(body), jsonErr)
+		return []string{}, fmt.Errorf("failed to unmarshal %s, %w", string(body), jsonErr)
 	}
 
 	var namedFiles = make([]NamedFile, len(files))

--- a/cmd/checkMigrations.go
+++ b/cmd/checkMigrations.go
@@ -114,7 +114,7 @@ func getGithubFileNames() ([]string, error) {
 	jsonErr := json.Unmarshal(body, &files)
 
 	if jsonErr != nil {
-		return []string{}, fmt.Errorf(errorContext, jsonErr)
+		return []string{}, fmt.Errorf("Failed to unmarshal %s, %w", string(body), jsonErr)
 	}
 
 	var namedFiles = make([]NamedFile, len(files))


### PR DESCRIPTION
Sometimes Github is erroring on unmarshal, so turn it into a straight string for debugging.

In addition, only run validatemigrations on a PR. This will help with occasional API throttling we run into with github.