### PR TITLE
[DO NOT MERGE] Rescan last 200000 blocks for diffs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ before_install:
 - docker build -f dockerfiles/gomoderator/Dockerfile .
 script:
 - set -e
-- scripts/check_config.sh
 - env GO111MODULE=on make validatemigrationorder
 - env GO111MODULE=on make test
 - env GO111MODULE=on make integrationtest

--- a/dockerfiles/execute/Dockerfile
+++ b/dockerfiles/execute/Dockerfile
@@ -57,7 +57,7 @@ COPY --from=builder /go/src/github.com/makerdao/vdb-mcd-transformers/plugins/tra
 COPY --from=builder /go/src/github.com/makerdao/vdb-mcd-transformers/dockerfiles/wait-for-it.sh .
 COPY --from=builder /go/src/github.com/makerdao/vdb-mcd-transformers/dockerfiles/execute/run_migrations.sh .
 
-HEALTHCHECK CMD grep -q "event watcher starting" /tmp/execute_health_check && grep -q "storage watcher starting" /tmp/execute_health_check
+HEALTHCHECK CMD grep -q "storage watcher starting" /tmp/execute_health_check
 
 # need to execute with a shell to access env variables
 CMD ["./startup_script.sh"]

--- a/dockerfiles/execute/Dockerfile
+++ b/dockerfiles/execute/Dockerfile
@@ -1,6 +1,8 @@
-FROM golang:alpine as builder
+FROM golang:1.15.5-buster as builder
 
-RUN apk --update --no-cache add make git g++ linux-headers
+RUN apt-get update && \
+    apt-get install -y \
+    make git g++ linux-headers-amd64
 
 # Build migration tool
 WORKDIR /go
@@ -29,20 +31,16 @@ RUN make plugin PACKAGE=github.com/makerdao/vdb-mcd-transformers \
 
 
 # app container
-FROM golang:alpine
+FROM golang:1.15.5-buster
 WORKDIR /go/src/github.com/makerdao/vulcanizedb
 
-# add certificates for node requests via https
-# bash for wait-for-it
-RUN apk update \
-        && apk upgrade \
-        && apk add --no-cache \
+RUN apt-get update \
+        && apt-get install -y \
         ca-certificates \
         bash \
+        busybox \
+        postgresql-client \
         && update-ca-certificates 2>/dev/null || true
-
-# add go so we can build the plugin
-RUN apk add --update --no-cache git g++ linux-headers
 
 ARG CONFIG_FILE=environments/mcdTransformers.toml
 

--- a/dockerfiles/execute/startup_script.sh
+++ b/dockerfiles/execute/startup_script.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 source run_migrations.sh
 
 echo "Starting transformer execution from 200000 blocks back"

--- a/dockerfiles/execute/startup_script.sh
+++ b/dockerfiles/execute/startup_script.sh
@@ -1,12 +1,7 @@
 #!/bin/sh
 source run_migrations.sh
 
-DIFF_STARTING_BLOCK="-1"
-
-if test -n "$DIFF_BLOCK_FROM_HEAD_OF_CHAIN"; then
-    DIFF_STARTING_BLOCK=$DIFF_BLOCK_FROM_HEAD_OF_CHAIN
-fi
-
-echo "Starting transformer execution from $DIFF_STARTING_BLOCK blocks back"
+echo "Starting transformer execution from 200000 blocks back"
 # Fire up execute
-./vulcanizedb execute --config config.toml -d $DIFF_STARTING_BLOCK
+# rescanning diffs in last 200,000 to cover missed diffs between blocks 11234894 and 11315955
+./vulcanizedb execute --config config.toml -d 200000

--- a/environments/mcdTransformers.toml
+++ b/environments/mcdTransformers.toml
@@ -64,6 +64,20 @@
     "vow"
   ]
 
+  [exporter.bite]
+    contracts = ["MCD_CAT_1_0_0", "MCD_CAT_1_1_0"]
+    migrations = "db/migrations"
+    path = "transformers/events/bite/initializer"
+    rank = "0"
+    repository = "github.com/makerdao/vdb-mcd-transformers"
+    type = "eth_event"
+  [exporter.cat_file_flip]
+    contracts = ["MCD_CAT_1_0_0", "MCD_CAT_1_1_0"]
+    migrations = "db/migrations"
+    path = "transformers/events/cat_file/flip/initializer"
+    rank = "0"
+    repository = "github.com/makerdao/vdb-mcd-transformers"
+    type = "eth_event"
   [exporter.cat_v1_0_0]
     migrations = "db/migrations"
     path = "transformers/storage/cat/v1_0_0/initializer"
@@ -82,6 +96,13 @@
     rank = "0"
     repository = "github.com/makerdao/vdb-mcd-transformers"
     type = "eth_storage"
+  [exporter.deal]
+    contracts = ["MCD_FLAP_1_0_0", "MCD_FLAP_1_0_9", "MCD_FLIP_BAT_A_1_0_0", "MCD_FLIP_BAT_A_1_0_9", "MCD_FLIP_BAT_A_1_1_0", "MCD_FLIP_COMP_A_1_1_2", "MCD_FLIP_ETH_A_1_0_0", "MCD_FLIP_ETH_A_1_0_9", "MCD_FLIP_ETH_A_1_1_0", "MCD_FLIP_ETH_B_1_1_3", "MCD_FLIP_KNC_A_1_0_8", "MCD_FLIP_KNC_A_1_0_9", "MCD_FLIP_KNC_A_1_1_0", "MCD_FLIP_LINK_A_1_1_2", "MCD_FLIP_LRC_A_1_1_2", "MCD_FLIP_MANA_A_1_0_9", "MCD_FLIP_MANA_A_1_1_0", "MCD_FLIP_PAXUSD_A_1_1_1", "MCD_FLIP_SAI_1_0_0", "MCD_FLIP_TUSD_A_1_0_7", "MCD_FLIP_TUSD_A_1_0_9", "MCD_FLIP_TUSD_A_1_1_0", "MCD_FLIP_USDC_A_1_0_4", "MCD_FLIP_USDC_A_1_0_9", "MCD_FLIP_USDC_A_1_1_0", "MCD_FLIP_USDC_B_1_0_7", "MCD_FLIP_USDC_B_1_0_9", "MCD_FLIP_USDC_B_1_1_0", "MCD_FLIP_USDT_A_1_1_1", "MCD_FLIP_WBTC_A_1_0_6", "MCD_FLIP_WBTC_A_1_0_9", "MCD_FLIP_WBTC_A_1_1_0", "MCD_FLIP_ZRX_A_1_0_8", "MCD_FLIP_ZRX_A_1_0_9", "MCD_FLIP_ZRX_A_1_1_0", "MCD_FLOP_1_0_1", "MCD_FLOP_1_0_9", "MCD_FLIP_BAL_A_1_1_14", "MCD_FLIP_YFI_A_1_1_14"]
+    migrations = "db/migrations"
+    path = "transformers/events/deal/initializer"
+    rank = "0"
+    repository = "github.com/makerdao/vdb-mcd-transformers"
+    type = "eth_event"
   [exporter.flap_v1_0_0]
     migrations = "db/migrations"
     path = "transformers/storage/flap/initializers/v1_0_0"

--- a/environments/mcdTransformers.toml
+++ b/environments/mcdTransformers.toml
@@ -1,57 +1,69 @@
 [exporter]
   home = "github.com/makerdao/vulcanizedb"
   name = "transformerExporter"
-  save = false
-  transformerNames = ["cat_v1_0_0", "cat_v1_1_0", "cdp_manager", "flap_v1_0_0", "flap_v1_0_9", "flip_bat_a_v1_0_0", "flip_bat_a_v1_0_9", "flip_bat_a_v1_1_0", "flip_comp_a_v1_1_2", "flip_eth_a_v1_0_0", "flip_eth_a_v1_0_9", "flip_eth_a_v1_1_0", "flip_eth_b_v1_1_3", "flip_knc_a_v1_0_8", "flip_knc_a_v1_0_9", "flip_knc_a_v1_1_0", "flip_link_a_v1_1_2", "flip_lrc_a_v1_1_2", "flip_mana_a_v1_0_9", "flip_mana_a_v1_1_0", "flip_paxusd_a_v1_1_1", "flip_sai_v1_0_0", "flip_tusd_a_v1_0_7", "flip_tusd_a_v1_0_9", "flip_tusd_a_v1_1_0", "flip_usdc_a_v1_0_4", "flip_usdc_a_v1_0_9", "flip_usdc_a_v1_1_0", "flip_usdc_b_v1_0_7", "flip_usdc_b_v1_0_9", "flip_usdc_b_v1_1_0", "flip_usdt_a_v1_1_1", "flip_wbtc_a_v1_0_6", "flip_wbtc_a_v1_0_9", "flip_wbtc_a_v1_1_0", "flip_zrx_a_v1_0_8", "flip_zrx_a_v1_0_9", "flip_zrx_a_v1_1_0", "flop_v1_0_1", "flop_v1_0_9", "jug", "median_bat_v1_0_0", "median_comp_v1_1_2", "median_eth_v1_0_0", "median_knc_v1_0_8", "median_link_v1_1_2", "median_lrc_v1_1_2", "median_mana_v1_0_9", "median_usdt_v1_0_4", "median_wbtc_v1_0_6", "median_zrx_v1_0_8", "pot", "spot", "vat", "vow", "auction_file", "bite", "cat_claw", "cat_file_box", "cat_file_chop_lump", "cat_file_flip", "cat_file_vow", "deal", "dent", "deny", "flap_kick", "flip_file_cat", "flip_kick", "flop_kick", "jug_drip", "jug_file_base", "jug_file_ilk", "jug_file_vow", "jug_init", "log_bump", "log_buy_enabled", "log_delete", "log_insert", "log_item_update", "log_kill", "log_make", "log_matching_enabled", "log_median_price", "log_min_sell", "log_sorted_offer", "log_take", "log_trade", "log_unsorted_offer", "log_value", "median_diss_batch", "median_diss_single", "median_drop", "median_kiss_batch", "median_kiss_single", "median_lift", "new_cdp", "osm_change", "pot_cage", "pot_drip", "pot_exit", "pot_file_dsr", "pot_file_vow", "pot_join", "rely", "set_min_sell", "spot_file_mat", "spot_file_par", "spot_file_pip", "spot_poke", "tend", "tick", "vat_deny", "vat_file_debt_ceiling", "vat_file_ilk", "vat_flux", "vat_fold", "vat_fork", "vat_frob", "vat_grab", "vat_heal", "vat_hope", "vat_init", "vat_move", "vat_nope", "vat_rely", "vat_slip", "vat_suck", "vow_fess", "vow_file", "vow_file_auction_address", "vow_flog", "vow_heal", "yank", "flip_bal_a_v1_1_14", "median_bal_v1_1_14", "flip_yfi_a_v1_1_14", "median_yfi_v1_1_14"]
-  [exporter.auction_file]
-    contracts = ["MCD_FLAP_1_0_0", "MCD_FLAP_1_0_9", "MCD_FLIP_BAT_A_1_0_0", "MCD_FLIP_BAT_A_1_0_9", "MCD_FLIP_BAT_A_1_1_0", "MCD_FLIP_COMP_A_1_1_2", "MCD_FLIP_ETH_A_1_0_0", "MCD_FLIP_ETH_A_1_0_9", "MCD_FLIP_ETH_A_1_1_0", "MCD_FLIP_ETH_B_1_1_3", "MCD_FLIP_KNC_A_1_0_8", "MCD_FLIP_KNC_A_1_0_9", "MCD_FLIP_KNC_A_1_1_0", "MCD_FLIP_LINK_A_1_1_2", "MCD_FLIP_LRC_A_1_1_2", "MCD_FLIP_MANA_A_1_0_9", "MCD_FLIP_MANA_A_1_1_0", "MCD_FLIP_PAXUSD_A_1_1_1", "MCD_FLIP_SAI_1_0_0", "MCD_FLIP_TUSD_A_1_0_7", "MCD_FLIP_TUSD_A_1_0_9", "MCD_FLIP_TUSD_A_1_1_0", "MCD_FLIP_USDC_A_1_0_4", "MCD_FLIP_USDC_A_1_0_9", "MCD_FLIP_USDC_A_1_1_0", "MCD_FLIP_USDC_B_1_0_7", "MCD_FLIP_USDC_B_1_0_9", "MCD_FLIP_USDC_B_1_1_0", "MCD_FLIP_USDT_A_1_1_1", "MCD_FLIP_WBTC_A_1_0_6", "MCD_FLIP_WBTC_A_1_0_9", "MCD_FLIP_WBTC_A_1_1_0", "MCD_FLIP_ZRX_A_1_0_8", "MCD_FLIP_ZRX_A_1_0_9", "MCD_FLIP_ZRX_A_1_1_0", "MCD_FLOP_1_0_1", "MCD_FLOP_1_0_9", "MCD_FLIP_BAL_A_1_1_14", "MCD_FLIP_YFI_A_1_1_14"]
-    migrations = "db/migrations"
-    path = "transformers/events/auction_file/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.bite]
-    contracts = ["MCD_CAT_1_0_0", "MCD_CAT_1_1_0"]
-    migrations = "db/migrations"
-    path = "transformers/events/bite/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.cat_claw]
-    contracts = ["MCD_CAT_1_1_0"]
-    migrations = "db/migrations"
-    path = "transformers/events/cat_claw/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.cat_file_box]
-    contracts = ["MCD_CAT_1_1_0"]
-    migrations = "db/migrations"
-    path = "transformers/events/cat_file/box/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.cat_file_chop_lump]
-    contracts = ["MCD_CAT_1_0_0", "MCD_CAT_1_1_0"]
-    migrations = "db/migrations"
-    path = "transformers/events/cat_file/chop_lump/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.cat_file_flip]
-    contracts = ["MCD_CAT_1_0_0", "MCD_CAT_1_1_0"]
-    migrations = "db/migrations"
-    path = "transformers/events/cat_file/flip/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.cat_file_vow]
-    contracts = ["MCD_CAT_1_0_0", "MCD_CAT_1_1_0"]
-    migrations = "db/migrations"
-    path = "transformers/events/cat_file/vow/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
+  save = true
+  transformerNames = [
+    "cat_v1_0_0",
+    "cat_v1_1_0",
+    "cdp_manager",
+    "flap_v1_0_0",
+    "flap_v1_0_9",
+    "flip_bal_a_v1_1_14",
+    "flip_bat_a_v1_0_0",
+    "flip_bat_a_v1_0_9",
+    "flip_bat_a_v1_1_0",
+    "flip_comp_a_v1_1_2",
+    "flip_eth_a_v1_0_0",
+    "flip_eth_a_v1_0_9",
+    "flip_eth_a_v1_1_0",
+    "flip_eth_b_v1_1_3",
+    "flip_knc_a_v1_0_8",
+    "flip_knc_a_v1_0_9",
+    "flip_knc_a_v1_1_0",
+    "flip_link_a_v1_1_2",
+    "flip_lrc_a_v1_1_2",
+    "flip_mana_a_v1_0_9",
+    "flip_mana_a_v1_1_0",
+    "flip_paxusd_a_v1_1_1",
+    "flip_sai_v1_0_0",
+    "flip_tusd_a_v1_0_7",
+    "flip_tusd_a_v1_0_9",
+    "flip_tusd_a_v1_1_0",
+    "flip_usdc_a_v1_0_4",
+    "flip_usdc_a_v1_0_9",
+    "flip_usdc_a_v1_1_0",
+    "flip_usdc_b_v1_0_7",
+    "flip_usdc_b_v1_0_9",
+    "flip_usdc_b_v1_1_0",
+    "flip_usdt_a_v1_1_1",
+    "flip_wbtc_a_v1_0_6",
+    "flip_wbtc_a_v1_0_9",
+    "flip_wbtc_a_v1_1_0",
+    "flip_yfi_a_v1_1_14",
+    "flip_zrx_a_v1_0_8",
+    "flip_zrx_a_v1_0_9",
+    "flip_zrx_a_v1_1_0",
+    "flop_v1_0_1",
+    "flop_v1_0_9",
+    "jug",
+    "median_bal_v1_1_14",
+    "median_bat_v1_0_0",
+    "median_comp_v1_1_2",
+    "median_eth_v1_0_0",
+    "median_knc_v1_0_8",
+    "median_link_v1_1_2",
+    "median_lrc_v1_1_2",
+    "median_mana_v1_0_9",
+    "median_usdt_v1_0_4",
+    "median_wbtc_v1_0_6",
+    "median_yfi_v1_1_14",
+    "median_zrx_v1_0_8",
+    "pot",
+    "spot",
+    "vat",
+    "vow"
+  ]
+
   [exporter.cat_v1_0_0]
     migrations = "db/migrations"
     path = "transformers/storage/cat/v1_0_0/initializer"
@@ -70,34 +82,6 @@
     rank = "0"
     repository = "github.com/makerdao/vdb-mcd-transformers"
     type = "eth_storage"
-  [exporter.deal]
-    contracts = ["MCD_FLAP_1_0_0", "MCD_FLAP_1_0_9", "MCD_FLIP_BAT_A_1_0_0", "MCD_FLIP_BAT_A_1_0_9", "MCD_FLIP_BAT_A_1_1_0", "MCD_FLIP_COMP_A_1_1_2", "MCD_FLIP_ETH_A_1_0_0", "MCD_FLIP_ETH_A_1_0_9", "MCD_FLIP_ETH_A_1_1_0", "MCD_FLIP_ETH_B_1_1_3", "MCD_FLIP_KNC_A_1_0_8", "MCD_FLIP_KNC_A_1_0_9", "MCD_FLIP_KNC_A_1_1_0", "MCD_FLIP_LINK_A_1_1_2", "MCD_FLIP_LRC_A_1_1_2", "MCD_FLIP_MANA_A_1_0_9", "MCD_FLIP_MANA_A_1_1_0", "MCD_FLIP_PAXUSD_A_1_1_1", "MCD_FLIP_SAI_1_0_0", "MCD_FLIP_TUSD_A_1_0_7", "MCD_FLIP_TUSD_A_1_0_9", "MCD_FLIP_TUSD_A_1_1_0", "MCD_FLIP_USDC_A_1_0_4", "MCD_FLIP_USDC_A_1_0_9", "MCD_FLIP_USDC_A_1_1_0", "MCD_FLIP_USDC_B_1_0_7", "MCD_FLIP_USDC_B_1_0_9", "MCD_FLIP_USDC_B_1_1_0", "MCD_FLIP_USDT_A_1_1_1", "MCD_FLIP_WBTC_A_1_0_6", "MCD_FLIP_WBTC_A_1_0_9", "MCD_FLIP_WBTC_A_1_1_0", "MCD_FLIP_ZRX_A_1_0_8", "MCD_FLIP_ZRX_A_1_0_9", "MCD_FLIP_ZRX_A_1_1_0", "MCD_FLOP_1_0_1", "MCD_FLOP_1_0_9", "MCD_FLIP_BAL_A_1_1_14", "MCD_FLIP_YFI_A_1_1_14"]
-    migrations = "db/migrations"
-    path = "transformers/events/deal/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.dent]
-    contracts = ["MCD_FLIP_BAT_A_1_0_0", "MCD_FLIP_BAT_A_1_0_9", "MCD_FLIP_BAT_A_1_1_0", "MCD_FLIP_COMP_A_1_1_2", "MCD_FLIP_ETH_A_1_0_0", "MCD_FLIP_ETH_A_1_0_9", "MCD_FLIP_ETH_A_1_1_0", "MCD_FLIP_ETH_B_1_1_3", "MCD_FLIP_KNC_A_1_0_8", "MCD_FLIP_KNC_A_1_0_9", "MCD_FLIP_KNC_A_1_1_0", "MCD_FLIP_LINK_A_1_1_2", "MCD_FLIP_LRC_A_1_1_2", "MCD_FLIP_MANA_A_1_0_9", "MCD_FLIP_MANA_A_1_1_0", "MCD_FLIP_PAXUSD_A_1_1_1", "MCD_FLIP_SAI_1_0_0", "MCD_FLIP_TUSD_A_1_0_7", "MCD_FLIP_TUSD_A_1_0_9", "MCD_FLIP_TUSD_A_1_1_0", "MCD_FLIP_USDC_A_1_0_4", "MCD_FLIP_USDC_A_1_0_9", "MCD_FLIP_USDC_A_1_1_0", "MCD_FLIP_USDC_B_1_0_7", "MCD_FLIP_USDC_B_1_0_9", "MCD_FLIP_USDC_B_1_1_0", "MCD_FLIP_USDT_A_1_1_1", "MCD_FLIP_WBTC_A_1_0_6", "MCD_FLIP_WBTC_A_1_0_9", "MCD_FLIP_WBTC_A_1_1_0", "MCD_FLIP_ZRX_A_1_0_8", "MCD_FLIP_ZRX_A_1_0_9", "MCD_FLIP_ZRX_A_1_1_0", "MCD_FLOP_1_0_1", "MCD_FLOP_1_0_9", "MCD_FLIP_BAL_A_1_1_14", "MCD_FLIP_YFI_A_1_1_14"]
-    migrations = "db/migrations"
-    path = "transformers/events/dent/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.deny]
-    contracts = ["MCD_CAT_1_0_0", "MCD_CAT_1_1_0", "MCD_FLAP_1_0_0", "MCD_FLAP_1_0_9", "MCD_FLIP_BAT_A_1_0_0", "MCD_FLIP_BAT_A_1_0_9", "MCD_FLIP_BAT_A_1_1_0", "MCD_FLIP_COMP_A_1_1_2", "MCD_FLIP_ETH_A_1_0_0", "MCD_FLIP_ETH_A_1_0_9", "MCD_FLIP_ETH_A_1_1_0", "MCD_FLIP_ETH_B_1_1_3", "MCD_FLIP_KNC_A_1_0_8", "MCD_FLIP_KNC_A_1_0_9", "MCD_FLIP_KNC_A_1_1_0", "MCD_FLIP_LINK_A_1_1_2", "MCD_FLIP_LRC_A_1_1_2", "MCD_FLIP_MANA_A_1_0_9", "MCD_FLIP_MANA_A_1_1_0", "MCD_FLIP_PAXUSD_A_1_1_1", "MCD_FLIP_SAI_1_0_0", "MCD_FLIP_TUSD_A_1_0_7", "MCD_FLIP_TUSD_A_1_0_9", "MCD_FLIP_TUSD_A_1_1_0", "MCD_FLIP_USDC_A_1_0_4", "MCD_FLIP_USDC_A_1_0_9", "MCD_FLIP_USDC_A_1_1_0", "MCD_FLIP_USDC_B_1_0_7", "MCD_FLIP_USDC_B_1_0_9", "MCD_FLIP_USDC_B_1_1_0", "MCD_FLIP_USDT_A_1_1_1", "MCD_FLIP_WBTC_A_1_0_6", "MCD_FLIP_WBTC_A_1_0_9", "MCD_FLIP_WBTC_A_1_1_0", "MCD_FLIP_ZRX_A_1_0_8", "MCD_FLIP_ZRX_A_1_0_9", "MCD_FLIP_ZRX_A_1_1_0", "MCD_FLOP_1_0_1", "MCD_FLOP_1_0_9", "MCD_JUG", "MCD_POT", "MCD_SPOT", "MCD_VOW", "MEDIAN_BAT_1_0_0", "MEDIAN_COMP_1_1_2", "MEDIAN_ETH_1_0_0", "MEDIAN_KNC_1_0_8", "MEDIAN_LINK_1_1_2", "MEDIAN_LRC_1_1_2", "MEDIAN_MANA_1_0_9", "MEDIAN_USDT_1_0_4", "MEDIAN_WBTC_1_0_6", "MEDIAN_ZRX_1_0_8", "OSM_BAT", "OSM_COMP", "OSM_ETH", "OSM_KNC", "OSM_LINK", "OSM_LRC", "OSM_MANA", "OSM_USDT", "OSM_WBTC", "OSM_ZRX", "MCD_FLIP_BAL_A_1_1_14", "MEDIAN_BAL_1_1_14", "OSM_BAL", "MCD_FLIP_YFI_A_1_1_14", "MEDIAN_YFI_1_1_14", "OSM_YFI"]
-    migrations = "db/migrations"
-    path = "transformers/events/auth/deny_initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.flap_kick]
-    contracts = ["MCD_FLAP_1_0_0", "MCD_FLAP_1_0_9"]
-    migrations = "db/migrations"
-    path = "transformers/events/flap_kick/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
   [exporter.flap_v1_0_0]
     migrations = "db/migrations"
     path = "transformers/storage/flap/initializers/v1_0_0"
@@ -164,20 +148,6 @@
     rank = "0"
     repository = "github.com/makerdao/vdb-mcd-transformers"
     type = "eth_storage"
-  [exporter.flip_file_cat]
-    contracts = ["MCD_FLIP_BAT_A_1_1_0", "MCD_FLIP_COMP_A_1_1_2", "MCD_FLIP_ETH_A_1_1_0", "MCD_FLIP_ETH_B_1_1_3", "MCD_FLIP_KNC_A_1_1_0", "MCD_FLIP_LINK_A_1_1_2", "MCD_FLIP_LRC_A_1_1_2", "MCD_FLIP_MANA_A_1_1_0", "MCD_FLIP_PAXUSD_A_1_1_1", "MCD_FLIP_TUSD_A_1_1_0", "MCD_FLIP_USDC_A_1_1_0", "MCD_FLIP_USDC_B_1_1_0", "MCD_FLIP_USDT_A_1_1_1", "MCD_FLIP_WBTC_A_1_1_0", "MCD_FLIP_ZRX_A_1_1_0", "MCD_FLIP_BAL_A_1_1_14", "MCD_FLIP_YFI_A_1_1_14"]
-    migrations = "db/migrations"
-    path = "transformers/events/flip_file/cat/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.flip_kick]
-    contracts = ["MCD_FLIP_BAT_A_1_0_0", "MCD_FLIP_BAT_A_1_0_9", "MCD_FLIP_BAT_A_1_1_0", "MCD_FLIP_COMP_A_1_1_2", "MCD_FLIP_ETH_A_1_0_0", "MCD_FLIP_ETH_A_1_0_9", "MCD_FLIP_ETH_A_1_1_0", "MCD_FLIP_ETH_B_1_1_3", "MCD_FLIP_KNC_A_1_0_8", "MCD_FLIP_KNC_A_1_0_9", "MCD_FLIP_KNC_A_1_1_0", "MCD_FLIP_LINK_A_1_1_2", "MCD_FLIP_LRC_A_1_1_2", "MCD_FLIP_MANA_A_1_0_9", "MCD_FLIP_MANA_A_1_1_0", "MCD_FLIP_PAXUSD_A_1_1_1", "MCD_FLIP_SAI_1_0_0", "MCD_FLIP_TUSD_A_1_0_7", "MCD_FLIP_TUSD_A_1_0_9", "MCD_FLIP_TUSD_A_1_1_0", "MCD_FLIP_USDC_A_1_0_4", "MCD_FLIP_USDC_A_1_0_9", "MCD_FLIP_USDC_A_1_1_0", "MCD_FLIP_USDC_B_1_0_7", "MCD_FLIP_USDC_B_1_0_9", "MCD_FLIP_USDC_B_1_1_0", "MCD_FLIP_USDT_A_1_1_1", "MCD_FLIP_WBTC_A_1_0_6", "MCD_FLIP_WBTC_A_1_0_9", "MCD_FLIP_WBTC_A_1_1_0", "MCD_FLIP_ZRX_A_1_0_8", "MCD_FLIP_ZRX_A_1_0_9", "MCD_FLIP_ZRX_A_1_1_0", "MCD_FLIP_BAL_A_1_1_14", "MCD_FLIP_YFI_A_1_1_14"]
-    migrations = "db/migrations"
-    path = "transformers/events/flip_kick/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
   [exporter.flip_knc_a_v1_0_8]
     migrations = "db/migrations"
     path = "transformers/storage/flip/initializers/knc_a/v1_0_8"
@@ -334,13 +304,6 @@
     rank = "0"
     repository = "github.com/makerdao/vdb-mcd-transformers"
     type = "eth_storage"
-  [exporter.flop_kick]
-    contracts = ["MCD_FLOP_1_0_1", "MCD_FLOP_1_0_9"]
-    migrations = "db/migrations"
-    path = "transformers/events/flop_kick/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
   [exporter.flop_v1_0_1]
     migrations = "db/migrations"
     path = "transformers/storage/flop/initializers/v1_0_1"
@@ -359,146 +322,6 @@
     rank = "0"
     repository = "github.com/makerdao/vdb-mcd-transformers"
     type = "eth_storage"
-  [exporter.jug_drip]
-    contracts = ["MCD_JUG"]
-    migrations = "db/migrations"
-    path = "transformers/events/jug_drip/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.jug_file_base]
-    contracts = ["MCD_JUG"]
-    migrations = "db/migrations"
-    path = "transformers/events/jug_file/base/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.jug_file_ilk]
-    contracts = ["MCD_JUG"]
-    migrations = "db/migrations"
-    path = "transformers/events/jug_file/ilk/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.jug_file_vow]
-    contracts = ["MCD_JUG"]
-    migrations = "db/migrations"
-    path = "transformers/events/jug_file/vow/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.jug_init]
-    contracts = ["MCD_JUG"]
-    migrations = "db/migrations"
-    path = "transformers/events/jug_init/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.log_bump]
-    contracts = ["OASIS_MATCHING_MARKET_ONE", "OASIS_MATCHING_MARKET_TWO"]
-    migrations = "db/migrations"
-    path = "transformers/events/log_bump/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.log_buy_enabled]
-    contracts = ["OASIS_MATCHING_MARKET_ONE", "OASIS_MATCHING_MARKET_TWO"]
-    migrations = "db/migrations"
-    path = "transformers/events/log_buy_enabled/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.log_delete]
-    contracts = ["OASIS_MATCHING_MARKET_ONE", "OASIS_MATCHING_MARKET_TWO"]
-    migrations = "db/migrations"
-    path = "transformers/events/log_delete/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.log_insert]
-    contracts = ["OASIS_MATCHING_MARKET_ONE", "OASIS_MATCHING_MARKET_TWO"]
-    migrations = "db/migrations"
-    path = "transformers/events/log_insert/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.log_item_update]
-    contracts = ["OASIS_MATCHING_MARKET_ONE", "OASIS_MATCHING_MARKET_TWO"]
-    migrations = "db/migrations"
-    path = "transformers/events/log_item_update/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.log_kill]
-    contracts = ["OASIS_MATCHING_MARKET_ONE", "OASIS_MATCHING_MARKET_TWO"]
-    migrations = "db/migrations"
-    path = "transformers/events/log_kill/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.log_make]
-    contracts = ["OASIS_MATCHING_MARKET_ONE", "OASIS_MATCHING_MARKET_TWO"]
-    migrations = "db/migrations"
-    path = "transformers/events/log_make/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.log_matching_enabled]
-    contracts = ["OASIS_MATCHING_MARKET_ONE", "OASIS_MATCHING_MARKET_TWO"]
-    migrations = "db/migrations"
-    path = "transformers/events/log_matching_enabled/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.log_median_price]
-    contracts = ["MEDIAN_BAT_1_0_0", "MEDIAN_COMP_1_1_2", "MEDIAN_ETH_1_0_0", "MEDIAN_KNC_1_0_8", "MEDIAN_LINK_1_1_2", "MEDIAN_LRC_1_1_2", "MEDIAN_MANA_1_0_9", "MEDIAN_USDT_1_0_4", "MEDIAN_WBTC_1_0_6", "MEDIAN_ZRX_1_0_8", "MEDIAN_BAL_1_1_14", "MEDIAN_YFI_1_1_14"]
-    migrations = "db/migrations"
-    path = "transformers/events/log_median_price/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.log_min_sell]
-    contracts = ["OASIS_MATCHING_MARKET_ONE", "OASIS_MATCHING_MARKET_TWO"]
-    migrations = "db/migrations"
-    path = "transformers/events/log_min_sell/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.log_sorted_offer]
-    contracts = ["OASIS_MATCHING_MARKET_ONE", "OASIS_MATCHING_MARKET_TWO"]
-    migrations = "db/migrations"
-    path = "transformers/events/log_sorted_offer/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.log_take]
-    contracts = ["OASIS_MATCHING_MARKET_ONE", "OASIS_MATCHING_MARKET_TWO"]
-    migrations = "db/migrations"
-    path = "transformers/events/log_take/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.log_trade]
-    contracts = ["OASIS_MATCHING_MARKET_ONE", "OASIS_MATCHING_MARKET_TWO"]
-    migrations = "db/migrations"
-    path = "transformers/events/log_trade/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.log_unsorted_offer]
-    contracts = ["OASIS_MATCHING_MARKET_ONE", "OASIS_MATCHING_MARKET_TWO"]
-    migrations = "db/migrations"
-    path = "transformers/events/log_unsorted_offer/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.log_value]
-    contracts = ["OSM_BAT", "OSM_COMP", "OSM_ETH", "OSM_KNC", "OSM_LINK", "OSM_LRC", "OSM_MANA", "OSM_USDT", "OSM_WBTC", "OSM_ZRX", "OSM_BAL", "OSM_YFI"]
-    migrations = "db/migrations"
-    path = "transformers/events/log_value/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
   [exporter.median_bal_v1_1_14]
     migrations = "db/migrations"
     path = "transformers/storage/median/initializers/median_bal/v1_1_14"
@@ -517,60 +340,18 @@
     rank = "0"
     repository = "github.com/makerdao/vdb-mcd-transformers"
     type = "eth_storage"
-  [exporter.median_diss_batch]
-    contracts = ["MEDIAN_BAT_1_0_0", "MEDIAN_COMP_1_1_2", "MEDIAN_ETH_1_0_0", "MEDIAN_KNC_1_0_8", "MEDIAN_LINK_1_1_2", "MEDIAN_LRC_1_1_2", "MEDIAN_MANA_1_0_9", "MEDIAN_USDT_1_0_4", "MEDIAN_WBTC_1_0_6", "MEDIAN_ZRX_1_0_8", "MEDIAN_BAL_1_1_14", "MEDIAN_YFI_1_1_14"]
-    migrations = "db/migrations"
-    path = "transformers/events/median_diss/batch/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.median_diss_single]
-    contracts = ["MEDIAN_BAT_1_0_0", "MEDIAN_COMP_1_1_2", "MEDIAN_ETH_1_0_0", "MEDIAN_KNC_1_0_8", "MEDIAN_LINK_1_1_2", "MEDIAN_LRC_1_1_2", "MEDIAN_MANA_1_0_9", "MEDIAN_USDT_1_0_4", "MEDIAN_WBTC_1_0_6", "MEDIAN_ZRX_1_0_8", "MEDIAN_BAL_1_1_14", "MEDIAN_YFI_1_1_14"]
-    migrations = "db/migrations"
-    path = "transformers/events/median_diss/single/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.median_drop]
-    contracts = ["MEDIAN_BAT_1_0_0", "MEDIAN_COMP_1_1_2", "MEDIAN_ETH_1_0_0", "MEDIAN_KNC_1_0_8", "MEDIAN_LINK_1_1_2", "MEDIAN_LRC_1_1_2", "MEDIAN_MANA_1_0_9", "MEDIAN_USDT_1_0_4", "MEDIAN_WBTC_1_0_6", "MEDIAN_ZRX_1_0_8", "MEDIAN_BAL_1_1_14", "MEDIAN_YFI_1_1_14"]
-    migrations = "db/migrations"
-    path = "transformers/events/median_drop/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
   [exporter.median_eth_v1_0_0]
     migrations = "db/migrations"
     path = "transformers/storage/median/initializers/median_eth/v1_0_0"
     rank = "0"
     repository = "github.com/makerdao/vdb-mcd-transformers"
     type = "eth_storage"
-  [exporter.median_kiss_batch]
-    contracts = ["MEDIAN_BAT_1_0_0", "MEDIAN_COMP_1_1_2", "MEDIAN_ETH_1_0_0", "MEDIAN_KNC_1_0_8", "MEDIAN_LINK_1_1_2", "MEDIAN_LRC_1_1_2", "MEDIAN_MANA_1_0_9", "MEDIAN_USDT_1_0_4", "MEDIAN_WBTC_1_0_6", "MEDIAN_ZRX_1_0_8", "MEDIAN_BAL_1_1_14", "MEDIAN_YFI_1_1_14"]
-    migrations = "db/migrations"
-    path = "transformers/events/median_kiss/batch/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.median_kiss_single]
-    contracts = ["MEDIAN_BAT_1_0_0", "MEDIAN_COMP_1_1_2", "MEDIAN_ETH_1_0_0", "MEDIAN_KNC_1_0_8", "MEDIAN_LINK_1_1_2", "MEDIAN_LRC_1_1_2", "MEDIAN_MANA_1_0_9", "MEDIAN_USDT_1_0_4", "MEDIAN_WBTC_1_0_6", "MEDIAN_ZRX_1_0_8", "MEDIAN_BAL_1_1_14", "MEDIAN_YFI_1_1_14"]
-    migrations = "db/migrations"
-    path = "transformers/events/median_kiss/single/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
   [exporter.median_knc_v1_0_8]
     migrations = "db/migrations"
     path = "transformers/storage/median/initializers/median_knc/v1_0_8"
     rank = "0"
     repository = "github.com/makerdao/vdb-mcd-transformers"
     type = "eth_storage"
-  [exporter.median_lift]
-    contracts = ["MEDIAN_BAT_1_0_0", "MEDIAN_COMP_1_1_2", "MEDIAN_ETH_1_0_0", "MEDIAN_KNC_1_0_8", "MEDIAN_LINK_1_1_2", "MEDIAN_LRC_1_1_2", "MEDIAN_MANA_1_0_9", "MEDIAN_USDT_1_0_4", "MEDIAN_WBTC_1_0_6", "MEDIAN_ZRX_1_0_8", "MEDIAN_BAL_1_1_14", "MEDIAN_YFI_1_1_14"]
-    migrations = "db/migrations"
-    path = "transformers/events/median_lift/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
   [exporter.median_link_v1_1_2]
     migrations = "db/migrations"
     path = "transformers/storage/median/initializers/median_link/v1_1_2"
@@ -613,296 +394,30 @@
     rank = "0"
     repository = "github.com/makerdao/vdb-mcd-transformers"
     type = "eth_storage"
-  [exporter.new_cdp]
-    contracts = ["CDP_MANAGER"]
-    migrations = "db/migrations"
-    path = "transformers/events/new_cdp/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.osm_change]
-    contracts = ["OSM_BAT", "OSM_COMP", "OSM_ETH", "OSM_KNC", "OSM_LINK", "OSM_LRC", "OSM_MANA", "OSM_USDT", "OSM_WBTC", "OSM_ZRX", "OSM_BAL", "OSM_YFI"]
-    migrations = "db/migrations"
-    path = "transformers/events/osm_change/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
   [exporter.pot]
     migrations = "db/migrations"
     path = "transformers/storage/pot/initializer"
     rank = "0"
     repository = "github.com/makerdao/vdb-mcd-transformers"
     type = "eth_storage"
-  [exporter.pot_cage]
-    contracts = ["MCD_POT"]
-    migrations = "db/migrations"
-    path = "transformers/events/pot_cage/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.pot_drip]
-    contracts = ["MCD_POT"]
-    migrations = "db/migrations"
-    path = "transformers/events/pot_drip/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.pot_exit]
-    contracts = ["MCD_POT"]
-    migrations = "db/migrations"
-    path = "transformers/events/pot_exit/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.pot_file_dsr]
-    contracts = ["MCD_POT"]
-    migrations = "db/migrations"
-    path = "transformers/events/pot_file/dsr/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.pot_file_vow]
-    contracts = ["MCD_POT"]
-    migrations = "db/migrations"
-    path = "transformers/events/pot_file/vow/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.pot_join]
-    contracts = ["MCD_POT"]
-    migrations = "db/migrations"
-    path = "transformers/events/pot_join/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.rely]
-    contracts = ["MCD_CAT_1_0_0", "MCD_CAT_1_1_0", "MCD_FLAP_1_0_0", "MCD_FLAP_1_0_9", "MCD_FLIP_BAT_A_1_0_0", "MCD_FLIP_BAT_A_1_0_9", "MCD_FLIP_BAT_A_1_1_0", "MCD_FLIP_COMP_A_1_1_2", "MCD_FLIP_ETH_A_1_0_0", "MCD_FLIP_ETH_A_1_0_9", "MCD_FLIP_ETH_A_1_1_0", "MCD_FLIP_ETH_B_1_1_3", "MCD_FLIP_KNC_A_1_0_8", "MCD_FLIP_KNC_A_1_0_9", "MCD_FLIP_KNC_A_1_1_0", "MCD_FLIP_LINK_A_1_1_2", "MCD_FLIP_LRC_A_1_1_2", "MCD_FLIP_MANA_A_1_0_9", "MCD_FLIP_MANA_A_1_1_0", "MCD_FLIP_PAXUSD_A_1_1_1", "MCD_FLIP_SAI_1_0_0", "MCD_FLIP_TUSD_A_1_0_7", "MCD_FLIP_TUSD_A_1_0_9", "MCD_FLIP_TUSD_A_1_1_0", "MCD_FLIP_USDC_A_1_0_4", "MCD_FLIP_USDC_A_1_0_9", "MCD_FLIP_USDC_A_1_1_0", "MCD_FLIP_USDC_B_1_0_7", "MCD_FLIP_USDC_B_1_0_9", "MCD_FLIP_USDC_B_1_1_0", "MCD_FLIP_USDT_A_1_1_1", "MCD_FLIP_WBTC_A_1_0_6", "MCD_FLIP_WBTC_A_1_0_9", "MCD_FLIP_WBTC_A_1_1_0", "MCD_FLIP_ZRX_A_1_0_8", "MCD_FLIP_ZRX_A_1_0_9", "MCD_FLIP_ZRX_A_1_1_0", "MCD_FLOP_1_0_1", "MCD_FLOP_1_0_9", "MCD_JUG", "MCD_POT", "MCD_SPOT", "MCD_VOW", "MEDIAN_BAT_1_0_0", "MEDIAN_COMP_1_1_2", "MEDIAN_ETH_1_0_0", "MEDIAN_KNC_1_0_8", "MEDIAN_LINK_1_1_2", "MEDIAN_LRC_1_1_2", "MEDIAN_MANA_1_0_9", "MEDIAN_USDT_1_0_4", "MEDIAN_WBTC_1_0_6", "MEDIAN_ZRX_1_0_8", "OSM_BAT", "OSM_COMP", "OSM_ETH", "OSM_KNC", "OSM_LINK", "OSM_LRC", "OSM_MANA", "OSM_USDT", "OSM_WBTC", "OSM_ZRX", "MCD_FLIP_BAL_A_1_1_14", "MEDIAN_BAL_1_1_14", "OSM_BAL", "MCD_FLIP_YFI_A_1_1_14", "MEDIAN_YFI_1_1_14", "OSM_YFI"]
-    migrations = "db/migrations"
-    path = "transformers/events/auth/rely_initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.set_min_sell]
-    contracts = ["OASIS_MATCHING_MARKET_ONE", "OASIS_MATCHING_MARKET_TWO"]
-    migrations = "db/migrations"
-    path = "transformers/events/set_min_sell/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
   [exporter.spot]
     migrations = "db/migrations"
     path = "transformers/storage/spot/initializer"
     rank = "0"
     repository = "github.com/makerdao/vdb-mcd-transformers"
     type = "eth_storage"
-  [exporter.spot_file_mat]
-    contracts = ["MCD_SPOT"]
-    migrations = "db/migrations"
-    path = "transformers/events/spot_file/mat/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.spot_file_par]
-    contracts = ["MCD_SPOT"]
-    migrations = "db/migrations"
-    path = "transformers/events/spot_file/par/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.spot_file_pip]
-    contracts = ["MCD_SPOT"]
-    migrations = "db/migrations"
-    path = "transformers/events/spot_file/pip/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.spot_poke]
-    contracts = ["MCD_SPOT"]
-    migrations = "db/migrations"
-    path = "transformers/events/spot_poke/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.tend]
-    contracts = ["MCD_FLAP_1_0_0", "MCD_FLAP_1_0_9", "MCD_FLIP_BAT_A_1_0_0", "MCD_FLIP_BAT_A_1_0_9", "MCD_FLIP_BAT_A_1_1_0", "MCD_FLIP_COMP_A_1_1_2", "MCD_FLIP_ETH_A_1_0_0", "MCD_FLIP_ETH_A_1_0_9", "MCD_FLIP_ETH_A_1_1_0", "MCD_FLIP_ETH_B_1_1_3", "MCD_FLIP_KNC_A_1_0_8", "MCD_FLIP_KNC_A_1_0_9", "MCD_FLIP_KNC_A_1_1_0", "MCD_FLIP_LINK_A_1_1_2", "MCD_FLIP_LRC_A_1_1_2", "MCD_FLIP_MANA_A_1_0_9", "MCD_FLIP_MANA_A_1_1_0", "MCD_FLIP_PAXUSD_A_1_1_1", "MCD_FLIP_SAI_1_0_0", "MCD_FLIP_TUSD_A_1_0_7", "MCD_FLIP_TUSD_A_1_0_9", "MCD_FLIP_TUSD_A_1_1_0", "MCD_FLIP_USDC_A_1_0_4", "MCD_FLIP_USDC_A_1_0_9", "MCD_FLIP_USDC_A_1_1_0", "MCD_FLIP_USDC_B_1_0_7", "MCD_FLIP_USDC_B_1_0_9", "MCD_FLIP_USDC_B_1_1_0", "MCD_FLIP_USDT_A_1_1_1", "MCD_FLIP_WBTC_A_1_0_6", "MCD_FLIP_WBTC_A_1_0_9", "MCD_FLIP_WBTC_A_1_1_0", "MCD_FLIP_ZRX_A_1_0_8", "MCD_FLIP_ZRX_A_1_0_9", "MCD_FLIP_ZRX_A_1_1_0", "MCD_FLIP_BAL_A_1_1_14", "MCD_FLIP_YFI_A_1_1_14"]
-    migrations = "db/migrations"
-    path = "transformers/events/tend/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.tick]
-    contracts = ["MCD_FLAP_1_0_0", "MCD_FLAP_1_0_9", "MCD_FLIP_BAT_A_1_0_0", "MCD_FLIP_BAT_A_1_0_9", "MCD_FLIP_BAT_A_1_1_0", "MCD_FLIP_COMP_A_1_1_2", "MCD_FLIP_ETH_A_1_0_0", "MCD_FLIP_ETH_A_1_0_9", "MCD_FLIP_ETH_A_1_1_0", "MCD_FLIP_ETH_B_1_1_3", "MCD_FLIP_KNC_A_1_0_8", "MCD_FLIP_KNC_A_1_0_9", "MCD_FLIP_KNC_A_1_1_0", "MCD_FLIP_LINK_A_1_1_2", "MCD_FLIP_LRC_A_1_1_2", "MCD_FLIP_MANA_A_1_0_9", "MCD_FLIP_MANA_A_1_1_0", "MCD_FLIP_PAXUSD_A_1_1_1", "MCD_FLIP_SAI_1_0_0", "MCD_FLIP_TUSD_A_1_0_7", "MCD_FLIP_TUSD_A_1_0_9", "MCD_FLIP_TUSD_A_1_1_0", "MCD_FLIP_USDC_A_1_0_4", "MCD_FLIP_USDC_A_1_0_9", "MCD_FLIP_USDC_A_1_1_0", "MCD_FLIP_USDC_B_1_0_7", "MCD_FLIP_USDC_B_1_0_9", "MCD_FLIP_USDC_B_1_1_0", "MCD_FLIP_USDT_A_1_1_1", "MCD_FLIP_WBTC_A_1_0_6", "MCD_FLIP_WBTC_A_1_0_9", "MCD_FLIP_WBTC_A_1_1_0", "MCD_FLIP_ZRX_A_1_0_8", "MCD_FLIP_ZRX_A_1_0_9", "MCD_FLIP_ZRX_A_1_1_0", "MCD_FLOP_1_0_1", "MCD_FLOP_1_0_9", "MCD_FLIP_BAL_A_1_1_14", "MCD_FLIP_YFI_A_1_1_14"]
-    migrations = "db/migrations"
-    path = "transformers/events/tick/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
   [exporter.vat]
     migrations = "db/migrations"
     path = "transformers/storage/vat/initializer"
     rank = "0"
     repository = "github.com/makerdao/vdb-mcd-transformers"
     type = "eth_storage"
-  [exporter.vat_deny]
-    contracts = ["MCD_VAT"]
-    migrations = "db/migrations"
-    path = "transformers/events/vat_auth/deny_initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.vat_file_debt_ceiling]
-    contracts = ["MCD_VAT"]
-    migrations = "db/migrations"
-    path = "transformers/events/vat_file/debt_ceiling/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.vat_file_ilk]
-    contracts = ["MCD_VAT"]
-    migrations = "db/migrations"
-    path = "transformers/events/vat_file/ilk/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.vat_flux]
-    contracts = ["MCD_VAT"]
-    migrations = "db/migrations"
-    path = "transformers/events/vat_flux/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.vat_fold]
-    contracts = ["MCD_VAT"]
-    migrations = "db/migrations"
-    path = "transformers/events/vat_fold/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.vat_fork]
-    contracts = ["MCD_VAT"]
-    migrations = "db/migrations"
-    path = "transformers/events/vat_fork/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.vat_frob]
-    contracts = ["MCD_VAT"]
-    migrations = "db/migrations"
-    path = "transformers/events/vat_frob/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.vat_grab]
-    contracts = ["MCD_VAT"]
-    migrations = "db/migrations"
-    path = "transformers/events/vat_grab/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.vat_heal]
-    contracts = ["MCD_VAT"]
-    migrations = "db/migrations"
-    path = "transformers/events/vat_heal/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.vat_hope]
-    contracts = ["MCD_VAT"]
-    migrations = "db/migrations"
-    path = "transformers/events/vat_auth/hope_initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.vat_init]
-    contracts = ["MCD_VAT"]
-    migrations = "db/migrations"
-    path = "transformers/events/vat_init/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.vat_move]
-    contracts = ["MCD_VAT"]
-    migrations = "db/migrations"
-    path = "transformers/events/vat_move/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.vat_nope]
-    contracts = ["MCD_VAT"]
-    migrations = "db/migrations"
-    path = "transformers/events/vat_auth/nope_initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.vat_rely]
-    contracts = ["MCD_VAT"]
-    migrations = "db/migrations"
-    path = "transformers/events/vat_auth/rely_initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.vat_slip]
-    contracts = ["MCD_VAT"]
-    migrations = "db/migrations"
-    path = "transformers/events/vat_slip/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.vat_suck]
-    contracts = ["MCD_VAT"]
-    migrations = "db/migrations"
-    path = "transformers/events/vat_suck/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
   [exporter.vow]
     migrations = "db/migrations"
     path = "transformers/storage/vow/initializer"
     rank = "0"
     repository = "github.com/makerdao/vdb-mcd-transformers"
     type = "eth_storage"
-  [exporter.vow_fess]
-    contracts = ["MCD_VOW"]
-    migrations = "db/migrations"
-    path = "transformers/events/vow_fess/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.vow_file]
-    contracts = ["MCD_VOW"]
-    migrations = "db/migrations"
-    path = "transformers/events/vow_file/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.vow_file_auction_address]
-    contracts = ["MCD_VOW"]
-    migrations = "db/migrations"
-    path = "transformers/events/vow_file/auction_address/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.vow_flog]
-    contracts = ["MCD_VOW"]
-    migrations = "db/migrations"
-    path = "transformers/events/vow_flog/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.vow_heal]
-    contracts = ["MCD_VOW"]
-    migrations = "db/migrations"
-    path = "transformers/events/vow_heal/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
-  [exporter.yank]
-    contracts = ["MCD_FLAP_1_0_0", "MCD_FLAP_1_0_9", "MCD_FLIP_BAT_A_1_0_0", "MCD_FLIP_BAT_A_1_0_9", "MCD_FLIP_BAT_A_1_1_0", "MCD_FLIP_COMP_A_1_1_2", "MCD_FLIP_ETH_A_1_0_0", "MCD_FLIP_ETH_A_1_0_9", "MCD_FLIP_ETH_A_1_1_0", "MCD_FLIP_ETH_B_1_1_3", "MCD_FLIP_KNC_A_1_0_8", "MCD_FLIP_KNC_A_1_0_9", "MCD_FLIP_KNC_A_1_1_0", "MCD_FLIP_LINK_A_1_1_2", "MCD_FLIP_LRC_A_1_1_2", "MCD_FLIP_MANA_A_1_0_9", "MCD_FLIP_MANA_A_1_1_0", "MCD_FLIP_PAXUSD_A_1_1_1", "MCD_FLIP_SAI_1_0_0", "MCD_FLIP_TUSD_A_1_0_7", "MCD_FLIP_TUSD_A_1_0_9", "MCD_FLIP_TUSD_A_1_1_0", "MCD_FLIP_USDC_A_1_0_4", "MCD_FLIP_USDC_A_1_0_9", "MCD_FLIP_USDC_A_1_1_0", "MCD_FLIP_USDC_B_1_0_7", "MCD_FLIP_USDC_B_1_0_9", "MCD_FLIP_USDC_B_1_1_0", "MCD_FLIP_USDT_A_1_1_1", "MCD_FLIP_WBTC_A_1_0_6", "MCD_FLIP_WBTC_A_1_0_9", "MCD_FLIP_WBTC_A_1_1_0", "MCD_FLIP_ZRX_A_1_0_8", "MCD_FLIP_ZRX_A_1_0_9", "MCD_FLIP_ZRX_A_1_1_0", "MCD_FLOP_1_0_1", "MCD_FLOP_1_0_9", "MCD_FLIP_BAL_A_1_1_14", "MCD_FLIP_YFI_A_1_1_14"]
-    migrations = "db/migrations"
-    path = "transformers/events/yank/initializer"
-    rank = "0"
-    repository = "github.com/makerdao/vdb-mcd-transformers"
-    type = "eth_event"
 
 [contract]
   [contract.CDP_MANAGER]

--- a/plugins/execute/transformerExporter.go
+++ b/plugins/execute/transformerExporter.go
@@ -3,84 +3,6 @@
 package main
 
 import (
-	auction_file "github.com/makerdao/vdb-mcd-transformers/transformers/events/auction_file/initializer"
-	deny "github.com/makerdao/vdb-mcd-transformers/transformers/events/auth/deny_initializer"
-	rely "github.com/makerdao/vdb-mcd-transformers/transformers/events/auth/rely_initializer"
-	bite "github.com/makerdao/vdb-mcd-transformers/transformers/events/bite/initializer"
-	cat_claw "github.com/makerdao/vdb-mcd-transformers/transformers/events/cat_claw/initializer"
-	cat_file_box "github.com/makerdao/vdb-mcd-transformers/transformers/events/cat_file/box/initializer"
-	cat_file_chop_lump "github.com/makerdao/vdb-mcd-transformers/transformers/events/cat_file/chop_lump/initializer"
-	cat_file_flip "github.com/makerdao/vdb-mcd-transformers/transformers/events/cat_file/flip/initializer"
-	cat_file_vow "github.com/makerdao/vdb-mcd-transformers/transformers/events/cat_file/vow/initializer"
-	deal "github.com/makerdao/vdb-mcd-transformers/transformers/events/deal/initializer"
-	dent "github.com/makerdao/vdb-mcd-transformers/transformers/events/dent/initializer"
-	flap_kick "github.com/makerdao/vdb-mcd-transformers/transformers/events/flap_kick/initializer"
-	flip_file_cat "github.com/makerdao/vdb-mcd-transformers/transformers/events/flip_file/cat/initializer"
-	flip_kick "github.com/makerdao/vdb-mcd-transformers/transformers/events/flip_kick/initializer"
-	flop_kick "github.com/makerdao/vdb-mcd-transformers/transformers/events/flop_kick/initializer"
-	jug_drip "github.com/makerdao/vdb-mcd-transformers/transformers/events/jug_drip/initializer"
-	jug_file_base "github.com/makerdao/vdb-mcd-transformers/transformers/events/jug_file/base/initializer"
-	jug_file_ilk "github.com/makerdao/vdb-mcd-transformers/transformers/events/jug_file/ilk/initializer"
-	jug_file_vow "github.com/makerdao/vdb-mcd-transformers/transformers/events/jug_file/vow/initializer"
-	jug_init "github.com/makerdao/vdb-mcd-transformers/transformers/events/jug_init/initializer"
-	log_bump "github.com/makerdao/vdb-mcd-transformers/transformers/events/log_bump/initializer"
-	log_buy_enabled "github.com/makerdao/vdb-mcd-transformers/transformers/events/log_buy_enabled/initializer"
-	log_delete "github.com/makerdao/vdb-mcd-transformers/transformers/events/log_delete/initializer"
-	log_insert "github.com/makerdao/vdb-mcd-transformers/transformers/events/log_insert/initializer"
-	log_item_update "github.com/makerdao/vdb-mcd-transformers/transformers/events/log_item_update/initializer"
-	log_kill "github.com/makerdao/vdb-mcd-transformers/transformers/events/log_kill/initializer"
-	log_make "github.com/makerdao/vdb-mcd-transformers/transformers/events/log_make/initializer"
-	log_matching_enabled "github.com/makerdao/vdb-mcd-transformers/transformers/events/log_matching_enabled/initializer"
-	log_median_price "github.com/makerdao/vdb-mcd-transformers/transformers/events/log_median_price/initializer"
-	log_min_sell "github.com/makerdao/vdb-mcd-transformers/transformers/events/log_min_sell/initializer"
-	log_sorted_offer "github.com/makerdao/vdb-mcd-transformers/transformers/events/log_sorted_offer/initializer"
-	log_take "github.com/makerdao/vdb-mcd-transformers/transformers/events/log_take/initializer"
-	log_trade "github.com/makerdao/vdb-mcd-transformers/transformers/events/log_trade/initializer"
-	log_unsorted_offer "github.com/makerdao/vdb-mcd-transformers/transformers/events/log_unsorted_offer/initializer"
-	log_value "github.com/makerdao/vdb-mcd-transformers/transformers/events/log_value/initializer"
-	median_diss_batch "github.com/makerdao/vdb-mcd-transformers/transformers/events/median_diss/batch/initializer"
-	median_diss_single "github.com/makerdao/vdb-mcd-transformers/transformers/events/median_diss/single/initializer"
-	median_drop "github.com/makerdao/vdb-mcd-transformers/transformers/events/median_drop/initializer"
-	median_kiss_batch "github.com/makerdao/vdb-mcd-transformers/transformers/events/median_kiss/batch/initializer"
-	median_kiss_single "github.com/makerdao/vdb-mcd-transformers/transformers/events/median_kiss/single/initializer"
-	median_lift "github.com/makerdao/vdb-mcd-transformers/transformers/events/median_lift/initializer"
-	new_cdp "github.com/makerdao/vdb-mcd-transformers/transformers/events/new_cdp/initializer"
-	osm_change "github.com/makerdao/vdb-mcd-transformers/transformers/events/osm_change/initializer"
-	pot_cage "github.com/makerdao/vdb-mcd-transformers/transformers/events/pot_cage/initializer"
-	pot_drip "github.com/makerdao/vdb-mcd-transformers/transformers/events/pot_drip/initializer"
-	pot_exit "github.com/makerdao/vdb-mcd-transformers/transformers/events/pot_exit/initializer"
-	pot_file_dsr "github.com/makerdao/vdb-mcd-transformers/transformers/events/pot_file/dsr/initializer"
-	pot_file_vow "github.com/makerdao/vdb-mcd-transformers/transformers/events/pot_file/vow/initializer"
-	pot_join "github.com/makerdao/vdb-mcd-transformers/transformers/events/pot_join/initializer"
-	set_min_sell "github.com/makerdao/vdb-mcd-transformers/transformers/events/set_min_sell/initializer"
-	spot_file_mat "github.com/makerdao/vdb-mcd-transformers/transformers/events/spot_file/mat/initializer"
-	spot_file_par "github.com/makerdao/vdb-mcd-transformers/transformers/events/spot_file/par/initializer"
-	spot_file_pip "github.com/makerdao/vdb-mcd-transformers/transformers/events/spot_file/pip/initializer"
-	spot_poke "github.com/makerdao/vdb-mcd-transformers/transformers/events/spot_poke/initializer"
-	tend "github.com/makerdao/vdb-mcd-transformers/transformers/events/tend/initializer"
-	tick "github.com/makerdao/vdb-mcd-transformers/transformers/events/tick/initializer"
-	vat_deny "github.com/makerdao/vdb-mcd-transformers/transformers/events/vat_auth/deny_initializer"
-	vat_hope "github.com/makerdao/vdb-mcd-transformers/transformers/events/vat_auth/hope_initializer"
-	vat_nope "github.com/makerdao/vdb-mcd-transformers/transformers/events/vat_auth/nope_initializer"
-	vat_rely "github.com/makerdao/vdb-mcd-transformers/transformers/events/vat_auth/rely_initializer"
-	vat_file_debt_ceiling "github.com/makerdao/vdb-mcd-transformers/transformers/events/vat_file/debt_ceiling/initializer"
-	vat_file_ilk "github.com/makerdao/vdb-mcd-transformers/transformers/events/vat_file/ilk/initializer"
-	vat_flux "github.com/makerdao/vdb-mcd-transformers/transformers/events/vat_flux/initializer"
-	vat_fold "github.com/makerdao/vdb-mcd-transformers/transformers/events/vat_fold/initializer"
-	vat_fork "github.com/makerdao/vdb-mcd-transformers/transformers/events/vat_fork/initializer"
-	vat_frob "github.com/makerdao/vdb-mcd-transformers/transformers/events/vat_frob/initializer"
-	vat_grab "github.com/makerdao/vdb-mcd-transformers/transformers/events/vat_grab/initializer"
-	vat_heal "github.com/makerdao/vdb-mcd-transformers/transformers/events/vat_heal/initializer"
-	vat_init "github.com/makerdao/vdb-mcd-transformers/transformers/events/vat_init/initializer"
-	vat_move "github.com/makerdao/vdb-mcd-transformers/transformers/events/vat_move/initializer"
-	vat_slip "github.com/makerdao/vdb-mcd-transformers/transformers/events/vat_slip/initializer"
-	vat_suck "github.com/makerdao/vdb-mcd-transformers/transformers/events/vat_suck/initializer"
-	vow_fess "github.com/makerdao/vdb-mcd-transformers/transformers/events/vow_fess/initializer"
-	vow_file_auction_address "github.com/makerdao/vdb-mcd-transformers/transformers/events/vow_file/auction_address/initializer"
-	vow_file "github.com/makerdao/vdb-mcd-transformers/transformers/events/vow_file/initializer"
-	vow_flog "github.com/makerdao/vdb-mcd-transformers/transformers/events/vow_flog/initializer"
-	vow_heal "github.com/makerdao/vdb-mcd-transformers/transformers/events/vow_heal/initializer"
-	yank "github.com/makerdao/vdb-mcd-transformers/transformers/events/yank/initializer"
 	cat_v1_0_0 "github.com/makerdao/vdb-mcd-transformers/transformers/storage/cat/v1_0_0/initializer"
 	cat_v1_1_0 "github.com/makerdao/vdb-mcd-transformers/transformers/storage/cat/v1_1_0/initializer"
 	cdp_manager "github.com/makerdao/vdb-mcd-transformers/transformers/storage/cdp_manager/initializer"
@@ -150,5 +72,67 @@ type exporter string
 var Exporter exporter
 
 func (e exporter) Export() ([]event.TransformerInitializer, []storage.TransformerInitializer, []interface1.ContractTransformerInitializer) {
-	return []event.TransformerInitializer{log_make.EventTransformerInitializer, log_unsorted_offer.EventTransformerInitializer, vat_fork.EventTransformerInitializer, vat_nope.EventTransformerInitializer, cat_claw.EventTransformerInitializer, cat_file_flip.EventTransformerInitializer, new_cdp.EventTransformerInitializer, vat_fold.EventTransformerInitializer, vat_init.EventTransformerInitializer, vow_file_auction_address.EventTransformerInitializer, median_kiss_batch.EventTransformerInitializer, vat_grab.EventTransformerInitializer, median_kiss_single.EventTransformerInitializer, vat_flux.EventTransformerInitializer, deny.EventTransformerInitializer, pot_join.EventTransformerInitializer, log_insert.EventTransformerInitializer, jug_init.EventTransformerInitializer, vat_slip.EventTransformerInitializer, log_sorted_offer.EventTransformerInitializer, cat_file_chop_lump.EventTransformerInitializer, vat_move.EventTransformerInitializer, cat_file_box.EventTransformerInitializer, vat_suck.EventTransformerInitializer, log_trade.EventTransformerInitializer, jug_drip.EventTransformerInitializer, tick.EventTransformerInitializer, median_diss_single.EventTransformerInitializer, cat_file_vow.EventTransformerInitializer, auction_file.EventTransformerInitializer, vow_heal.EventTransformerInitializer, vow_file.EventTransformerInitializer, pot_cage.EventTransformerInitializer, log_kill.EventTransformerInitializer, jug_file_base.EventTransformerInitializer, spot_file_mat.EventTransformerInitializer, vat_heal.EventTransformerInitializer, log_value.EventTransformerInitializer, vat_frob.EventTransformerInitializer, log_buy_enabled.EventTransformerInitializer, log_matching_enabled.EventTransformerInitializer, tend.EventTransformerInitializer, vat_file_ilk.EventTransformerInitializer, spot_poke.EventTransformerInitializer, log_min_sell.EventTransformerInitializer, spot_file_par.EventTransformerInitializer, pot_drip.EventTransformerInitializer, vow_fess.EventTransformerInitializer, spot_file_pip.EventTransformerInitializer, log_median_price.EventTransformerInitializer, bite.EventTransformerInitializer, vat_deny.EventTransformerInitializer, deal.EventTransformerInitializer, vow_flog.EventTransformerInitializer, log_take.EventTransformerInitializer, median_drop.EventTransformerInitializer, pot_file_dsr.EventTransformerInitializer, osm_change.EventTransformerInitializer, set_min_sell.EventTransformerInitializer, flip_file_cat.EventTransformerInitializer, flip_kick.EventTransformerInitializer, rely.EventTransformerInitializer, pot_exit.EventTransformerInitializer, jug_file_ilk.EventTransformerInitializer, dent.EventTransformerInitializer, log_delete.EventTransformerInitializer, vat_hope.EventTransformerInitializer, vat_rely.EventTransformerInitializer, median_lift.EventTransformerInitializer, flop_kick.EventTransformerInitializer, median_diss_batch.EventTransformerInitializer, jug_file_vow.EventTransformerInitializer, log_item_update.EventTransformerInitializer, pot_file_vow.EventTransformerInitializer, flap_kick.EventTransformerInitializer, log_bump.EventTransformerInitializer, vat_file_debt_ceiling.EventTransformerInitializer, yank.EventTransformerInitializer}, []storage.TransformerInitializer{flip_bat_a_v1_1_0.StorageTransformerInitializer, flip_eth_a_v1_0_9.StorageTransformerInitializer, flip_eth_b_v1_1_3.StorageTransformerInitializer, flip_eth_a_v1_1_0.StorageTransformerInitializer, flip_paxusd_a_v1_1_1.StorageTransformerInitializer, flip_sai_v1_0_0.StorageTransformerInitializer, flip_bat_a_v1_0_0.StorageTransformerInitializer, flip_usdc_b_v1_1_0.StorageTransformerInitializer, flip_knc_a_v1_0_8.StorageTransformerInitializer, median_yfi_v1_1_14.StorageTransformerInitializer, median_bat_v1_0_0.StorageTransformerInitializer, flip_wbtc_a_v1_0_6.StorageTransformerInitializer, median_wbtc_v1_0_6.StorageTransformerInitializer, flip_usdc_a_v1_0_4.StorageTransformerInitializer, median_link_v1_1_2.StorageTransformerInitializer, median_knc_v1_0_8.StorageTransformerInitializer, flip_knc_a_v1_0_9.StorageTransformerInitializer, median_bal_v1_1_14.StorageTransformerInitializer, cdp_manager.StorageTransformerInitializer, spot.StorageTransformerInitializer, flip_wbtc_a_v1_1_0.StorageTransformerInitializer, jug.StorageTransformerInitializer, flip_usdc_a_v1_1_0.StorageTransformerInitializer, flip_eth_a_v1_0_0.StorageTransformerInitializer, flip_yfi_a_v1_1_14.StorageTransformerInitializer, flip_zrx_a_v1_0_9.StorageTransformerInitializer, vat.StorageTransformerInitializer, flip_usdc_a_v1_0_9.StorageTransformerInitializer, flip_comp_a_v1_1_2.StorageTransformerInitializer, flip_tusd_a_v1_1_0.StorageTransformerInitializer, flop_v1_0_9.StorageTransformerInitializer, flip_knc_a_v1_1_0.StorageTransformerInitializer, flip_zrx_a_v1_0_8.StorageTransformerInitializer, flip_bat_a_v1_0_9.StorageTransformerInitializer, flip_wbtc_a_v1_0_9.StorageTransformerInitializer, vow.StorageTransformerInitializer, cat_v1_1_0.StorageTransformerInitializer, flip_mana_a_v1_0_9.StorageTransformerInitializer, median_mana_v1_0_9.StorageTransformerInitializer, flip_link_a_v1_1_2.StorageTransformerInitializer, flip_tusd_a_v1_0_7.StorageTransformerInitializer, median_usdt_v1_0_4.StorageTransformerInitializer, flop_v1_0_1.StorageTransformerInitializer, median_lrc_v1_1_2.StorageTransformerInitializer, median_eth_v1_0_0.StorageTransformerInitializer, pot.StorageTransformerInitializer, flip_zrx_a_v1_1_0.StorageTransformerInitializer, median_comp_v1_1_2.StorageTransformerInitializer, flap_v1_0_0.StorageTransformerInitializer, flip_usdc_b_v1_0_9.StorageTransformerInitializer, flip_usdt_a_v1_1_1.StorageTransformerInitializer, flip_tusd_a_v1_0_9.StorageTransformerInitializer, flip_usdc_b_v1_0_7.StorageTransformerInitializer, flip_bal_a_v1_1_14.StorageTransformerInitializer, median_zrx_v1_0_8.StorageTransformerInitializer, flap_v1_0_9.StorageTransformerInitializer, cat_v1_0_0.StorageTransformerInitializer, flip_mana_a_v1_1_0.StorageTransformerInitializer, flip_lrc_a_v1_1_2.StorageTransformerInitializer}, []interface1.ContractTransformerInitializer{}
+	return []event.TransformerInitializer{},
+		[]storage.TransformerInitializer{
+			cat_v1_0_0.StorageTransformerInitializer,
+			cat_v1_1_0.StorageTransformerInitializer,
+			cdp_manager.StorageTransformerInitializer,
+			flap_v1_0_0.StorageTransformerInitializer,
+			flap_v1_0_9.StorageTransformerInitializer,
+			flip_bal_a_v1_1_14.StorageTransformerInitializer,
+			flip_bat_a_v1_0_0.StorageTransformerInitializer,
+			flip_bat_a_v1_0_9.StorageTransformerInitializer,
+			flip_bat_a_v1_1_0.StorageTransformerInitializer,
+			flip_comp_a_v1_1_2.StorageTransformerInitializer,
+			flip_eth_a_v1_0_0.StorageTransformerInitializer,
+			flip_eth_a_v1_0_9.StorageTransformerInitializer,
+			flip_eth_a_v1_1_0.StorageTransformerInitializer,
+			flip_eth_b_v1_1_3.StorageTransformerInitializer,
+			flip_knc_a_v1_0_8.StorageTransformerInitializer,
+			flip_knc_a_v1_0_9.StorageTransformerInitializer,
+			flip_knc_a_v1_1_0.StorageTransformerInitializer,
+			flip_link_a_v1_1_2.StorageTransformerInitializer,
+			flip_lrc_a_v1_1_2.StorageTransformerInitializer,
+			flip_mana_a_v1_0_9.StorageTransformerInitializer,
+			flip_mana_a_v1_1_0.StorageTransformerInitializer,
+			flip_paxusd_a_v1_1_1.StorageTransformerInitializer,
+			flip_sai_v1_0_0.StorageTransformerInitializer,
+			flip_tusd_a_v1_0_7.StorageTransformerInitializer,
+			flip_tusd_a_v1_0_9.StorageTransformerInitializer,
+			flip_tusd_a_v1_1_0.StorageTransformerInitializer,
+			flip_usdc_a_v1_0_4.StorageTransformerInitializer,
+			flip_usdc_a_v1_0_9.StorageTransformerInitializer,
+			flip_usdc_a_v1_1_0.StorageTransformerInitializer,
+			flip_usdc_b_v1_0_7.StorageTransformerInitializer,
+			flip_usdc_b_v1_0_9.StorageTransformerInitializer,
+			flip_usdc_b_v1_1_0.StorageTransformerInitializer,
+			flip_usdt_a_v1_1_1.StorageTransformerInitializer,
+			flip_wbtc_a_v1_0_6.StorageTransformerInitializer,
+			flip_wbtc_a_v1_0_9.StorageTransformerInitializer,
+			flip_wbtc_a_v1_1_0.StorageTransformerInitializer,
+			flip_yfi_a_v1_1_14.StorageTransformerInitializer,
+			flip_zrx_a_v1_0_8.StorageTransformerInitializer,
+			flip_zrx_a_v1_0_9.StorageTransformerInitializer,
+			flip_zrx_a_v1_1_0.StorageTransformerInitializer,
+			flop_v1_0_1.StorageTransformerInitializer,
+			flop_v1_0_9.StorageTransformerInitializer,
+			jug.StorageTransformerInitializer,
+			median_bal_v1_1_14.StorageTransformerInitializer,
+			median_bat_v1_0_0.StorageTransformerInitializer,
+			median_comp_v1_1_2.StorageTransformerInitializer,
+			median_eth_v1_0_0.StorageTransformerInitializer,
+			median_knc_v1_0_8.StorageTransformerInitializer,
+			median_link_v1_1_2.StorageTransformerInitializer,
+			median_lrc_v1_1_2.StorageTransformerInitializer,
+			median_mana_v1_0_9.StorageTransformerInitializer,
+			median_usdt_v1_0_4.StorageTransformerInitializer,
+			median_wbtc_v1_0_6.StorageTransformerInitializer,
+			median_yfi_v1_1_14.StorageTransformerInitializer,
+			median_zrx_v1_0_8.StorageTransformerInitializer,
+			pot.StorageTransformerInitializer,
+			spot.StorageTransformerInitializer,
+			vat.StorageTransformerInitializer,
+			vow.StorageTransformerInitializer,
+		},
+		[]interface1.ContractTransformerInitializer{}
 }


### PR DESCRIPTION
- diffs were not transformed between blocks 11,234,894 and 11,315,955
- these diffs aren't picked up by the existing execute process since it
  only looks at diffs within 1250 blocks of the head
- current head is ~11,360,000, so scanning within 200,000 or head
  should cover all that were missed
- only need storage transformers since existing execute process will
  handle events