### PR TITLE
Adjust time series auctions bucket limit to 1000

### DIFF
--- a/db/migrations/20201007080800_create_time_auction_totals_query.sql
+++ b/db/migrations/20201007080800_create_time_auction_totals_query.sql
@@ -18,7 +18,7 @@ $$
 DECLARE
     r api.time_bid_total%rowtype;
 BEGIN
-    ASSERT EXTRACT(EPOCH FROM (range_end - range_start)) / EXTRACT(EPOCH FROM bucket_interval) <= 100, 'Please limit requests to at most 100 buckets.';
+    ASSERT EXTRACT(EPOCH FROM (range_end - range_start)) / EXTRACT(EPOCH FROM bucket_interval) <= 1000, 'Please limit requests to at most 1000 buckets.';
     
     FOR r IN 
         WITH buckets AS (
@@ -72,7 +72,7 @@ $$
 DECLARE
     r api.time_bid_total%rowtype;
 BEGIN
-    ASSERT EXTRACT(EPOCH FROM (range_end - range_start)) / EXTRACT(EPOCH FROM bucket_interval) <= 100, 'Please limit requests to at most 100 buckets.';
+    ASSERT EXTRACT(EPOCH FROM (range_end - range_start)) / EXTRACT(EPOCH FROM bucket_interval) <= 1000, 'Please limit requests to at most 1000 buckets.';
     
     FOR r IN 
         WITH buckets AS (
@@ -131,7 +131,7 @@ $$
 DECLARE
     r api.time_bid_total%rowtype;
 BEGIN
-    ASSERT EXTRACT(EPOCH FROM (range_end - range_start)) / EXTRACT(EPOCH FROM bucket_interval) <= 100, 'Please limit requests to at most 100 buckets.';
+    ASSERT EXTRACT(EPOCH FROM (range_end - range_start)) / EXTRACT(EPOCH FROM bucket_interval) <= 1000, 'Please limit requests to at most 1000 buckets.';
     
     FOR r IN 
         WITH buckets AS (
@@ -201,7 +201,7 @@ $$
 DECLARE
     r api.time_bite_total%rowtype;
 BEGIN
-    ASSERT EXTRACT(EPOCH FROM (range_end - range_start)) / EXTRACT(EPOCH FROM bucket_interval) <= 100, 'Please limit requests to at most 100 buckets.';
+    ASSERT EXTRACT(EPOCH FROM (range_end - range_start)) / EXTRACT(EPOCH FROM bucket_interval) <= 1000, 'Please limit requests to at most 1000 buckets.';
     
     FOR r IN 
         WITH buckets AS (


### PR DESCRIPTION
The bucket limit was set kind of arbitrarily based on my first best guess, but I've been getting feedback that the limit is too low. Running my own tests shows an increase of about ~200ms query response with 100 buckets to ~2000ms with 1000 buckets. This seems reasonable to me, but I am uncertain about how you are measuring performance targets.