### PR TITLE
(VDB-1726) Create urn IDs for src & dst in fork [prod]

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1473,12 +1473,12 @@ CREATE FUNCTION api.get_urns_by_ilk(ilk_identifier text, block_height bigint DEF
     AS $$
 SELECT *
 FROM (SELECT DISTINCT ON (urn_identifier, urn_snapshot.ilk_identifier) urn_identifier,
-                                                          urn_snapshot.ilk_identifier,
-                                                          urn_snapshot.block_height,
-                                                          ink,
-                                                          coalesce(art, 0),
-                                                          created,
-                                                          updated
+                                                                       urn_snapshot.ilk_identifier,
+                                                                       urn_snapshot.block_height,
+                                                                       ink,
+                                                                       coalesce(art, 0),
+                                                                       created,
+                                                                       updated
       FROM api.urn_snapshot
       WHERE urn_snapshot.block_height <= get_urns_by_ilk.block_height
         AND urn_snapshot.ilk_identifier = get_urns_by_ilk.ilk_identifier

--- a/generators/new_collateral/config/parser.go
+++ b/generators/new_collateral/config/parser.go
@@ -21,9 +21,9 @@ func NewParser() parser {
 }
 
 var (
-	ErrorDecodingConfigFile = errors.New("error decoding config file")
-	ErrorParsingExporterMetadata = errors.New("error parsing exporter metadata from config file")
-    ErrorParsingTransformerExporters = errors.New("error parsing transformer exporters from config file")
+	ErrorDecodingConfigFile          = errors.New("error decoding config file")
+	ErrorParsingExporterMetadata     = errors.New("error parsing exporter metadata from config file")
+	ErrorParsingTransformerExporters = errors.New("error parsing transformer exporters from config file")
 )
 
 func (parser) ParseCurrentConfig(configFilePath, configFileName string) (types.TransformersConfig, error) {

--- a/transformers/events/vat_fork/transformer.go
+++ b/transformers/events/vat_fork/transformer.go
@@ -46,6 +46,15 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 			return nil, shared.ErrCouldNotCreateFK(ilkErr)
 		}
 
+		_, srcUrnIDErr := mcdShared.GetOrCreateUrn(src, ilk, db)
+		if srcUrnIDErr != nil {
+			return nil, shared.ErrCouldNotCreateFK(srcUrnIDErr)
+		}
+		_, dstUrnIDErr := mcdShared.GetOrCreateUrn(dst, ilk, db)
+		if dstUrnIDErr != nil {
+			return nil, shared.ErrCouldNotCreateFK(dstUrnIDErr)
+		}
+
 		dinkBytes, dinkErr := mcdShared.GetLogNoteArgumentAtIndex(3, log.Log.Data)
 		if dinkErr != nil {
 			return nil, dinkErr


### PR DESCRIPTION
- fork creates/updates urns for the passed ilk + src/dst fields. If we
  don't write them to the urns table, they won't be available to the
  storage transformers parsing urn diffs - and diffs will go
  unrecognized.