### PR TITLE
(VDB-1726) Create urn IDs for src & dst in fork [beta]

### DIFF
--- a/transformers/events/vat_fork/transformer.go
+++ b/transformers/events/vat_fork/transformer.go
@@ -45,6 +45,15 @@ func (Transformer) ToModels(_ string, logs []core.EventLog, db *postgres.DB) ([]
 			return nil, shared.ErrCouldNotCreateFK(ilkErr)
 		}
 
+		_, srcUrnIDErr := shared.GetOrCreateUrn(src, ilk, db)
+		if srcUrnIDErr != nil {
+			return nil, shared.ErrCouldNotCreateFK(srcUrnIDErr)
+		}
+		_, dstUrnIDErr := shared.GetOrCreateUrn(dst, ilk, db)
+		if dstUrnIDErr != nil {
+			return nil, shared.ErrCouldNotCreateFK(dstUrnIDErr)
+		}
+
 		dinkBytes, dinkErr := shared.GetLogNoteArgumentAtIndex(3, log.Log.Data)
 		if dinkErr != nil {
 			return nil, dinkErr


### PR DESCRIPTION
- fork creates/updates urns for the passed ilk + src/dst fields. If we
  don't write them to the urns table, they won't be available to the
  storage transformers parsing urn diffs - and diffs will go
  unrecognized.