### PR TITLE
Vdb 1739 fix data generation

### DIFF
--- a/generators/data_generator/data_generator.go
+++ b/generators/data_generator/data_generator.go
@@ -429,7 +429,7 @@ func (state *GeneratorState) insertCurrentHeader() error {
 	header := state.currentHeader
 	var id int64
 	// TODO: derive eth node id from db so this doesn't fail if id 1 does not exist
-	err := state.pgTx.QueryRow(headerSql, header.Hash, header.BlockNumber, header.Raw, header.Timestamp, 1).Scan(&id)
+	err := state.pgTx.QueryRow(headerSql, header.Hash, header.BlockNumber, header.Raw, header.Timestamp, state.db.NodeID).Scan(&id)
 	state.currentHeader.Id = id
 	return err
 }

--- a/generators/data_generator/data_generator.go
+++ b/generators/data_generator/data_generator.go
@@ -428,7 +428,6 @@ func (state *GeneratorState) insertInitialIlkData(ilkId int64) error {
 func (state *GeneratorState) insertCurrentHeader() error {
 	header := state.currentHeader
 	var id int64
-	// TODO: derive eth node id from db so this doesn't fail if id 1 does not exist
 	err := state.pgTx.QueryRow(headerSql, header.Hash, header.BlockNumber, header.Raw, header.Timestamp, state.db.NodeID).Scan(&id)
 	state.currentHeader.Id = id
 	return err

--- a/generators/data_generator/data_generator.go
+++ b/generators/data_generator/data_generator.go
@@ -27,8 +27,7 @@ import (
 const (
 	headerSql = `INSERT INTO public.headers (hash, block_number, raw, block_timestamp, eth_node_id)
 		VALUES ($1, $2, $3, $4, $5) RETURNING id`
-	nodeSql = `INSERT INTO public.eth_nodes (genesis_block, network_id, eth_node_id) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING`
-	txSql   = `INSERT INTO public.transactions (header_id, hash, tx_from, tx_index, tx_to)
+	txSql = `INSERT INTO public.transactions (header_id, hash, tx_from, tx_index, tx_to)
 		VALUES ($1, $2, $3, $4, $5)`
 	insertIlkQuery = `INSERT INTO maker.ilks (ilk, identifier) VALUES ($1, $2) RETURNING id`
 	insertUrnQuery = `INSERT INTO maker.urns (identifier, ilk_id) VALUES ($1, $2) RETURNING id`
@@ -79,9 +78,8 @@ func main() {
 	}
 
 	pg := postgres.DB{
-		DB:     db,
-		Node:   node,
-		NodeID: 0,
+		DB:   db,
+		Node: node,
 	}
 
 	if *seedPtr != -1 {
@@ -186,7 +184,7 @@ func (state *GeneratorState) Run(steps int) error {
 // Creates a starting ilk and urn, with the corresponding header.
 func (state *GeneratorState) doInitialSetup() error {
 	// This may or may not have been initialised, needed for a FK constraint
-	_, nodeErr := state.pgTx.Exec(nodeSql, "GENESIS", 1, node.ID)
+	nodeErr := state.db.CreateNode(&state.db.Node)
 	if nodeErr != nil {
 		return fmt.Errorf("could not insert initial node: %v", nodeErr)
 	}


### PR DESCRIPTION
This fixes 2 issues with the data generation.

1) Storage Diffs require an eth_node_id. This worked in tests because we injected a pg that happened to have a matching EthNode id but it failed in the real code. I adjusted the tests to make sure they don't create a node in this one case (because the generator itself creates a node).

2) Headers hard coded their eth-node id to 1, which works if you blew away your database first, but not otherwise.