### PR TITLE
Add index on api.urn_snapshot block_height

### DIFF
--- a/db/migrations/20210108171701_add_index_to_urn_snapshot_block_height.sql
+++ b/db/migrations/20210108171701_add_index_to_urn_snapshot_block_height.sql
@@ -1,0 +1,7 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+CREATE INDEX CONCURRENTLY urn_snapshot_block_height_index
+  ON api.urn_snapshot (block_height);
+
+-- +goose Down
+DROP INDEX CONCURRENTLY api.urn_snapshot_block_height_index;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 11.2
--- Dumped by pg_dump version 11.10
+-- Dumped from database version 11.6
+-- Dumped by pg_dump version 11.6
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 11.6
--- Dumped by pg_dump version 11.6
+-- Dumped from database version 11.2
+-- Dumped by pg_dump version 11.10
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -16367,6 +16367,13 @@ ALTER TABLE ONLY maker.yank
 
 ALTER TABLE ONLY maker.yank
     ADD CONSTRAINT yank_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: urn_snapshot_block_height_index; Type: INDEX; Schema: api; Owner: -
+--
+
+CREATE INDEX urn_snapshot_block_height_index ON api.urn_snapshot USING btree (block_height);
 
 
 --


### PR DESCRIPTION
- Add `urn_snapshot_block_height_index` on `api.urn_snapshot` `block_height` column. (The completeness checker relies on a query filter that uses this index).
- Create index concurrently. This command can't be run in a transaction block.