### PR TITLE
Add min_block_height arg to api.get_urns_by_ilk

### DIFF
--- a/db/migrations/20210111132543_update_urns_by_ilk_query.sql
+++ b/db/migrations/20210111132543_update_urns_by_ilk_query.sql
@@ -1,0 +1,31 @@
+-- +goose Up
+DROP FUNCTION api.get_urns_by_ilk(TEXT, BIGINT, INTEGER, INTEGER);
+
+CREATE FUNCTION api.get_urns_by_ilk(ilk_identifier TEXT,
+                                    block_height bigint DEFAULT api.max_block(),
+                                    min_block_height bigint DEFAULT 0,
+                                    max_results integer DEFAULT NULL::integer,
+                                    result_offset integer DEFAULT 0) RETURNS SETOF api.urn_snapshot
+    LANGUAGE sql
+    STABLE
+AS
+$$
+SELECT *
+FROM (SELECT DISTINCT ON (urn_identifier, urn_snapshot.ilk_identifier) urn_identifier,
+                                                                       urn_snapshot.ilk_identifier,
+                                                                       urn_snapshot.block_height,
+                                                                       ink,
+                                                                       coalesce(art, 0),
+                                                                       created,
+                                                                       updated
+      FROM api.urn_snapshot
+      WHERE urn_snapshot.block_height <= get_urns_by_ilk.block_height
+        AND urn_snapshot.block_height > get_urns_by_ilk.min_block_height
+        AND urn_snapshot.ilk_identifier = get_urns_by_ilk.ilk_identifier
+      ORDER BY urn_identifier, ilk_identifier, updated DESC) AS latest_urns
+ORDER BY updated DESC
+LIMIT get_urns_by_ilk.max_results OFFSET get_urns_by_ilk.result_offset
+$$;
+
+-- +goose Down
+DROP FUNCTION api.get_urns_by_ilk(TEXT, BIGINT, BIGINT, INTEGER, INTEGER);

--- a/db/migrations/20210111132543_update_urns_by_ilk_query.sql
+++ b/db/migrations/20210111132543_update_urns_by_ilk_query.sql
@@ -20,7 +20,7 @@ FROM (SELECT DISTINCT ON (urn_identifier, urn_snapshot.ilk_identifier) urn_ident
                                                                        updated
       FROM api.urn_snapshot
       WHERE urn_snapshot.block_height <= get_urns_by_ilk.block_height
-        AND urn_snapshot.block_height > get_urns_by_ilk.min_block_height
+        AND urn_snapshot.block_height >= get_urns_by_ilk.min_block_height
         AND urn_snapshot.ilk_identifier = get_urns_by_ilk.ilk_identifier
       ORDER BY urn_identifier, ilk_identifier, updated DESC) AS latest_urns
 ORDER BY updated DESC

--- a/db/migrations/20210111132543_update_urns_by_ilk_query.sql
+++ b/db/migrations/20210111132543_update_urns_by_ilk_query.sql
@@ -29,3 +29,26 @@ $$;
 
 -- +goose Down
 DROP FUNCTION api.get_urns_by_ilk(TEXT, BIGINT, BIGINT, INTEGER, INTEGER);
+
+CREATE FUNCTION api.get_urns_by_ilk(ilk_identifier TEXT, block_height bigint DEFAULT api.max_block(),
+                                    max_results integer DEFAULT NULL::integer,
+                                    result_offset integer DEFAULT 0) RETURNS SETOF api.urn_snapshot
+    LANGUAGE sql
+    STABLE
+AS
+$$
+SELECT *
+FROM (SELECT DISTINCT ON (urn_identifier, urn_snapshot.ilk_identifier) urn_identifier,
+                                                                       urn_snapshot.ilk_identifier,
+                                                                       urn_snapshot.block_height,
+                                                                       ink,
+                                                                       coalesce(art, 0),
+                                                                       created,
+                                                                       updated
+      FROM api.urn_snapshot
+      WHERE urn_snapshot.block_height <= get_urns_by_ilk.block_height
+        AND urn_snapshot.ilk_identifier = get_urns_by_ilk.ilk_identifier
+      ORDER BY urn_identifier, ilk_identifier, updated DESC) AS latest_urns
+ORDER BY updated DESC
+LIMIT get_urns_by_ilk.max_results OFFSET get_urns_by_ilk.result_offset
+$$;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1492,7 +1492,7 @@ FROM (SELECT DISTINCT ON (urn_identifier, urn_snapshot.ilk_identifier) urn_ident
                                                                        updated
       FROM api.urn_snapshot
       WHERE urn_snapshot.block_height <= get_urns_by_ilk.block_height
-        AND urn_snapshot.block_height > get_urns_by_ilk.min_block_height
+        AND urn_snapshot.block_height >= get_urns_by_ilk.min_block_height
         AND urn_snapshot.ilk_identifier = get_urns_by_ilk.ilk_identifier
       ORDER BY urn_identifier, ilk_identifier, updated DESC) AS latest_urns
 ORDER BY updated DESC

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1476,10 +1476,10 @@ $$;
 
 
 --
--- Name: get_urns_by_ilk(text, bigint, integer, integer); Type: FUNCTION; Schema: api; Owner: -
+-- Name: get_urns_by_ilk(text, bigint, bigint, integer, integer); Type: FUNCTION; Schema: api; Owner: -
 --
 
-CREATE FUNCTION api.get_urns_by_ilk(ilk_identifier text, block_height bigint DEFAULT api.max_block(), max_results integer DEFAULT NULL::integer, result_offset integer DEFAULT 0) RETURNS SETOF api.urn_snapshot
+CREATE FUNCTION api.get_urns_by_ilk(ilk_identifier text, block_height bigint DEFAULT api.max_block(), min_block_height bigint DEFAULT 0, max_results integer DEFAULT NULL::integer, result_offset integer DEFAULT 0) RETURNS SETOF api.urn_snapshot
     LANGUAGE sql STABLE
     AS $$
 SELECT *
@@ -1492,6 +1492,7 @@ FROM (SELECT DISTINCT ON (urn_identifier, urn_snapshot.ilk_identifier) urn_ident
                                                                        updated
       FROM api.urn_snapshot
       WHERE urn_snapshot.block_height <= get_urns_by_ilk.block_height
+        AND urn_snapshot.block_height > get_urns_by_ilk.min_block_height
         AND urn_snapshot.ilk_identifier = get_urns_by_ilk.ilk_identifier
       ORDER BY urn_identifier, ilk_identifier, updated DESC) AS latest_urns
 ORDER BY updated DESC

--- a/transformers/component_tests/queries/get_urns_by_ilk_query_test.go
+++ b/transformers/component_tests/queries/get_urns_by_ilk_query_test.go
@@ -177,7 +177,7 @@ var _ = Describe("All Urns function", func() {
 
 			var result []helper.UrnState
 			err = db.Select(&result, `SELECT urn_identifier, ilk_identifier, ink, art, created, updated
-			FROM api.get_urns_by_ilk($1, $2, $3)`, helper.FakeIlk.Identifier, blockTwo, maxResults)
+			FROM api.get_urns_by_ilk($1, $2, $3, $4)`, helper.FakeIlk.Identifier, blockTwo, blockOne, maxResults)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(len(result)).To(Equal(maxResults))
@@ -190,7 +190,7 @@ var _ = Describe("All Urns function", func() {
 
 			var result []helper.UrnState
 			err = db.Select(&result, `SELECT urn_identifier, ilk_identifier, ink, art, created, updated
-			FROM api.get_urns_by_ilk($1, $2, $3, $4)`, helper.FakeIlk.Identifier, blockTwo, maxResults, resultOffset)
+			FROM api.get_urns_by_ilk($1, $2, $3, $4, $5)`, helper.FakeIlk.Identifier, blockTwo, 0, maxResults, resultOffset)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(len(result)).To(Equal(1))
@@ -203,12 +203,13 @@ var _ = Describe("All Urns function", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	Describe("it includes diffs only up to given block height", func() {
+	Describe("selecting diffs by block height", func() {
 		var (
-			actualUrn                          helper.UrnState
-			blockTwo, timestampTwo, updatedInk int
-			setupDataOne                       map[string]interface{}
-			metadata                           helper.UrnMetadata
+			actualUrn                                 helper.UrnState
+			blockTwo, timestampTwo, blockTwoInk       int
+			blockThree, timestampThree, blockThreeInk int
+			setupDataOne                              map[string]interface{}
+			metadata                                  helper.UrnMetadata
 		)
 
 		BeforeEach(func() {
@@ -225,12 +226,25 @@ var _ = Describe("All Urns function", func() {
 			fakeHeaderTwoID, err := headerRepo.CreateOrUpdateHeader(fakeHeaderTwo)
 			Expect(err).NotTo(HaveOccurred())
 
-			updatedInk = rand.Int()
-			err = vatRepo.Create(diffID, fakeHeaderTwoID, metadata.UrnInk, strconv.Itoa(updatedInk))
+			blockTwoInk = rand.Int()
+			err = vatRepo.Create(diffID, fakeHeaderTwoID, metadata.UrnInk, strconv.Itoa(blockTwoInk))
+			Expect(err).NotTo(HaveOccurred())
+
+			blockThree = blockTwo + 1
+			fakeHeaderThree := fakes.GetFakeHeader(int64(blockThree))
+			timestampThree = timestampTwo + 1
+			fakeHeaderThree.Timestamp = strconv.Itoa(timestampThree)
+			hashThree := test_data.RandomString(5)
+			fakeHeaderThree.Hash = hashThree
+			fakeHeaderThreeID, err := headerRepo.CreateOrUpdateHeader(fakeHeaderThree)
+			Expect(err).NotTo(HaveOccurred())
+
+			blockThreeInk = rand.Int()
+			err = vatRepo.Create(diffID, fakeHeaderThreeID, metadata.UrnInk, strconv.Itoa(blockThreeInk))
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("gets urn state as of block one", func() {
+		It("gets past urn state as of block one", func() {
 			err = db.Get(&actualUrn, urnsByIlkQuery, helper.FakeIlk.Identifier, blockOne)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -248,20 +262,40 @@ var _ = Describe("All Urns function", func() {
 			helper.AssertUrn(actualUrn, expectedUrn)
 		})
 
-		It("gets urn state with updated values", func() {
+		It("gets latest urn state with updated values as of block three", func() {
+			createdTimestamp := helper.GetExpectedTimestamp(timestampOne)
+			updatedTimestampThree := helper.GetExpectedTimestamp(timestampThree)
+			expectedUrn := helper.UrnState{
+				UrnIdentifier: urnOne,
+				IlkIdentifier: helper.FakeIlk.Identifier,
+				BlockHeight:   blockThree,
+				Ink:           strconv.Itoa(blockThreeInk),
+				Art:           strconv.Itoa(setupDataOne[vat.UrnArt].(int)), // Not changed
+				Created:       helper.GetValidNullString(createdTimestamp),
+				Updated:       helper.GetValidNullString(updatedTimestampThree),
+			}
+
+			err = db.Get(&actualUrn, urnsByIlkQuery, helper.FakeIlk.Identifier, blockThree)
+			Expect(err).NotTo(HaveOccurred())
+
+			helper.AssertUrn(actualUrn, expectedUrn)
+		})
+
+		It("gets block two urn state with updated values using both min and max block height", func() {
 			createdTimestamp := helper.GetExpectedTimestamp(timestampOne)
 			updatedTimestampTwo := helper.GetExpectedTimestamp(timestampTwo)
 			expectedUrn := helper.UrnState{
 				UrnIdentifier: urnOne,
 				IlkIdentifier: helper.FakeIlk.Identifier,
 				BlockHeight:   blockTwo,
-				Ink:           strconv.Itoa(updatedInk),
+				Ink:           strconv.Itoa(blockTwoInk),
 				Art:           strconv.Itoa(setupDataOne[vat.UrnArt].(int)), // Not changed
 				Created:       helper.GetValidNullString(createdTimestamp),
 				Updated:       helper.GetValidNullString(updatedTimestampTwo),
 			}
 
-			err = db.Get(&actualUrn, urnsByIlkQuery, helper.FakeIlk.Identifier, blockTwo)
+			urnsByIlkMinHeightQuery := `SELECT urn_identifier, ilk_identifier, block_height, ink, art, created, updated FROM api.get_urns_by_ilk($1, $2, $3)`
+			err = db.Get(&actualUrn, urnsByIlkMinHeightQuery, helper.FakeIlk.Identifier, blockTwo, blockOne)
 			Expect(err).NotTo(HaveOccurred())
 
 			helper.AssertUrn(actualUrn, expectedUrn)

--- a/transformers/component_tests/queries/get_urns_by_ilk_query_test.go
+++ b/transformers/component_tests/queries/get_urns_by_ilk_query_test.go
@@ -190,7 +190,7 @@ var _ = Describe("All Urns function", func() {
 
 			var result []helper.UrnState
 			err = db.Select(&result, `SELECT urn_identifier, ilk_identifier, ink, art, created, updated
-			FROM api.get_urns_by_ilk($1, $2, $3, $4, $5)`, helper.FakeIlk.Identifier, blockTwo, 0, maxResults, resultOffset)
+			FROM api.get_urns_by_ilk($1, $2, $3, $4, $5)`, helper.FakeIlk.Identifier, blockTwo, blockOne, maxResults, resultOffset)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(len(result)).To(Equal(1))
@@ -281,7 +281,7 @@ var _ = Describe("All Urns function", func() {
 			helper.AssertUrn(actualUrn, expectedUrn)
 		})
 
-		It("gets block two urn state with updated values using both min and max block height", func() {
+		It("gets urn state as of block two by filtering by both min and max block height", func() {
 			createdTimestamp := helper.GetExpectedTimestamp(timestampOne)
 			updatedTimestampTwo := helper.GetExpectedTimestamp(timestampTwo)
 			expectedUrn := helper.UrnState{


### PR DESCRIPTION
- Add an optional `min_block_height` argument to `api.get_urns_by_ilk`
- Update tests to exercise new argument. Feedback welcome here—I hope the behavior is clear.
- Postgres considers functions unique based on name and argument signature. That means we can use `CREATE OR REPLACE` to modify functions with the same signature, but here we need to `DROP` and `CREATE` a function with the same name, but an extra argument. The potential impact here is that this query will be briefly unavailable when the migration is running.