### PR TITLE
Clean up panics and return errors instead

### DIFF
--- a/transformers/storage/cat/repository.go
+++ b/transformers/storage/cat/repository.go
@@ -64,7 +64,7 @@ func (repo *StorageRepository) Create(diffID, headerID int64, metadata types.Val
 	case IlkDunk:
 		return repo.insertIlkDunk(diffID, headerID, metadata, value.(string))
 	default:
-		panic(fmt.Sprintf("unrecognized cat contract storage name: %s", metadata.Name))
+		return fmt.Errorf("unrecognized cat contract storage name: %s", metadata.Name)
 	}
 }
 

--- a/transformers/storage/cat/repository_test.go
+++ b/transformers/storage/cat/repository_test.go
@@ -45,13 +45,12 @@ var _ = Describe("Cat storage repository", func() {
 	})
 
 	Describe("Variable", func() {
-		It("panics if the metadata name is not recognized", func() {
+		It("returns an error if the metadata name is not recognized", func() {
 			unrecognizedMetadata := types.ValueMetadata{Name: "unrecognized"}
-			repoCreate := func() {
-				repo.Create(diffID, fakeHeaderID, unrecognizedMetadata, "")
-			}
 
-			Expect(repoCreate).Should(Panic())
+			err := repo.Create(diffID, fakeHeaderID, unrecognizedMetadata, "")
+
+			Expect(err).Should(HaveOccurred())
 		})
 
 		Describe("Live", func() {

--- a/transformers/storage/cdp_manager/repository.go
+++ b/transformers/storage/cdp_manager/repository.go
@@ -65,7 +65,7 @@ func (repository *StorageRepository) Create(diffID, headerID int64, metadata typ
 	case Count:
 		return repository.insertCount(diffID, headerID, metadata, value.(string))
 	default:
-		panic("unrecognized storage metadata name")
+		return fmt.Errorf("unrecognized cdp manager contract storage name: %s", metadata.Name)
 	}
 }
 

--- a/transformers/storage/cdp_manager/repository_test.go
+++ b/transformers/storage/cdp_manager/repository_test.go
@@ -58,13 +58,12 @@ var _ = Describe("CDP Manager storage repository", func() {
 		Expect(insertHeaderErr).NotTo(HaveOccurred())
 	})
 
-	It("panics if the metadata name is not recognized", func() {
+	It("returns an error if the metadata name is not recognized", func() {
 		unrecognizedMetadata := types.ValueMetadata{Name: "unrecognized"}
-		repoCreate := func() {
-			repository.Create(diffID, fakeHeaderID, unrecognizedMetadata, "")
-		}
 
-		Expect(repoCreate).Should(Panic())
+		err := repository.Create(diffID, fakeHeaderID, unrecognizedMetadata, "")
+
+		Expect(err).Should(HaveOccurred())
 	})
 
 	Describe("vat", func() {

--- a/transformers/storage/flap/repository.go
+++ b/transformers/storage/flap/repository.go
@@ -52,7 +52,7 @@ func (repository *StorageRepository) Create(diffID, headerID int64, metadata typ
 	case storage.Packed:
 		return repository.insertPackedValueRecord(diffID, headerID, metadata, value.(map[int]string))
 	default:
-		panic(fmt.Sprintf("unrecognized flap contract storage name: %s", metadata.Name))
+		return fmt.Errorf("unrecognized flap contract storage name: %s", metadata.Name)
 	}
 }
 
@@ -196,7 +196,7 @@ func (repository *StorageRepository) insertPackedValueRecord(diffID, headerID in
 		case storage.BidEnd:
 			insertErr = repository.insertBidEnd(diffID, headerID, metadata, value)
 		default:
-			panic(fmt.Sprintf("unrecognized flap contract storage name in packed values: %s", metadata.Name))
+			return fmt.Errorf("unrecognized flap contract storage name in packed values: %s", metadata.Name)
 		}
 		if insertErr != nil {
 			return fmt.Errorf("error inserting flap packed value from diff ID %d: %w", diffID, insertErr)

--- a/transformers/storage/flap/repository_test.go
+++ b/transformers/storage/flap/repository_test.go
@@ -42,13 +42,12 @@ var _ = Describe("Flap storage repository", func() {
 		diffID = CreateFakeDiffRecord(db)
 	})
 
-	It("panics if the metadata name is not recognized", func() {
+	It("returns an error if the metadata name is not recognized", func() {
 		unrecognizedMetadata := types.ValueMetadata{Name: "unrecognized"}
-		flapCreate := func() {
-			repo.Create(diffID, fakeHeaderID, unrecognizedMetadata, "")
-		}
 
-		Expect(flapCreate).Should(Panic())
+		err := repo.Create(diffID, fakeHeaderID, unrecognizedMetadata, "")
+
+		Expect(err).Should(HaveOccurred())
 	})
 
 	It("rolls back the record and address insertions if there's a failure", func() {
@@ -233,10 +232,8 @@ var _ = Describe("Flap storage repository", func() {
 				PackedNames: packedNames,
 			}
 
-			createFunc := func() {
-				repo.Create(diffID, fakeHeaderID, badMetadata, values)
-			}
-			Expect(createFunc).To(Panic())
+			err := repo.Create(diffID, fakeHeaderID, badMetadata, values)
+			Expect(err).Should(HaveOccurred())
 		})
 
 		It("returns an error if inserting fails", func() {

--- a/transformers/storage/flip/repository.go
+++ b/transformers/storage/flip/repository.go
@@ -64,7 +64,7 @@ func (repo *StorageRepository) Create(diffID, headerID int64, metadata types.Val
 	case storage.Packed:
 		return repo.insertPackedValueRecord(diffID, headerID, metadata, value.(map[int]string))
 	default:
-		panic(fmt.Sprintf("unrecognized flip contract storage name: %s", metadata.Name))
+		return fmt.Errorf("unrecognized flip contract storage name: %s", metadata.Name)
 	}
 }
 
@@ -374,7 +374,7 @@ func (repo *StorageRepository) insertPackedValueRecord(diffID, headerID int64, m
 		case storage.BidEnd:
 			insertErr = repo.insertBidEnd(diffID, headerID, metadata, value)
 		default:
-			panic(fmt.Sprintf("unrecognized flip contract storage name in packed values: %s", metadata.Name))
+			return fmt.Errorf("unrecognized flip contract storage name in packed values: %s", metadata.Name)
 		}
 		if insertErr != nil {
 			return fmt.Errorf("error inserting flip packed value from diff ID %d: %w", diffID, insertErr)

--- a/transformers/storage/flip/repository_test.go
+++ b/transformers/storage/flip/repository_test.go
@@ -40,13 +40,12 @@ var _ = Describe("Flip storage repository", func() {
 		diffID = CreateFakeDiffRecord(db)
 	})
 
-	It("panics if the metadata name is not recognized", func() {
+	It("returns an error if the metadata name is not recognized", func() {
 		unrecognizedMetadata := types.ValueMetadata{Name: "unrecognized"}
-		flipCreate := func() {
-			_ = repo.Create(diffID, fakeHeaderID, unrecognizedMetadata, "")
-		}
 
-		Expect(flipCreate).Should(Panic())
+		err := repo.Create(diffID, fakeHeaderID, unrecognizedMetadata, "")
+
+		Expect(err).Should(HaveOccurred())
 	})
 
 	It("rolls back the record and address insertions if there's a failure", func() {
@@ -230,7 +229,7 @@ var _ = Describe("Flip storage repository", func() {
 				AssertVariable(tauResult, diffID, fakeHeaderID, fakeTau)
 			})
 
-			It("panics if the packed name is not recognized", func() {
+			It("returns an error if the packed name is not recognized", func() {
 				packedNames := make(map[int]string)
 				packedNames[0] = "notRecognized"
 
@@ -239,10 +238,9 @@ var _ = Describe("Flip storage repository", func() {
 					PackedNames: packedNames,
 				}
 
-				createFunc := func() {
-					_ = repo.Create(diffID, fakeHeaderID, badMetadata, values)
-				}
-				Expect(createFunc).To(Panic())
+				err := repo.Create(diffID, fakeHeaderID, badMetadata, values)
+
+				Expect(err).To(HaveOccurred())
 			})
 
 			It("returns an error if inserting fails", func() {

--- a/transformers/storage/flop/repository.go
+++ b/transformers/storage/flop/repository.go
@@ -59,7 +59,7 @@ func (repository *StorageRepository) Create(diffID, headerID int64, metadata typ
 	case storage.BidLot:
 		return repository.insertBidLot(diffID, headerID, metadata, value.(string))
 	default:
-		panic(fmt.Sprintf("unrecognized flop contract storage name: %s", metadata.Name))
+		return fmt.Errorf("unrecognized flop contract storage name: %s", metadata.Name)
 	}
 }
 
@@ -219,7 +219,7 @@ func (repository *StorageRepository) insertPackedValueRecord(diffID, headerID in
 		case storage.BidEnd:
 			insertErr = repository.insertBidEnd(diffID, headerID, metadata, value)
 		default:
-			panic(fmt.Sprintf("unrecognized flop contract storage name in packed values: %s", metadata.Name))
+			return fmt.Errorf("unrecognized flop contract storage name in packed values: %s", metadata.Name)
 		}
 		if insertErr != nil {
 			return fmt.Errorf("error inserting flop packed value from diff ID %d: %w", diffID, insertErr)

--- a/transformers/storage/flop/repository_test.go
+++ b/transformers/storage/flop/repository_test.go
@@ -41,13 +41,12 @@ var _ = Describe("Flop storage repository", func() {
 		diffID = CreateFakeDiffRecord(db)
 	})
 
-	It("panics if the metadata name is not recognized", func() {
+	It("returns an error if the metadata name is not recognized", func() {
 		unrecognizedMetadata := types.ValueMetadata{Name: "unrecognized"}
-		flopCreate := func() {
-			repo.Create(diffID, fakeHeaderID, unrecognizedMetadata, "")
-		}
 
-		Expect(flopCreate).Should(Panic())
+		err := repo.Create(diffID, fakeHeaderID, unrecognizedMetadata, "")
+
+		Expect(err).Should(HaveOccurred())
 	})
 
 	Describe("Vat", func() {
@@ -161,7 +160,7 @@ var _ = Describe("Flop storage repository", func() {
 			AssertVariable(tauResult, diffID, fakeHeaderID, fakeTau)
 		})
 
-		It("panics if the packed name is not recognized", func() {
+		It("returns an error if the packed name is not recognized", func() {
 			packedNames := make(map[int]string)
 			packedNames[0] = "notRecognized"
 
@@ -170,10 +169,9 @@ var _ = Describe("Flop storage repository", func() {
 				PackedNames: packedNames,
 			}
 
-			createFunc := func() {
-				_ = repo.Create(diffID, fakeHeaderID, badMetadata, values)
-			}
-			Expect(createFunc).To(Panic())
+			err := repo.Create(diffID, fakeHeaderID, badMetadata, values)
+
+			Expect(err).To(HaveOccurred())
 		})
 
 		It("returns an error if inserting fails", func() {

--- a/transformers/storage/jug/repository.go
+++ b/transformers/storage/jug/repository.go
@@ -55,7 +55,7 @@ func (repository StorageRepository) Create(diffID, headerID int64, metadata type
 		return repository.insertJugBase(diffID, headerID, value.(string))
 
 	default:
-		panic(fmt.Sprintf("unrecognized jug contract storage name: %s", metadata.Name))
+		return fmt.Errorf("unrecognized jug contract storage name: %s", metadata.Name)
 	}
 }
 

--- a/transformers/storage/jug/repository_test.go
+++ b/transformers/storage/jug/repository_test.go
@@ -61,6 +61,16 @@ var _ = Describe("Jug storage repository", func() {
 		diffID = CreateFakeDiffRecord(db)
 	})
 
+	Describe("Variable", func() {
+		It("returns an error if the metadata name is not recognized", func() {
+			unrecognizedMetadata := types.ValueMetadata{Name: "unrecognized"}
+
+			err := repo.Create(diffID, fakeHeaderID, unrecognizedMetadata, "")
+
+			Expect(err).Should(HaveOccurred())
+		})
+	})
+
 	Describe("Wards", func() {
 		It("writes a row", func() {
 			fakeUserAddress := "0x" + fakes.RandomString(40)

--- a/transformers/storage/pot/repository.go
+++ b/transformers/storage/pot/repository.go
@@ -49,7 +49,7 @@ func (repo StorageRepository) Create(diffID, headerID int64, metadata types.Valu
 	case Live:
 		return repo.insertLive(diffID, headerID, value.(string))
 	default:
-		panic(fmt.Sprintf("unrecognized pot contract storage name: %s", metadata.Name))
+		return fmt.Errorf("unrecognized pot contract storage name: %s", metadata.Name)
 	}
 }
 

--- a/transformers/storage/pot/repository_test.go
+++ b/transformers/storage/pot/repository_test.go
@@ -43,13 +43,12 @@ var _ = Describe("Pot storage repository", func() {
 	})
 
 	Describe("Variable", func() {
-		It("panics if the metadata name is not recognized", func() {
+		It("returns an error if the metadata name is not recognized", func() {
 			unrecognizedMetadata := types.ValueMetadata{Name: "unrecognized"}
-			repoCreate := func() {
-				repo.Create(diffID, fakeHeaderID, unrecognizedMetadata, "")
-			}
 
-			Expect(repoCreate).Should(Panic())
+			err := repo.Create(diffID, fakeHeaderID, unrecognizedMetadata, "")
+
+			Expect(err).Should(HaveOccurred())
 		})
 	})
 

--- a/transformers/storage/spot/repository.go
+++ b/transformers/storage/spot/repository.go
@@ -55,7 +55,7 @@ func (repository StorageRepository) Create(diffID, headerID int64, metadata type
 		return repository.insertSpotLive(diffID, headerID, value.(string))
 
 	default:
-		panic(fmt.Sprintf("unrecognized spot contract storage name: %s", metadata.Name))
+		return fmt.Errorf("unrecognized spot contract storage name: %s", metadata.Name)
 	}
 }
 

--- a/transformers/storage/spot/repository_test.go
+++ b/transformers/storage/spot/repository_test.go
@@ -60,6 +60,14 @@ var _ = Describe("Spot storage repository", func() {
 		diffID = CreateFakeDiffRecord(db)
 	})
 
+	It("returns an error if the metadata name is not recognized", func() {
+		unrecognizedMetadata := types.ValueMetadata{Name: "unrecognized"}
+
+		err := repo.Create(diffID, fakeHeaderID, unrecognizedMetadata, "")
+
+		Expect(err).Should(HaveOccurred())
+	})
+
 	Describe("Wards mapping", func() {
 		It("writes a row", func() {
 			fakeUserAddress := "0x" + fakes.RandomString(40)

--- a/transformers/storage/vat/repository.go
+++ b/transformers/storage/vat/repository.go
@@ -83,7 +83,7 @@ func (repository *StorageRepository) Create(diffID, headerID int64, metadata typ
 	case Live:
 		return repository.insertVatLive(diffID, headerID, value.(string))
 	default:
-		panic(fmt.Sprintf("unrecognized vat contract storage name: %s", metadata.Name))
+		return fmt.Errorf("unrecognized vat contract storage name: %s", metadata.Name)
 	}
 }
 

--- a/transformers/storage/vat/repository_test.go
+++ b/transformers/storage/vat/repository_test.go
@@ -64,6 +64,16 @@ var _ = Describe("Vat storage repository", func() {
 		diffID = CreateFakeDiffRecord(db)
 	})
 
+	Describe("Variable", func() {
+		It("returns an error if the metadata name is not recognized", func() {
+			unrecognizedMetadata := types.ValueMetadata{Name: "unrecognized"}
+
+			err := repo.Create(diffID, fakeHeaderID, unrecognizedMetadata, "")
+
+			Expect(err).Should(HaveOccurred())
+		})
+	})
+
 	Describe("Wards mapping", func() {
 		It("writes a row", func() {
 			fakeUserAddress := "0x" + fakes.RandomString(40)

--- a/transformers/storage/vow/repository.go
+++ b/transformers/storage/vow/repository.go
@@ -78,7 +78,7 @@ func (repository StorageRepository) Create(diffID, headerID int64, metadata type
 	case Live:
 		return repository.insertVowLive(diffID, headerID, value.(string))
 	default:
-		panic(fmt.Sprintf("unrecognized storage metadata name: %s", metadata.Name))
+		return fmt.Errorf("unrecognized storage metadata name: %s", metadata.Name)
 	}
 }
 

--- a/transformers/storage/vow/repository_test.go
+++ b/transformers/storage/vow/repository_test.go
@@ -57,6 +57,16 @@ var _ = Describe("Vow storage repository test", func() {
 		diffID = CreateFakeDiffRecord(db)
 	})
 
+	Describe("Variable", func() {
+		It("returns an error if the metadata name is not recognized", func() {
+			unrecognizedMetadata := types.ValueMetadata{Name: "unrecognized"}
+
+			err := repo.Create(diffID, fakeHeaderID, unrecognizedMetadata, "")
+
+			Expect(err).Should(HaveOccurred())
+		})
+	})
+
 	Describe("Wards mapping", func() {
 		It("writes a row", func() {
 			fakeUserAddress := "0x" + fakes.RandomString(40)


### PR DESCRIPTION
Reduce or remove use of `panic` and return an `error` instead to allow Sentry to capture errors since Sentry may not capture panics[ occurring in goroutines](https://github.com/getsentry/sentry-go/issues/115#issuecomment-564032753). Most changes occurred in storage repository when the metadata is not recognized. 

