### PR TITLE
(VDB-1803) Add indexes to places required for API

### DIFF
--- a/db/migrations/20210127120357_create_indexes_to_support_api.sql
+++ b/db/migrations/20210127120357_create_indexes_to_support_api.sql
@@ -1,0 +1,11 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+CREATE INDEX CONCURRENTLY median_slot_index
+    ON maker.median_slot (slot);
+
+CREATE INDEX CONCURRENTLY flip_file_cat_data_index
+    ON maker.flip_file_cat (data);
+
+-- +goose Down
+DROP INDEX maker.median_slot_index;
+DROP INDEX maker.flip_file_cat_data_index;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -17430,6 +17430,13 @@ CREATE INDEX flip_file_cat_address_id_index ON maker.flip_file_cat USING btree (
 
 
 --
+-- Name: flip_file_cat_data_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX flip_file_cat_data_index ON maker.flip_file_cat USING btree (data);
+
+
+--
 -- Name: flip_file_cat_header_index; Type: INDEX; Schema: maker; Owner: -
 --
 
@@ -18323,6 +18330,13 @@ CREATE INDEX median_slot_header_id_index ON maker.median_slot USING btree (heade
 --
 
 CREATE INDEX median_slot_id_index ON maker.median_slot USING btree (slot_id);
+
+
+--
+-- Name: median_slot_index; Type: INDEX; Schema: maker; Owner: -
+--
+
+CREATE INDEX median_slot_index ON maker.median_slot USING btree (slot);
 
 
 --


### PR DESCRIPTION
- When Postgraphile is configured to not ignore indexes, it will not
  expose columns that are not indexed. These changes add indexes to
  columns that contain core data for the tables in question, so that
  they can be accessed via the API