### PR TITLE
Use an older version of aws-cli

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 - make installtools
 - bash ./scripts/install-postgres-11.sh
 - sudo apt-get update && sudo apt-get install python3-pip -y
-- sudo pip3 install awscli
+- sudo pip3 install awscli==1.18.223
 script:
 - set -e
 - scripts/check_config.sh


### PR DESCRIPTION
Suggested a bump to version <1.19 of the aws-cli
https://github.com/aws/aws-cli/issues/5968#issuecomment-783774993

Although we should consider upgrading python and/or aws-cli itself according to 
https://aws.amazon.com/blogs/developer/announcing-the-end-of-support-for-python-3-4-and-3-5-in-the-aws-sdk-for-python-and-aws-cli-v1/