### PR TITLE
Update api.flip_bid_event_bid to use event block

### DIFF
--- a/db/migrations/20210317095927_add_block_height_to_flip_bid_event_bid.sql
+++ b/db/migrations/20210317095927_add_block_height_to_flip_bid_event_bid.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+CREATE OR REPLACE FUNCTION api.flip_bid_event_bid(event api.flip_bid_event)
+    RETURNS api.flip_bid_snapshot AS
+$$
+SELECT * FROM api.get_flip_with_address(event.bid_id, event.contract_address, event.block_height)
+$$
+    LANGUAGE sql
+    STABLE;
+
+-- +goose Down
+CREATE OR REPLACE FUNCTION api.flip_bid_event_bid(event api.flip_bid_event)
+    RETURNS api.flip_bid_snapshot AS
+$$
+SELECT * FROM api.get_flip_with_address(event.bid_id, event.contract_address)
+$$
+    LANGUAGE sql
+    STABLE;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 11.6
--- Dumped by pg_dump version 11.6
+-- Dumped from database version 11.10
+-- Dumped by pg_dump version 13.2
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -902,8 +902,6 @@ $$;
 
 SET default_tablespace = '';
 
-SET default_with_oids = false;
-
 --
 -- Name: ilk_snapshot; Type: TABLE; Schema: api; Owner: -
 --
@@ -1183,7 +1181,7 @@ $$;
 CREATE FUNCTION api.flip_bid_event_bid(event api.flip_bid_event) RETURNS api.flip_bid_snapshot
     LANGUAGE sql STABLE
     AS $$
-SELECT * FROM api.get_flip_with_address(event.bid_id, event.contract_address)
+SELECT * FROM api.get_flip_with_address(event.bid_id, event.contract_address, event.block_height)
 $$;
 
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 11.10
--- Dumped by pg_dump version 13.2
+-- Dumped from database version 11.6
+-- Dumped by pg_dump version 11.6
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -901,6 +901,8 @@ $$;
 
 
 SET default_tablespace = '';
+
+SET default_with_oids = false;
 
 --
 -- Name: ilk_snapshot; Type: TABLE; Schema: api; Owner: -


### PR DESCRIPTION
Embedded `bid`s inside `bidEvents` are showing the most recent state snapshot instead of the historical snapshot at the time of the event. Passing the event's block height to `api.get_flip_with_address` should fix this up.