### PR TITLE
Add configs for production storage backfill

### DIFF
--- a/dockerfiles/backfill_storage/startup_script.sh
+++ b/dockerfiles/backfill_storage/startup_script.sh
@@ -28,5 +28,5 @@ if test -z "$VDB_PG_CONNECT"; then
 fi
 
 # Run backfillStorage
-echo "Running backfillStorage from block 0 to 0"
-./vulcanizedb backfillStorage -s=0  -e=0 --config config.toml
+echo "Running backfillStorage from block 12464984 to 13379859"
+./vulcanizedb backfillStorage -s=12464984 -e=13379859 --config config.toml

--- a/dockerfiles/backfill_storage/startup_script.sh
+++ b/dockerfiles/backfill_storage/startup_script.sh
@@ -28,5 +28,5 @@ if test -z "$VDB_PG_CONNECT"; then
 fi
 
 # Run backfillStorage
-echo "Running backfillStorage from block 12464984 to 13379859"
-./vulcanizedb backfillStorage -s=12464984 -e=13379859 --config config.toml
+echo "Running backfillStorage from block 12246413 to 13425397"
+./vulcanizedb backfillStorage -s=12246413 -e=13425397 --config config.toml

--- a/environments/backfillStorage.toml
+++ b/environments/backfillStorage.toml
@@ -3,7 +3,157 @@
     name     = "transformerExporter"
     save     = true
     schema   = "maker"
-    transformerNames = []
+    transformerNames = ["clip_aave_a_v1_6_0", "clip_bal_a_v1_6_0", "clip_bat_a_v1_6_0", "clip_comp_a_v1_6_0", "clip_eth_a_v1_5_0", "clip_eth_b_v1_5_0", "clip_eth_c_v1_5_0", "clip_knc_a_v1_6_0", "clip_link_a_v1_3_0", "clip_lrc_a_v1_6_0", "clip_mana_a_v1_6_0", "clip_renbtc_a_v1_6_0", "clip_uni_a_v1_6_0", "clip_univ2aaveeth_a_v1_8_0", "clip_univ2daieth_a_v1_8_0", "clip_univ2daiusdt_a_v1_8_0", "clip_univ2ethusdt_a_v1_8_0", "clip_univ2linketh_a_v1_8_0", "clip_univ2unieth_a_v1_8_0", "clip_univ2usdceth_a_v1_8_0", "clip_univ2wbtcdai_a_v1_8_0", "clip_univ2wbtceth_a_v1_8_0", "clip_wbtc_a_v1_5_0", "clip_yfi_a_v1_5_0", "clip_zrx_a_v1_6_0"]
+    [exporter.clip_aave_a_v1_6_0]
+        migrations = "db/migrations"
+        path = "transformers/storage/clip/initializers/aave_a/v1_6_0"
+        rank = "0"
+        repository = "github.com/makerdao/vdb-mcd-transformers"
+        type = "eth_storage"
+    [exporter.clip_bal_a_v1_6_0]
+        migrations = "db/migrations"
+        path = "transformers/storage/clip/initializers/bal_a/v1_6_0"
+        rank = "0"
+        repository = "github.com/makerdao/vdb-mcd-transformers"
+        type = "eth_storage"
+    [exporter.clip_bat_a_v1_6_0]
+        migrations = "db/migrations"
+        path = "transformers/storage/clip/initializers/bat_a/v1_6_0"
+        rank = "0"
+        repository = "github.com/makerdao/vdb-mcd-transformers"
+        type = "eth_storage"
+    [exporter.clip_comp_a_v1_6_0]
+        migrations = "db/migrations"
+        path = "transformers/storage/clip/initializers/comp_a/v1_6_0"
+        rank = "0"
+        repository = "github.com/makerdao/vdb-mcd-transformers"
+        type = "eth_storage"
+    [exporter.clip_eth_a_v1_5_0]
+        migrations = "db/migrations"
+        path = "transformers/storage/clip/initializers/eth_a/v1_5_0"
+        rank = "0"
+        repository = "github.com/makerdao/vdb-mcd-transformers"
+        type = "eth_storage"
+    [exporter.clip_eth_b_v1_5_0]
+        migrations = "db/migrations"
+        path = "transformers/storage/clip/initializers/eth_b/v1_5_0"
+        rank = "0"
+        repository = "github.com/makerdao/vdb-mcd-transformers"
+        type = "eth_storage"
+    [exporter.clip_eth_c_v1_5_0]
+        migrations = "db/migrations"
+        path = "transformers/storage/clip/initializers/eth_c/v1_5_0"
+        rank = "0"
+        repository = "github.com/makerdao/vdb-mcd-transformers"
+        type = "eth_storage"
+    [exporter.clip_knc_a_v1_6_0]
+        migrations = "db/migrations"
+        path = "transformers/storage/clip/initializers/knc_a/v1_6_0"
+        rank = "0"
+        repository = "github.com/makerdao/vdb-mcd-transformers"
+        type = "eth_storage"
+    [exporter.clip_link_a_v1_3_0]
+        migrations = "db/migrations"
+        path = "transformers/storage/clip/initializers/link_a/v1_3_0"
+        rank = "0"
+        repository = "github.com/makerdao/vdb-mcd-transformers"
+        type = "eth_storage"
+    [exporter.clip_lrc_a_v1_6_0]
+        migrations = "db/migrations"
+        path = "transformers/storage/clip/initializers/lrc_a/v1_6_0"
+        rank = "0"
+        repository = "github.com/makerdao/vdb-mcd-transformers"
+        type = "eth_storage"
+    [exporter.clip_mana_a_v1_6_0]
+        migrations = "db/migrations"
+        path = "transformers/storage/clip/initializers/mana_a/v1_6_0"
+        rank = "0"
+        repository = "github.com/makerdao/vdb-mcd-transformers"
+        type = "eth_storage"
+    [exporter.clip_renbtc_a_v1_6_0]
+        migrations = "db/migrations"
+        path = "transformers/storage/clip/initializers/renbtc_a/v1_6_0"
+        rank = "0"
+        repository = "github.com/makerdao/vdb-mcd-transformers"
+        type = "eth_storage"
+    [exporter.clip_uni_a_v1_6_0]
+        migrations = "db/migrations"
+        path = "transformers/storage/clip/initializers/uni_a/v1_6_0"
+        rank = "0"
+        repository = "github.com/makerdao/vdb-mcd-transformers"
+        type = "eth_storage"
+    [exporter.clip_univ2aaveeth_a_v1_8_0]
+        migrations = "db/migrations"
+        path = "transformers/storage/clip/initializers/univ2aaveeth_a/v1_8_0"
+        rank = "0"
+        repository = "github.com/makerdao/vdb-mcd-transformers"
+        type = "eth_storage"
+    [exporter.clip_univ2daieth_a_v1_8_0]
+        migrations = "db/migrations"
+        path = "transformers/storage/clip/initializers/univ2daieth_a/v1_8_0"
+        rank = "0"
+        repository = "github.com/makerdao/vdb-mcd-transformers"
+        type = "eth_storage"
+    [exporter.clip_univ2daiusdt_a_v1_8_0]
+        migrations = "db/migrations"
+        path = "transformers/storage/clip/initializers/univ2daiusdt_a/v1_8_0"
+        rank = "0"
+        repository = "github.com/makerdao/vdb-mcd-transformers"
+        type = "eth_storage"
+    [exporter.clip_univ2ethusdt_a_v1_8_0]
+        migrations = "db/migrations"
+        path = "transformers/storage/clip/initializers/univ2ethusdt_a/v1_8_0"
+        rank = "0"
+        repository = "github.com/makerdao/vdb-mcd-transformers"
+        type = "eth_storage"
+    [exporter.clip_univ2linketh_a_v1_8_0]
+        migrations = "db/migrations"
+        path = "transformers/storage/clip/initializers/univ2linketh_a/v1_8_0"
+        rank = "0"
+        repository = "github.com/makerdao/vdb-mcd-transformers"
+        type = "eth_storage"
+    [exporter.clip_univ2unieth_a_v1_8_0]
+        migrations = "db/migrations"
+        path = "transformers/storage/clip/initializers/univ2unieth_a/v1_8_0"
+        rank = "0"
+        repository = "github.com/makerdao/vdb-mcd-transformers"
+        type = "eth_storage"
+    [exporter.clip_univ2usdceth_a_v1_8_0]
+        migrations = "db/migrations"
+        path = "transformers/storage/clip/initializers/univ2usdceth_a/v1_8_0"
+        rank = "0"
+        repository = "github.com/makerdao/vdb-mcd-transformers"
+        type = "eth_storage"
+    [exporter.clip_univ2wbtcdai_a_v1_8_0]
+        migrations = "db/migrations"
+        path = "transformers/storage/clip/initializers/univ2wbtcdai_a/v1_8_0"
+        rank = "0"
+        repository = "github.com/makerdao/vdb-mcd-transformers"
+        type = "eth_storage"
+    [exporter.clip_univ2wbtceth_a_v1_8_0]
+        migrations = "db/migrations"
+        path = "transformers/storage/clip/initializers/univ2wbtceth_a/v1_8_0"
+        rank = "0"
+        repository = "github.com/makerdao/vdb-mcd-transformers"
+        type = "eth_storage"
+    [exporter.clip_wbtc_a_v1_5_0]
+        migrations = "db/migrations"
+        path = "transformers/storage/clip/initializers/wbtc_a/v1_5_0"
+        rank = "0"
+        repository = "github.com/makerdao/vdb-mcd-transformers"
+        type = "eth_storage"
+    [exporter.clip_yfi_a_v1_5_0]
+        migrations = "db/migrations"
+        path = "transformers/storage/clip/initializers/yfi_a/v1_5_0"
+        rank = "0"
+        repository = "github.com/makerdao/vdb-mcd-transformers"
+        type = "eth_storage"
+    [exporter.clip_zrx_a_v1_6_0]
+        migrations = "db/migrations"
+        path = "transformers/storage/clip/initializers/zrx_a/v1_6_0"
+        rank = "0"
+        repository = "github.com/makerdao/vdb-mcd-transformers"
+        type = "eth_storage"
 [contract]
     [contract.CDP_MANAGER]
         address  = "0x5ef30b9986345249bc32d8928b7ee64de9435e39"

--- a/plugins/backfill/storage/transformerExporter.go
+++ b/plugins/backfill/storage/transformerExporter.go
@@ -3,6 +3,31 @@
 package main
 
 import (
+	clip_aave_a_v1_6_0 "github.com/makerdao/vdb-mcd-transformers/transformers/storage/clip/initializers/aave_a/v1_6_0"
+	clip_bal_a_v1_6_0 "github.com/makerdao/vdb-mcd-transformers/transformers/storage/clip/initializers/bal_a/v1_6_0"
+	clip_bat_a_v1_6_0 "github.com/makerdao/vdb-mcd-transformers/transformers/storage/clip/initializers/bat_a/v1_6_0"
+	clip_comp_a_v1_6_0 "github.com/makerdao/vdb-mcd-transformers/transformers/storage/clip/initializers/comp_a/v1_6_0"
+	clip_eth_a_v1_5_0 "github.com/makerdao/vdb-mcd-transformers/transformers/storage/clip/initializers/eth_a/v1_5_0"
+	clip_eth_b_v1_5_0 "github.com/makerdao/vdb-mcd-transformers/transformers/storage/clip/initializers/eth_b/v1_5_0"
+	clip_eth_c_v1_5_0 "github.com/makerdao/vdb-mcd-transformers/transformers/storage/clip/initializers/eth_c/v1_5_0"
+	clip_knc_a_v1_6_0 "github.com/makerdao/vdb-mcd-transformers/transformers/storage/clip/initializers/knc_a/v1_6_0"
+	clip_link_a_v1_3_0 "github.com/makerdao/vdb-mcd-transformers/transformers/storage/clip/initializers/link_a/v1_3_0"
+	clip_lrc_a_v1_6_0 "github.com/makerdao/vdb-mcd-transformers/transformers/storage/clip/initializers/lrc_a/v1_6_0"
+	clip_mana_a_v1_6_0 "github.com/makerdao/vdb-mcd-transformers/transformers/storage/clip/initializers/mana_a/v1_6_0"
+	clip_renbtc_a_v1_6_0 "github.com/makerdao/vdb-mcd-transformers/transformers/storage/clip/initializers/renbtc_a/v1_6_0"
+	clip_uni_a_v1_6_0 "github.com/makerdao/vdb-mcd-transformers/transformers/storage/clip/initializers/uni_a/v1_6_0"
+	clip_univ2aaveeth_a_v1_8_0 "github.com/makerdao/vdb-mcd-transformers/transformers/storage/clip/initializers/univ2aaveeth_a/v1_8_0"
+	clip_univ2daieth_a_v1_8_0 "github.com/makerdao/vdb-mcd-transformers/transformers/storage/clip/initializers/univ2daieth_a/v1_8_0"
+	clip_univ2daiusdt_a_v1_8_0 "github.com/makerdao/vdb-mcd-transformers/transformers/storage/clip/initializers/univ2daiusdt_a/v1_8_0"
+	clip_univ2ethusdt_a_v1_8_0 "github.com/makerdao/vdb-mcd-transformers/transformers/storage/clip/initializers/univ2ethusdt_a/v1_8_0"
+	clip_univ2linketh_a_v1_8_0 "github.com/makerdao/vdb-mcd-transformers/transformers/storage/clip/initializers/univ2linketh_a/v1_8_0"
+	clip_univ2unieth_a_v1_8_0 "github.com/makerdao/vdb-mcd-transformers/transformers/storage/clip/initializers/univ2unieth_a/v1_8_0"
+	clip_univ2usdceth_a_v1_8_0 "github.com/makerdao/vdb-mcd-transformers/transformers/storage/clip/initializers/univ2usdceth_a/v1_8_0"
+	clip_univ2wbtcdai_a_v1_8_0 "github.com/makerdao/vdb-mcd-transformers/transformers/storage/clip/initializers/univ2wbtcdai_a/v1_8_0"
+	clip_univ2wbtceth_a_v1_8_0 "github.com/makerdao/vdb-mcd-transformers/transformers/storage/clip/initializers/univ2wbtceth_a/v1_8_0"
+	clip_wbtc_a_v1_5_0 "github.com/makerdao/vdb-mcd-transformers/transformers/storage/clip/initializers/wbtc_a/v1_5_0"
+	clip_yfi_a_v1_5_0 "github.com/makerdao/vdb-mcd-transformers/transformers/storage/clip/initializers/yfi_a/v1_5_0"
+	clip_zrx_a_v1_6_0 "github.com/makerdao/vdb-mcd-transformers/transformers/storage/clip/initializers/zrx_a/v1_6_0"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/event"
 	"github.com/makerdao/vulcanizedb/libraries/shared/factories/storage"
 	interface1 "github.com/makerdao/vulcanizedb/libraries/shared/transformer"
@@ -14,6 +39,32 @@ var Exporter exporter
 
 func (e exporter) Export() ([]event.TransformerInitializer, []storage.TransformerInitializer, []interface1.ContractTransformerInitializer) {
 	return []event.TransformerInitializer{},
-		[]storage.TransformerInitializer{},
+		[]storage.TransformerInitializer{
+			clip_aave_a_v1_6_0.StorageTransformerInitializer,
+			clip_bal_a_v1_6_0.StorageTransformerInitializer,
+			clip_bat_a_v1_6_0.StorageTransformerInitializer,
+			clip_comp_a_v1_6_0.StorageTransformerInitializer,
+			clip_eth_a_v1_5_0.StorageTransformerInitializer,
+			clip_eth_b_v1_5_0.StorageTransformerInitializer,
+			clip_eth_c_v1_5_0.StorageTransformerInitializer,
+			clip_knc_a_v1_6_0.StorageTransformerInitializer,
+			clip_link_a_v1_3_0.StorageTransformerInitializer,
+			clip_lrc_a_v1_6_0.StorageTransformerInitializer,
+			clip_mana_a_v1_6_0.StorageTransformerInitializer,
+			clip_renbtc_a_v1_6_0.StorageTransformerInitializer,
+			clip_uni_a_v1_6_0.StorageTransformerInitializer,
+			clip_univ2aaveeth_a_v1_8_0.StorageTransformerInitializer,
+			clip_univ2daieth_a_v1_8_0.StorageTransformerInitializer,
+			clip_univ2daiusdt_a_v1_8_0.StorageTransformerInitializer,
+			clip_univ2ethusdt_a_v1_8_0.StorageTransformerInitializer,
+			clip_univ2linketh_a_v1_8_0.StorageTransformerInitializer,
+			clip_univ2unieth_a_v1_8_0.StorageTransformerInitializer,
+			clip_univ2usdceth_a_v1_8_0.StorageTransformerInitializer,
+			clip_univ2wbtcdai_a_v1_8_0.StorageTransformerInitializer,
+			clip_univ2wbtceth_a_v1_8_0.StorageTransformerInitializer,
+			clip_wbtc_a_v1_5_0.StorageTransformerInitializer,
+			clip_yfi_a_v1_5_0.StorageTransformerInitializer,
+			clip_zrx_a_v1_6_0.StorageTransformerInitializer,
+		},
 		[]interface1.ContractTransformerInitializer{}
 }


### PR DESCRIPTION
- This starts at the LINK-A deployment block
- Ends at the block 13425397, 2021-10-15T22:44:54Z, based on timestamp in log file post deploy of the new transformers
