### PR TITLE
update action version

### DIFF
--- a/.github/workflows/test-vdb-command.yml
+++ b/.github/workflows/test-vdb-command.yml
@@ -9,10 +9,10 @@ jobs:
     steps:
       -
         name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
       -
@@ -51,10 +51,10 @@ jobs:
     steps:
       -
        name: Checkout repo
-       uses: actions/checkout@v2
+       uses: actions/checkout@v3
       -
        name: Setup Python
-       uses: actions/setup-python@v2
+       uses: actions/setup-python@v4
        with:
         python-version: 3.7
       -


### PR DESCRIPTION
We'll need to update the GitHub actions that rely on node12 since it's deprecated now. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
